### PR TITLE
feat: social localization docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -541,7 +541,8 @@
               "uikit/customization/overview",
               "uikit/customization/dynamic-ui",
               "uikit/customization/component-styling",
-              "uikit/customization/advanced-customization"
+              "uikit/customization/advanced-customization",
+              "uikit/customization/localization"
             ]
           },
           {

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -282,7 +282,15 @@ The social.plus UIKit uses a platform-native localization system on each platfor
   <Tab title="Android (Kotlin)">
     ## Overview
 
-    The Android UIKit uses the standard Android resource system. Strings are defined in `strings.xml` files across multiple library modules, all prefixed with `amity_`. Localization works through Android's standard `values-<language-code>/` resource override mechanism — no custom API is needed.
+    The Android UIKit v4 resolves every UI string through a 3-level priority chain. Higher levels win; missing keys fall through to the next level automatically.
+
+    | Priority | Level | Source |
+    |----------|-------|--------|
+    | Highest | 1 | Programmatic key overrides (`setOverrides()`) |
+    | | 2 | Active locale bundle (`setLocale()`) |
+    | Lowest | 3 | Android string resources (`strings.xml` — English default) |
+
+    String resolution is handled by two providers: `DefaultAmitySocialStringProvider` (social strings) and `DefaultAmityCommonStringProvider` (common strings). Both providers are singletons initialized in your `Application.onCreate()`.
 
     ## Built-in Languages
 
@@ -292,77 +300,128 @@ The social.plus UIKit uses a platform-native localization system on each platfor
 
     ## How to Add a New Language
 
-    There are two approaches:
+    ### Option A — Locale bundle via String Provider API (recommended)
 
-    ### Option A — Override in your app (no fork required)
-
-    Android resource merging allows your app to override library string values. Add a `strings.xml` to your app with the translated keys:
+    Provide a `Map<String, String>` of translated keys and register it with the provider. No fork required.
 
     <Steps>
-      <Step title="Create language resource files">
-        In your app module, create `values-<language-code>/strings.xml` files. For Japanese:
+      <Step title="Initialize the providers">
+        Call both providers in your `Application.onCreate()`:
 
-        ```
-        app/src/main/res/
-        ├── values/strings.xml           ← your app's default strings
-        └── values-ja/strings.xml        ← Japanese overrides
+        ```kotlin
+        class MyApplication : Application() {
+            override fun onCreate() {
+                super.onCreate()
+                DefaultAmitySocialStringProvider.initialize(this)
+                DefaultAmityCommonStringProvider.initialize(this)
+            }
+        }
         ```
       </Step>
 
-      <Step title="Translate the UIKit strings">
-        Copy the `amity_` prefixed keys you want to translate and provide the translated values:
+      <Step title="Create a locale bundle">
+        Create a Kotlin object (or a plain `Map<String, String>`) with the translated keys. You only need to include keys you're translating — missing keys fall back to the English `strings.xml` values automatically.
 
-        ```xml
-        <!-- values-ja/strings.xml -->
-        <resources>
-            <string name="amity_cancel">キャンセル</string>
-            <string name="amity_done">完了</string>
-            <string name="amity_general_error_message">エラーが発生しました。もう一度お試しください。</string>
-        </resources>
+        ```kotlin
+        object MyJapaneseStrings {
+            val social: Map<String, String> = mapOf(
+                "amity_social_button_comments" to "コメント",
+                "amity_social_button_delete_comment" to "コメントを削除",
+                "amity_social_button_edit_comment" to "コメントを編集",
+            )
+
+            val common: Map<String, String> = mapOf(
+                "amity_common_button_cancel" to "キャンセル",
+                "amity_common_button_done" to "完了",
+            )
+        }
+        ```
+      </Step>
+
+      <Step title="Register the locale bundle">
+        Call `setLocale()` on both providers — typically in `Application.onCreate()` after initialization, or in response to a user language-switch action:
+
+        ```kotlin
+        DefaultAmitySocialStringProvider.setLocale("ja", MyJapaneseStrings.social)
+        DefaultAmityCommonStringProvider.setLocale("ja", MyJapaneseStrings.common)
         ```
 
-        Android automatically picks the correct file based on the device locale — no code changes needed.
+        To revert to the default English resources:
+
+        ```kotlin
+        DefaultAmitySocialStringProvider.getInstance().clearLocale()
+        DefaultAmityCommonStringProvider.getInstance().clearLocale()
+        ```
       </Step>
     </Steps>
 
-    ### Option B — Fork the UIKit repository
+    ### Option B — Override individual keys
 
-    For complete control, clone the Android UIKit and add `values-<language-code>/` directories inside each module:
+    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
+
+    ```kotlin
+    DefaultAmitySocialStringProvider.setOverrides(mapOf(
+        "amity_social_button_comments" to "Replies",
+        "amity_social_modal_dialog_generic_error" to "Something went wrong. Please try again.",
+    ))
+
+    DefaultAmityCommonStringProvider.setOverrides(mapOf(
+        "amity_common_button_cancel" to "Dismiss",
+    ))
+    ```
+
+    To clear overrides:
+
+    ```kotlin
+    DefaultAmitySocialStringProvider.getInstance().clearOverrides()
+    DefaultAmityCommonStringProvider.getInstance().clearOverrides()
+    ```
+
+    ### Option C — Fork the UIKit repository
+
+    For full static translation using the Android resource system, clone the UIKit and add `values-<language-code>/` resource directories inside each module:
 
     ```
     common/src/main/res/values-ja/strings.xml
     social/src/main/res/values-ja/strings.xml
     social-compose/src/main/res/values-ja/strings.xml
     chat/src/main/res/values-ja/strings.xml
+    chat-compose/src/main/res/values-ja/strings.xml
     ```
 
     ## Translation Key Reference
 
-    All UIKit strings are prefixed with `amity_`. String keys span multiple modules:
+    ### Key naming conventions
 
-    | Module | Resource file | Example key |
-    |--------|---------------|-------------|
-    | `common` | `common/.../values/strings.xml` | `amity_cancel`, `amity_done` |
-    | `social` | `social/.../values/strings.xml` | `amity_view_all_replies`, `amity_remove_follower` |
-    | `social-compose` | `social-compose/.../values/strings.xml` | Compose UI social strings |
-    | `chat` | `chat/.../values/strings.xml` | Chat-specific strings |
+    All UIKit localization keys follow the `amity_<domain>_<category>_<name>` pattern:
+
+    | Prefix | Domain | Example Key | Example Value |
+    |--------|--------|-------------|---------------|
+    | `amity_common_button_*` | Shared buttons | `amity_common_button_cancel` | `"Cancel"` |
+    | `amity_common_time_*` | Relative timestamps | `amity_common_time_time_days_suffix` | `"d"` |
+    | `amity_common_ad_*` | Ad labels | `amity_common_ad_sponsored` | `"Sponsored"` |
+    | `amity_social_button_*` | Social action buttons | `amity_social_button_comments` | `"Comments"` |
+    | `amity_social_label_*` | Social text labels | `amity_social_label_follow_requests` | `"Follow requests (%1$d)"` |
+    | `amity_social_modal_dialog_*` | Modal/dialog text | `amity_social_modal_dialog_generic_error` | `"Oops! something went wrong..."` |
+    | `amity_social_empty_state_*` | Empty state messages | — | — |
 
     ### Format specifiers
 
-    ```xml
-    <!-- String substitution -->
-    <string name="amity_remove_follower">Remove %s from follower?</string>
+    ```kotlin
+    // String substitution
+    "amity_social_label_created_by" to "By %s"
 
-    <!-- Integer substitution -->
-    <string name="amity_view_all_replies">View all %d replies</string>
+    // Integer substitution
+    "amity_social_label_follow_requests" to "Follow requests (%1$d)"
 
-    <!-- Plurals -->
-    <plurals name="amity_number_of_days">
-        <item quantity="one">%d day</item>
-        <item quantity="other">%d days</item>
-    </plurals>
+    // Multiple arguments
+    "amity_social_error_post_text_exceed_error_message" to "Post text exceeds the %1$d characters limit"
     ```
 
-    For the full key list, refer to `strings.xml` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android).
+    <Note>
+      Keys are shared between `DefaultAmitySocialStringProvider` (social strings, ~1005 keys) and `DefaultAmityCommonStringProvider` (common strings, ~49 keys). Social keys start with `amity_social_`; common keys start with `amity_common_`. When overriding, use the correct provider for each key prefix.
+    </Note>
+
+    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android), or see the sample Thai locale bundle in `sample/src/main/java/.../localization/AmitySocialThaiStrings.kt` as a complete override example.
   </Tab>
 </Tabs>

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -1,0 +1,368 @@
+---
+title: "Localization"
+description: "Customize UI strings and add language support to the social.plus UIKit"
+---
+
+The social.plus UIKit uses a platform-native localization system on each platform. Select your platform below.
+
+<Tabs>
+  <Tab title="Web (React)">
+    ## Overview
+
+    The Web UIKit v4 resolves every UI string through a 5-level priority chain. Higher levels win; missing keys fall through to the next level automatically.
+
+    | Priority | Level | Source |
+    |----------|-------|--------|
+    | Highest | 1 | Config text via `CustomizationProvider` (remote config) |
+    | | 2 | Programmatic key overrides (`overrides` prop) |
+    | | 3 | Locale bundle (`localeBundle` prop or `localeMap` auto-detection) |
+    | | 4 | Built-in English defaults |
+    | Lowest | 5 | Raw key name (safety fallback for missing keys) |
+
+    ## Built-in Languages
+
+    | Language | Locale Code | Coverage |
+    |----------|-------------|----------|
+    | English | `en` | Full (~889 keys) — always the fallback |
+    | Thai | `th` | Partial (~500 keys) — auto-detected for `th` / `th-*` browser locales |
+
+    <Note>
+      English is always the final fallback. Any key missing from a custom bundle resolves to its English value automatically.
+    </Note>
+
+    ## Provider Props
+
+    Configure localization via the `localization` prop on `AmityUIKitProvider`.
+
+    | Prop | Type | Description |
+    |------|------|-------------|
+    | `localeBundle` | `Record<string, string>` | Explicitly set a locale bundle. Takes precedence over `localeMap` auto-detection. |
+    | `overrides` | `Record<string, string>` | Merge-override individual keys on top of the active locale. |
+    | `localeMap` | `Record<string, Record<string, string>>` | Map of locale code → bundle for automatic device-language detection via `navigator.language`. **Replaces** the default locale map when provided. |
+
+    ```tsx
+    import { thLocaleBundle } from '@amityco/ui-kit';
+
+    <AmityUIKitProvider
+      apiKey="..."
+      userId="..."
+      displayName="..."
+      apiRegion="us"
+      localization={{
+        localeBundle: thLocaleBundle,
+      }}
+    >
+      <App />
+    </AmityUIKitProvider>
+    ```
+
+    ## Scenarios
+
+    <AccordionGroup>
+      <Accordion title="Use a built-in locale (Thai)">
+        ```tsx
+        import { thLocaleBundle } from '@amityco/ui-kit';
+
+        <AmityUIKitProvider
+          localization={{ localeBundle: thLocaleBundle }}
+        >
+          <App />
+        </AmityUIKitProvider>
+        ```
+      </Accordion>
+
+      <Accordion title="Auto-detect device language">
+        ```tsx
+        import { thLocaleBundle } from '@amityco/ui-kit';
+
+        <AmityUIKitProvider
+          localization={{ localeMap: { th: thLocaleBundle } }}
+        >
+          <App />
+        </AmityUIKitProvider>
+        ```
+
+        The UIKit checks `navigator.language` — exact match first (e.g. `"th"`), then language-prefix match (e.g. `"th-TH"` → `"th"`). Falls back to English if no match is found.
+      </Accordion>
+
+      <Accordion title="Override specific strings">
+        ```tsx
+        <AmityUIKitProvider
+          localization={{
+            overrides: {
+              'amity_common_button_cancel': 'Dismiss',
+              'amity_social_button_delete_post_title': 'Remove this post?',
+            },
+          }}
+        >
+          <App />
+        </AmityUIKitProvider>
+        ```
+
+        Overrides merge on top of the active locale — only specified keys are replaced.
+      </Accordion>
+
+      <Accordion title="Switch locale at runtime">
+        `useLocale` controls the active locale. `useString` consumes strings and automatically re-renders all consumers when the locale changes.
+
+        ```tsx
+        import { useLocale, useString } from '@amityco/ui-kit';
+        import jaLocale from './locales/ja.json';
+
+        function LanguageSwitcher() {
+          const { setLocaleBundle, clearLocaleBundle } = useLocale();
+
+          return (
+            <>
+              <button onClick={() => setLocaleBundle(jaLocale)}>日本語</button>
+              <button onClick={() => clearLocaleBundle()}>English</button>
+            </>
+          );
+        }
+
+        // Any child component — automatically re-renders on locale change
+        function CancelButton() {
+          const label = useString('amity_common_button_cancel');
+          return <button>{label}</button>;
+        }
+        ```
+      </Accordion>
+    </AccordionGroup>
+
+    ## Translation Key Reference
+
+    ### Key naming conventions
+
+    | Prefix | Domain | Example Key | Example Value |
+    |--------|--------|-------------|---------------|
+    | `amity_common_button_*` | Shared buttons | `amity_common_button_cancel` | `"Cancel"` |
+    | `amity_common_time_*` | Relative timestamps | `amity_common_time_time_days_suffix` | `"d"` |
+    | `amity_common_ad_*` | Ad labels | `amity_common_ad_sponsored` | `"Sponsored"` |
+    | `amity_social_button_*` | Social action buttons | `amity_social_button_block_user` | `"Block user"` |
+    | `amity_social_label_*` | Social text labels | `amity_social_label_follow_requests` | `"Follow requests (%1$d)"` |
+    | `amity_social_modal_dialog_*` | Modal/dialog text | `amity_social_modal_dialog_generic_error` | `"Oops! something went wrong..."` |
+    | `amity_social_error_*` | Error messages | `amity_social_error_post_text_exceed_error_message` | `"...exceeds the %1$d characters limit"` |
+    | `amity_social_empty_state_*` | Empty state messages | — | — |
+    | `amity_chat_*` | Chat UI strings | `amity_chat_label_loading_chat` | `"Loading chat..."` |
+    | `amity_livechat_*` | Live chat strings | `amity_livechat_notification_copy_message` | `"Message copied"` |
+
+    ### Format specifiers
+
+    | Specifier | Meaning | Example |
+    |-----------|---------|---------|
+    | `%s` / `%1$s` / `%2$s` | Positional string substitution | `"By %s"` |
+    | `%d` / `%1$d` / `%2$d` | Integer substitution | `"Follow requests (%1$d)"` |
+    | `%@` | iOS-style string (treated as `%s`) | — |
+
+    <Note>
+      Translation keys are shared across platforms. The `%@` specifier is native to iOS; the web renderer normalizes it to string substitution automatically.
+    </Note>
+
+    For the complete list of ~889 keys, refer to [`en.json`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json) in the UIKit source repository.
+
+    ## How to Add a New Language
+
+    <Steps>
+      <Step title="Create a translation file">
+        Create a flat JSON file with the keys you want to translate. You only need to include keys you're translating — missing keys automatically fall back to English.
+
+        ```json
+        {
+          "amity_common_button_cancel": "キャンセル",
+          "amity_common_button_delete": "削除",
+          "amity_social_button_block_user": "ユーザーをブロック"
+        }
+        ```
+      </Step>
+
+      <Step title="Register via localeMap">
+        Pass the bundle via `localeMap` so the UIKit auto-detects it from `navigator.language`:
+
+        ```tsx
+        import jaLocale from './locales/ja.json';
+        import { thLocaleBundle } from '@amityco/ui-kit';
+
+        <AmityUIKitProvider
+          localization={{
+            localeMap: {
+              th: thLocaleBundle, // preserve built-in Thai auto-detection
+              ja: jaLocale,       // add Japanese
+            },
+          }}
+        >
+          <App />
+        </AmityUIKitProvider>
+        ```
+
+        <Warning>
+          Providing `localeMap` replaces the default locale map entirely. Include `th: thLocaleBundle` explicitly if you want to preserve built-in Thai auto-detection alongside your new language.
+        </Warning>
+      </Step>
+
+      <Step title="Verify coverage">
+        Compare your translation file against [`en.json`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json) to identify missing keys. Any untranslated key silently falls back to English — no errors are thrown.
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="iOS (Swift)">
+    ## Overview
+
+    The iOS UIKit ships with English strings in `AmityLocalizable.strings` inside the framework bundle. Localization works through the standard iOS bundle/`.lproj` mechanism. There is no dedicated `setLanguage()` API — string resolution happens through the framework's own bundle.
+
+    Strings are accessed internally via the `AmityLocalizedStringSet` enum and the `.localizedString` computed property on `String`:
+
+    ```swift
+    // Internal usage (for reference)
+    AmityLocalizedStringSet.General.ok.localizedString
+    // Resolves via: NSLocalizedString(key, tableName: "AmityLocalizable", bundle: AmityUIKit4Manager.bundle)
+    ```
+
+    ## Built-in Languages
+
+    | Language | Status |
+    |----------|--------|
+    | English | Full coverage — default |
+
+    All other languages must be added by forking the framework and adding `.lproj` string files. The framework bundle is not injectable at runtime — the `bundle` property is hardcoded to `Bundle(for: AmityUIKit4Manager.self)` — so there is no app-level override path without modifying the source.
+
+    ## How to Add a New Language
+
+    <Steps>
+      <Step title="Fork the UIKit repository">
+        Clone the open source iOS UIKit repository:
+
+        ```bash
+        git clone https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource.git
+        ```
+      </Step>
+
+      <Step title="Add a .lproj string file">
+        Inside the framework target, create a new `.lproj` folder for your language and add a translated `AmityLocalizable.strings` file. For example, to add Japanese:
+
+        ```
+        UpstraUIKit/AmityUIKit4/
+        └── Core/Localization/
+            ├── en.lproj/AmityLocalizable.strings   ← existing English
+            └── ja.lproj/AmityLocalizable.strings   ← new Japanese
+        ```
+
+        Translate the string values in the new file using the same keys:
+
+        ```
+        /* ja.lproj/AmityLocalizable.strings */
+        "cancel" = "キャンセル";
+        "delete" = "削除";
+        "deleted_comment_message" = "このコメントは削除されました";
+        ```
+      </Step>
+
+      <Step title="Build and integrate">
+        Build the modified framework and integrate it into your app. iOS will automatically select the correct `.lproj` file based on the device language.
+      </Step>
+    </Steps>
+
+    ## Translation Key Reference
+
+    Strings use a flat key format defined in `AmityLocalizedStringSet.swift`. Format arguments use iOS-style `%@` and `%d` specifiers.
+
+    ```
+    /* AmityLocalizable.strings sample */
+    "cancel" = "Cancel";
+    "delete" = "Delete";
+    "deleted_comment_message" = "This comment has been deleted";
+    "poll_vote_counts" = "%@ votes";
+    "unit_like_singular" = "%@ like";
+    "unit_like_plural" = "%@ likes";
+    ```
+
+    For the full key list, refer to `AmityLocalizable.strings` in the [iOS UIKit source repository](https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource).
+  </Tab>
+
+  <Tab title="Android (Kotlin)">
+    ## Overview
+
+    The Android UIKit uses the standard Android resource system. Strings are defined in `strings.xml` files across multiple library modules, all prefixed with `amity_`. Localization works through Android's standard `values-<language-code>/` resource override mechanism — no custom API is needed.
+
+    ## Built-in Languages
+
+    | Language | Status |
+    |----------|--------|
+    | English | Full coverage — default |
+
+    ## How to Add a New Language
+
+    There are two approaches:
+
+    ### Option A — Override in your app (no fork required)
+
+    Android resource merging allows your app to override library string values. Add a `strings.xml` to your app with the translated keys:
+
+    <Steps>
+      <Step title="Create language resource files">
+        In your app module, create `values-<language-code>/strings.xml` files. For Japanese:
+
+        ```
+        app/src/main/res/
+        ├── values/strings.xml           ← your app's default strings
+        └── values-ja/strings.xml        ← Japanese overrides
+        ```
+      </Step>
+
+      <Step title="Translate the UIKit strings">
+        Copy the `amity_` prefixed keys you want to translate and provide the translated values:
+
+        ```xml
+        <!-- values-ja/strings.xml -->
+        <resources>
+            <string name="amity_cancel">キャンセル</string>
+            <string name="amity_done">完了</string>
+            <string name="amity_general_error_message">エラーが発生しました。もう一度お試しください。</string>
+        </resources>
+        ```
+
+        Android automatically picks the correct file based on the device locale — no code changes needed.
+      </Step>
+    </Steps>
+
+    ### Option B — Fork the UIKit repository
+
+    For complete control, clone the Android UIKit and add `values-<language-code>/` directories inside each module:
+
+    ```
+    common/src/main/res/values-ja/strings.xml
+    social/src/main/res/values-ja/strings.xml
+    social-compose/src/main/res/values-ja/strings.xml
+    chat/src/main/res/values-ja/strings.xml
+    ```
+
+    ## Translation Key Reference
+
+    All UIKit strings are prefixed with `amity_`. String keys span multiple modules:
+
+    | Module | Resource file | Example key |
+    |--------|---------------|-------------|
+    | `common` | `common/.../values/strings.xml` | `amity_cancel`, `amity_done` |
+    | `social` | `social/.../values/strings.xml` | `amity_view_all_replies`, `amity_remove_follower` |
+    | `social-compose` | `social-compose/.../values/strings.xml` | Compose UI social strings |
+    | `chat` | `chat/.../values/strings.xml` | Chat-specific strings |
+
+    ### Format specifiers
+
+    ```xml
+    <!-- String substitution -->
+    <string name="amity_remove_follower">Remove %s from follower?</string>
+
+    <!-- Integer substitution -->
+    <string name="amity_view_all_replies">View all %d replies</string>
+
+    <!-- Plurals -->
+    <plurals name="amity_number_of_days">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+    ```
+
+    For the full key list, refer to `strings.xml` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android).
+  </Tab>
+</Tabs>

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -208,14 +208,17 @@ The social.plus UIKit uses a platform-native localization system on each platfor
   <Tab title="iOS (Swift)">
     ## Overview
 
-    The iOS UIKit ships with English strings in `AmityLocalizable.strings` inside the framework bundle. Localization works through the standard iOS bundle/`.lproj` mechanism. There is no dedicated `setLanguage()` API — string resolution happens through the framework's own bundle.
+    The iOS UIKit ships with English strings in `AmityLocalizable.strings` inside the framework bundle. Localization works through the standard iOS bundle/`.lproj` mechanism. There is no dedicated `setLanguage()` API — string resolution happens automatically based on the device language.
+
+    At runtime, the UIKit checks your **main app bundle** for an `AmityLocalizable.strings` file before falling back to its built-in English strings. This means you can add or override translations directly in your app project without forking the UIKit.
 
     Strings are accessed internally via the `AmityLocalizedStringSet` enum and the `.localizedString` computed property on `String`:
 
     ```swift
     // Internal usage (for reference)
     AmityLocalizedStringSet.General.ok.localizedString
-    // Resolves via: NSLocalizedString(key, tableName: "AmityLocalizable", bundle: AmityUIKit4Manager.bundle)
+    // Resolves via: NSLocalizedString(key, tableName: "AmityLocalizable", bundle: ...)
+    // Checks main app bundle first, then falls back to the framework bundle
     ```
 
     ## Built-in Languages
@@ -224,30 +227,26 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     |----------|--------|
     | English | Full coverage — default |
 
-    All other languages must be added by forking the framework and adding `.lproj` string files. The framework bundle is not injectable at runtime — the `bundle` property is hardcoded to `Bundle(for: AmityUIKit4Manager.self)` — so there is no app-level override path without modifying the source.
+    Additional languages can be added directly in your app project — no fork required.
 
     ## How to Add a New Language
 
     <Steps>
-      <Step title="Fork the UIKit repository">
-        Clone the open source iOS UIKit repository:
+      <Step title="Create .lproj string files in your app">
+        In your Xcode project, create `.lproj` folders for each language you want to support and add an `AmityLocalizable.strings` file inside each one. For example, to add Japanese:
 
-        ```bash
-        git clone https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource.git
         ```
+        MyApp/
+        └── Resources/
+            ├── en.lproj/AmityLocalizable.strings   ← English overrides (optional)
+            └── ja.lproj/AmityLocalizable.strings   ← Japanese translations
+        ```
+
+        Make sure the files are added to your app target in Xcode.
       </Step>
 
-      <Step title="Add a .lproj string file">
-        Inside the framework target, create a new `.lproj` folder for your language and add a translated `AmityLocalizable.strings` file. For example, to add Japanese:
-
-        ```
-        UpstraUIKit/AmityUIKit4/
-        └── Core/Localization/
-            ├── en.lproj/AmityLocalizable.strings   ← existing English
-            └── ja.lproj/AmityLocalizable.strings   ← new Japanese
-        ```
-
-        Translate the string values in the new file using the same keys:
+      <Step title="Translate the strings">
+        Use the same keys as the UIKit's built-in English strings and provide translated values:
 
         ```
         /* ja.lproj/AmityLocalizable.strings */
@@ -255,10 +254,12 @@ The social.plus UIKit uses a platform-native localization system on each platfor
         "delete" = "削除";
         "deleted_comment_message" = "このコメントは削除されました";
         ```
+
+        You only need to include keys you are translating — any key not found in your file automatically falls back to the UIKit's built-in English value.
       </Step>
 
-      <Step title="Build and integrate">
-        Build the modified framework and integrate it into your app. iOS will automatically select the correct `.lproj` file based on the device language.
+      <Step title="Run your app">
+        No code changes are needed. iOS automatically selects the correct `.lproj` folder based on the device language, and the UIKit loads strings from your app bundle at runtime.
       </Step>
     </Steps>
 
@@ -276,7 +277,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     "unit_like_plural" = "%@ likes";
     ```
 
-    For the full key list, refer to `AmityLocalizable.strings` in the [iOS UIKit source repository](https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource).
+    For the full key list, refer to [`AmityLocalizable.strings`](https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/master/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/AmityLocalizable.strings) in the open source repository. Use this as the reference for all available keys and their default English values when building your translations.
   </Tab>
 
   <Tab title="Android (Kotlin)">


### PR DESCRIPTION
This pull request adds comprehensive documentation for localization and language customization in the social.plus UIKit. The new guide covers how localization works across Web (React), iOS (Swift), and Android (Kotlin) platforms, including built-in languages, key resolution order, translation key conventions, and step-by-step instructions for adding new languages.

**Localization documentation by platform:**

* **Web (React):**
  - Introduces a 5-level priority chain for resolving UI strings, details built-in language bundles (English, Thai), and explains how to configure and override localization using `AmityUIKitProvider` props. Includes scenarios for auto-detection, runtime switching, and key overrides. Provides key naming conventions and format specifiers, plus instructions for adding new languages with `localeMap`.

* **iOS (Swift):**
  - Documents how localization uses the standard `.lproj` bundle system, with English as the default. Explains how to add new languages by forking the UIKit and adding new `.lproj` files, and references key formats and the source repository for translation keys.

* **Android (Kotlin):**
  - Describes using Android’s resource system for localization, with English as the default. Offers two methods for adding new languages: app-level resource overrides or forking the UIKit. Details translation key conventions, format specifiers, and points to the source repository for full key lists. (