### PR TITLE
chore: refine MCP page styles and reorder docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -742,20 +742,6 @@
         ]
       },
       {
-        "tab": "AI / MCP",
-        "groups": [
-          {
-            "group": "Getting Connected",
-            "pages": [
-              "ai-mcp/overview",
-              "ai-mcp/claude-desktop",
-              "ai-mcp/vscode",
-              "ai-mcp/cursor"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Guides",
         "groups": [
           {
@@ -826,6 +812,20 @@
             "pages": [
               "use-cases/social/product-tagging-and-social-commerce",
               "use-cases/social/advertising-and-monetization"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "AI / MCP",
+        "groups": [
+          {
+            "group": "Getting Connected",
+            "pages": [
+              "ai-mcp/overview",
+              "ai-mcp/claude-desktop",
+              "ai-mcp/vscode",
+              "ai-mcp/cursor"
             ]
           }
         ]

--- a/style.css
+++ b/style.css
@@ -747,6 +747,15 @@ html.dark .hero-section {
     background-color: #0a0a0f !important;
 }
 
+/* MCP page overrides dark-mode hero to blend with page background */
+[data-theme="dark"] .mcp-page .hero-section,
+html[data-theme="dark"] .mcp-page .hero-section,
+.dark .mcp-page .hero-section,
+html.dark .mcp-page .hero-section {
+    background: radial-gradient(ellipse 90% 65% at 50% 30%, rgba(59,65,236,0.14) 0%, transparent 70%) !important;
+    background-color: transparent !important;
+}
+
 /* Dark mode text fallbacks */
 [data-theme="dark"] .hero-title,
 html[data-theme="dark"] .hero-title,
@@ -1537,11 +1546,12 @@ html.dark .mcp-no-auth,
 }
 
 .mcp-orb-claude {
-    width: 520px;
-    height: 520px;
-    background: radial-gradient(circle, rgba(255,107,43,0.1) 0%, transparent 70%);
-    top: -120px;
-    left: -80px;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, rgba(255,107,43,0.12) 0%, transparent 70%);
+    bottom: -160px;
+    left: 50%;
+    transform: translateX(-50%);
     animation: mcp-orb-a 11s ease-in-out infinite alternate;
 }
 
@@ -1953,6 +1963,19 @@ html.dark .mcp-no-auth,
     margin: 0 0 0 0 !important;
 }
 
+/* Smooth fade from hero into tools section */
+.mcp-page .hero-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 120px;
+    background: linear-gradient(to bottom, transparent, rgba(6,6,14,0.6));
+    pointer-events: none;
+    display: block !important;
+}
+
 /* ── MCP hero title weight ── */
 .mcp-page .hero-title {
     font-weight: 600 !important;
@@ -1964,9 +1987,8 @@ html.dark .mcp-no-auth,
 .mcp-tools-outer {
     position: relative;
     overflow: hidden;
-    background: #06060e;
-    background-image: radial-gradient(circle, rgba(99,102,241,0.06) 1px, transparent 1px);
-    background-size: 28px 28px;
+    background: transparent;
+    background-image: none;
     padding: 4rem 2rem 6rem;
 }
 
@@ -1996,13 +2018,13 @@ html.dark .mcp-no-auth,
    ══════════════════════════════════════════════════════════ */
 
 .mcp-page .hero-section {
-    background: radial-gradient(50% 50% at 50% 50%, rgba(59,65,236,0.1) 39.4%, rgba(10,10,15,0) 100%) !important;
-    background-color: #0a0a0f !important;
+    background: radial-gradient(ellipse 90% 65% at 50% 30%, rgba(59,65,236,0.14) 0%, transparent 70%) !important;
+    background-color: transparent !important;
 }
 
 .mcp-page .hero-section::before,
 .mcp-page .hero-section::after {
-    border-color: rgba(255,255,255,0.06) !important;
+    display: none !important;
 }
 
 .mcp-page .hero-title {
@@ -2032,11 +2054,10 @@ html.dark .mcp-no-auth,
     color: #ffffff !important;
 }
 
-/* Tools outer: ALWAYS dark — independent of theme system */
+/* Tools outer: transparent — inherits dot-grid from .mcp-page */
 .mcp-tools-outer {
-    background: #06060e !important;
-    background-image: radial-gradient(circle, rgba(99,102,241,0.05) 1px, transparent 1px) !important;
-    background-size: 28px 28px !important;
+    background: transparent !important;
+    background-image: none !important;
 }
 
 /* Tools section text — always bright (bg is always dark above) */


### PR DESCRIPTION
Move the "AI / MCP" docs section to follow Guides in docs.json to adjust sidebar ordering. Update style.css to refine MCP page appearance: add dark-mode hero overrides to blend with page background, add a smooth fade at the hero bottom, and hide hero border accents; enlarge and center the .mcp-orb-claude and tweak its gradient/position; make .mcp-tools-outer transparent (remove dot-grid background); and consolidate dark-theme hero styling. These changes improve visual integration of the MCP pages in dark theme and tidy layout spacing.