### PR TITLE
fix: remove thai lang support

### DIFF
--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -3,33 +3,43 @@ title: "Localization"
 description: "Customize UI strings and add language support to the social.plus UIKit"
 ---
 
-The social.plus UIKit uses a platform-native localization system on each platform. Select your platform below.
+The social.plus UIKit ships with built-in English strings and a localization API that lets you add any language — or override individual strings — without forking the UIKit. Translation keys follow the same naming convention on Web, iOS, and Android.
+
+## Built-in Languages
+
+| Language | Locale Code | Status |
+|----------|-------------|--------|
+| English | `en` | Full coverage — always the final fallback |
+
+English is the only built-in language. Any key missing from a custom locale bundle automatically resolves to its English value — no errors are thrown and no code changes are needed.
+
+## Three Independent Modules
+
+Localization keys are organized into three independent modules. Each module has its own string provider instance, so when registering locale bundles or overrides you provide keys to the correct module provider.
+
+| Module | Scope |
+|--------|-------|
+| Social | Posts, comments, communities, events, stories, livestream, clips, polls, feeds, notifications |
+| Common | Reactions, ads, time labels, shared buttons, dialogs, error states, empty states |
+| Chat | Messages, channels, message input, chat-specific features |
+
+### Format specifiers
+
+| Specifier | Meaning | Example |
+|-----------|---------|---------|
+| `%s` / `%1$s` / `%2$s` | Positional string substitution | `"By %s"` |
+| `%d` / `%1$d` / `%2$d` | Integer substitution | `"Follow requests (%1$d)"` |
+| `%@` | iOS-style string substitution (equivalent to `%s`) | `"Voted by %@ participants"` |
+
+Format specifiers must be preserved in the exact same positions when translating. The `%@` specifier is native to iOS; the Web UIKit normalizes it to `%s` automatically.
+
+## Platform Implementation
+
+Select your platform below for API details and integration code.
 
 <Tabs>
   <Tab title="Web (React)">
-    ## Overview
-
-    The Web UIKit v4 resolves every UI string through a 5-level priority chain. Higher levels win; missing keys fall through to the next level automatically.
-
-    | Priority | Level | Source |
-    |----------|-------|--------|
-    | Highest | 1 | Config text via `CustomizationProvider` (remote config) |
-    | | 2 | Programmatic key overrides (`overrides` prop) |
-    | | 3 | Locale bundle (`localeBundle` prop or `localeMap` auto-detection) |
-    | | 4 | Built-in English defaults |
-    | Lowest | 5 | Raw key name (safety fallback for missing keys) |
-
-    ## Built-in Languages
-
-    | Language | Locale Code | Coverage |
-    |----------|-------------|----------|
-    | English | `en` | Full (~889 keys) — always the fallback |
-
-    <Note>
-      English is always the final fallback. Any key missing from a custom bundle resolves to its English value automatically.
-    </Note>
-
-    ## Provider Props
+    ### Provider Props
 
     Configure localization via the `localization` prop on `AmityUIKitProvider`.
 
@@ -37,7 +47,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     |------|------|-------------|
     | `localeBundle` | `Record<string, string>` | Explicitly set a locale bundle. Takes precedence over `localeMap` auto-detection. |
     | `overrides` | `Record<string, string>` | Merge-override individual keys on top of the active locale. |
-    | `localeMap` | `Record<string, Record<string, string>>` | Map of locale code → bundle for automatic device-language detection via `navigator.language`. **Replaces** the default locale map when provided. |
+    | `localeMap` | `Record<string, Record<string, string>>` | Map of locale code → bundle for automatic device-language detection via `navigator.language`. |
 
     ```tsx
     <AmityUIKitProvider
@@ -54,7 +64,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     </AmityUIKitProvider>
     ```
 
-    ## Scenarios
+    ### Scenarios
 
     <AccordionGroup>
       <Accordion title="Auto-detect device language">
@@ -115,38 +125,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
       </Accordion>
     </AccordionGroup>
 
-    ## Translation Key Reference
-
-    ### Key naming conventions
-
-    | Prefix | Domain | Example Key | Example Value |
-    |--------|--------|-------------|---------------|
-    | `amity_common_button_*` | Shared buttons | `amity_common_button_cancel` | `"Cancel"` |
-    | `amity_common_time_*` | Relative timestamps | `amity_common_time_time_days_suffix` | `"d"` |
-    | `amity_common_ad_*` | Ad labels | `amity_common_ad_sponsored` | `"Sponsored"` |
-    | `amity_social_button_*` | Social action buttons | `amity_social_button_block_user` | `"Block user"` |
-    | `amity_social_label_*` | Social text labels | `amity_social_label_follow_requests` | `"Follow requests (%1$d)"` |
-    | `amity_social_modal_dialog_*` | Modal/dialog text | `amity_social_modal_dialog_generic_error` | `"Oops! something went wrong..."` |
-    | `amity_social_error_*` | Error messages | `amity_social_error_post_text_exceed_error_message` | `"...exceeds the %1$d characters limit"` |
-    | `amity_social_empty_state_*` | Empty state messages | — | — |
-    | `amity_chat_*` | Chat UI strings | `amity_chat_label_loading_chat` | `"Loading chat..."` |
-    | `amity_livechat_*` | Live chat strings | `amity_livechat_notification_copy_message` | `"Message copied"` |
-
-    ### Format specifiers
-
-    | Specifier | Meaning | Example |
-    |-----------|---------|---------|
-    | `%s` / `%1$s` / `%2$s` | Positional string substitution | `"By %s"` |
-    | `%d` / `%1$d` / `%2$d` | Integer substitution | `"Follow requests (%1$d)"` |
-    | `%@` | iOS-style string (treated as `%s`) | — |
-
-    <Note>
-      Translation keys are shared across platforms. The `%@` specifier is native to iOS; the web renderer normalizes it to string substitution automatically.
-    </Note>
-
-    For the complete list of ~889 keys, refer to [`en.json`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json) in the UIKit source repository.
-
-    ## How to Add a New Language
+    ### How to Add a New Language
 
     <Steps>
       <Step title="Create a translation file">
@@ -187,103 +166,126 @@ The social.plus UIKit uses a platform-native localization system on each platfor
   </Tab>
 
   <Tab title="iOS (Swift)">
-    ## Overview
+    ### String Providers
 
-    The iOS UIKit ships with English strings in `AmityLocalizable.strings` inside the framework bundle. Localization works through the standard iOS bundle/`.lproj` mechanism. There is no dedicated `setLanguage()` API — string resolution happens automatically based on the device language.
+    The iOS UIKit uses `AmityStringProvider` with three singleton instances — `.social`, `.common`, and `.chat` — matching the three modules. Each provider exposes the same API for registering locale bundles and overrides.
 
-    At runtime, the UIKit checks your **main app bundle** for an `AmityLocalizable.strings` file before falling back to its built-in English strings. This means you can add or override translations directly in your app project without forking the UIKit.
+    | Method | Behavior |
+    |--------|----------|
+    | `setLocale(_:bundle:)` | Register a locale bundle (replace semantics). Activates immediately. |
+    | `activateLocale(_:)` | Re-activate a previously registered locale by identifier. |
+    | `deactivateLocale()` | Deactivate the current locale. Keys fall through to library defaults. Does **not** delete the cached bundle. |
+    | `setOverrides(_:)` | Merge key-value overrides on top of any active locale. Multiple calls merge. |
+    | `clearOverrides()` | Remove all programmatic overrides. |
 
-    Strings are accessed internally via the `AmityLocalizedStringSet` enum and the `.localizedString` computed property on `String`:
+    ### How to Add a New Language
 
-    ```swift
-    // Internal usage (for reference)
-    AmityLocalizedStringSet.General.ok.localizedString
-    // Resolves via: NSLocalizedString(key, tableName: "AmityLocalizable", bundle: ...)
-    // Checks main app bundle first, then falls back to the framework bundle
-    ```
+    #### Option A — Programmatic via String Provider API (recommended)
 
-    ## Built-in Languages
-
-    | Language | Status |
-    |----------|--------|
-    | English | Full coverage — default |
-
-    Additional languages can be added directly in your app project — no fork required.
-
-    ## How to Add a New Language
+    Provide a `[String: String]` dictionary of translated keys and register it with each provider. No fork required.
 
     <Steps>
-      <Step title="Create .lproj string files in your app">
-        In your Xcode project, create `.lproj` folders for each language you want to support and add an `AmityLocalizable.strings` file inside each one. For example, to add Japanese:
+      <Step title="Create a locale bundle">
+        Create a dictionary with the translated keys. You only need to include keys you're translating — missing keys fall back to the built-in English values automatically.
 
-        ```
-        MyApp/
-        └── Resources/
-            ├── en.lproj/AmityLocalizable.strings   ← English overrides (optional)
-            └── ja.lproj/AmityLocalizable.strings   ← Japanese translations
-        ```
+        ```swift
+        struct MyJapaneseStrings {
+            static let social: [String: String] = [
+                "amity_social_button_comments": "コメント",
+                "amity_social_button_delete_comment": "コメントを削除",
+                "amity_social_button_edit_comment": "コメントを編集",
+            ]
 
-        Make sure the files are added to your app target in Xcode.
+            static let common: [String: String] = [
+                "amity_common_button_cancel": "キャンセル",
+                "amity_common_button_done": "完了",
+            ]
+
+            static let chat: [String: String] = [
+                "amity_chat_edit_message": "メッセージを編集",
+            ]
+        }
+        ```
       </Step>
 
-      <Step title="Translate the strings">
-        Use the same keys as the UIKit's built-in English strings and provide translated values:
+      <Step title="Register the locale bundle">
+        Call `setLocale` on each provider — typically at app launch or in response to a user language-switch action:
 
+        ```swift
+        AmityStringProvider.social.setLocale("ja", bundle: MyJapaneseStrings.social)
+        AmityStringProvider.common.setLocale("ja", bundle: MyJapaneseStrings.common)
+        AmityStringProvider.chat.setLocale("ja", bundle: MyJapaneseStrings.chat)
         ```
-        /* ja.lproj/AmityLocalizable.strings */
-        "cancel" = "キャンセル";
-        "delete" = "削除";
-        "deleted_comment_message" = "このコメントは削除されました";
+
+        To revert to the default English strings:
+
+        ```swift
+        AmityStringProvider.social.deactivateLocale()
+        AmityStringProvider.common.deactivateLocale()
+        AmityStringProvider.chat.deactivateLocale()
         ```
-
-        You only need to include keys you are translating — any key not found in your file automatically falls back to the UIKit's built-in English value.
-      </Step>
-
-      <Step title="Run your app">
-        No code changes are needed. iOS automatically selects the correct `.lproj` folder based on the device language, and the UIKit loads strings from your app bundle at runtime.
       </Step>
     </Steps>
 
-    ## Translation Key Reference
+    #### Option B — Override individual keys
 
-    Strings use a flat key format defined in `AmityLocalizedStringSet.swift`. Format arguments use iOS-style `%@` and `%d` specifiers.
+    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
+
+    ```swift
+    AmityStringProvider.social.setOverrides([
+        "amity_social_button_comments": "Replies",
+        "amity_social_modal_dialog_generic_error": "Something went wrong. Please try again.",
+    ])
+
+    AmityStringProvider.common.setOverrides([
+        "amity_common_button_cancel": "Dismiss",
+    ])
+    ```
+
+    To clear overrides:
+
+    ```swift
+    AmityStringProvider.social.clearOverrides()
+    AmityStringProvider.common.clearOverrides()
+    ```
+
+    #### Option C — Bundle-based `.lproj` files
+
+    You can also provide translations via standard iOS `.lproj` directories in your app bundle. The UIKit checks `Bundle.main` for `AmityLocalizable.strings` before falling back to its framework bundle — no code changes needed.
 
     ```
-    /* AmityLocalizable.strings sample */
-    "cancel" = "Cancel";
-    "delete" = "Delete";
-    "deleted_comment_message" = "This comment has been deleted";
-    "poll_vote_counts" = "%@ votes";
-    "unit_like_singular" = "%@ like";
-    "unit_like_plural" = "%@ likes";
+    MyApp/
+    └── Resources/
+        ├── en.lproj/AmityLocalizable.strings   ← English overrides (optional)
+        └── ja.lproj/AmityLocalizable.strings   ← Japanese translations
     ```
 
-    For the full key list, refer to [`AmityLocalizable.strings`](https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/master/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/AmityLocalizable.strings) in the open source repository. Use this as the reference for all available keys and their default English values when building your translations.
+    ```
+    /* ja.lproj/AmityLocalizable.strings */
+    "amity_common_button_cancel" = "キャンセル";
+    "amity_common_button_delete" = "削除";
+    "amity_social_button_comments" = "コメント";
+    ```
+
+    iOS automatically selects the correct `.lproj` folder based on the device language. Strings provided via `.lproj` are resolved at the library defaults level — programmatic overrides and locale bundles still take precedence.
 
   </Tab>
 
   <Tab title="Android (Kotlin)">
-    ## Overview
-
-    The Android UIKit v4 resolves every UI string through a 3-level priority chain. Higher levels win; missing keys fall through to the next level automatically.
-
-    | Priority | Level | Source |
-    |----------|-------|--------|
-    | Highest | 1 | Programmatic key overrides (`setOverrides()`) |
-    | | 2 | Active locale bundle (`setLocale()`) |
-    | Lowest | 3 | Android string resources (`strings.xml` — English default) |
+    ### String Providers
 
     String resolution is handled by two providers: `DefaultAmitySocialStringProvider` (social strings) and `DefaultAmityCommonStringProvider` (common strings). Both providers are singletons initialized in your `Application.onCreate()`.
 
-    ## Built-in Languages
+    | Method | Behavior |
+    |--------|----------|
+    | `setLocale(id, bundle)` | Register a locale bundle (replace semantics). Activates immediately. |
+    | `clearLocale()` | Deactivate the current locale. Keys fall through to library defaults. |
+    | `setOverrides(map)` | Merge key-value overrides on top of any active locale. |
+    | `clearOverrides()` | Remove all programmatic overrides. |
 
-    | Language | Status |
-    |----------|--------|
-    | English | Full coverage — default |
+    ### How to Add a New Language
 
-    ## How to Add a New Language
-
-    ### Option A — Locale bundle via String Provider API (recommended)
+    #### Option A — Locale bundle via String Provider API (recommended)
 
     Provide a `Map<String, String>` of translated keys and register it with the provider. No fork required.
 
@@ -338,7 +340,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
       </Step>
     </Steps>
 
-    ### Option B — Override individual keys
+    #### Option B — Override individual keys
 
     To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
 
@@ -360,7 +362,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     DefaultAmityCommonStringProvider.getInstance().clearOverrides()
     ```
 
-    ### Option C — Fork the UIKit repository
+    #### Option C — Fork the UIKit repository
 
     For full static translation using the Android resource system, clone the UIKit and add `values-<language-code>/` resource directories inside each module:
 
@@ -372,40 +374,79 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     chat-compose/src/main/res/values-ja/strings.xml
     ```
 
-    ## Translation Key Reference
-
-    ### Key naming conventions
-
-    All UIKit localization keys follow the `amity_<domain>_<category>_<name>` pattern:
-
-    | Prefix | Domain | Example Key | Example Value |
-    |--------|--------|-------------|---------------|
-    | `amity_common_button_*` | Shared buttons | `amity_common_button_cancel` | `"Cancel"` |
-    | `amity_common_time_*` | Relative timestamps | `amity_common_time_time_days_suffix` | `"d"` |
-    | `amity_common_ad_*` | Ad labels | `amity_common_ad_sponsored` | `"Sponsored"` |
-    | `amity_social_button_*` | Social action buttons | `amity_social_button_comments` | `"Comments"` |
-    | `amity_social_label_*` | Social text labels | `amity_social_label_follow_requests` | `"Follow requests (%1$d)"` |
-    | `amity_social_modal_dialog_*` | Modal/dialog text | `amity_social_modal_dialog_generic_error` | `"Oops! something went wrong..."` |
-    | `amity_social_empty_state_*` | Empty state messages | — | — |
-
-    ### Format specifiers
-
-    ```kotlin
-    // String substitution
-    "amity_social_label_created_by" to "By %s"
-
-    // Integer substitution
-    "amity_social_label_follow_requests" to "Follow requests (%1$d)"
-
-    // Multiple arguments
-    "amity_social_error_post_text_exceed_error_message" to "Post text exceeds the %1$d characters limit"
-    ```
-
     <Note>
-      Keys are shared between `DefaultAmitySocialStringProvider` (social strings, ~1005 keys) and `DefaultAmityCommonStringProvider` (common strings, ~49 keys). Social keys start with `amity_social_`; common keys start with `amity_common_`. When overriding, use the correct provider for each key prefix.
+      Social keys start with `amity_social_`; common keys start with `amity_common_`. When calling provider methods, use the correct provider for each key prefix.
     </Note>
 
-    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android), or see the sample Thai locale bundle in `sample/src/main/java/.../localization/AmitySocialThaiStrings.kt` as a complete override example.
+    For the full key list, refer to the English default `strings.xml` files in the [Android UIKit open source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource):
+    - [`social-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml) (social keys)
+    - [`common-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/common-compose/src/main/res/values/strings.xml) (common keys)
+
+    You can also refer to the comprehensive [`LOCALIZATION_GUIDE.md`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/LOCALIZATION_GUIDE.md) in the repository for detailed instructions and examples.
 
   </Tab>
 </Tabs>
+
+## Generate Translations with AI
+
+You can use an AI assistant (e.g. ChatGPT, Claude, Copilot) to quickly generate a complete translation file for any language. Download the English reference file for your platform and use the following prompt:
+
+<AccordionGroup>
+  <Accordion title="Example AI prompt" icon="sparkles">
+    ```
+    I have a localization file for a mobile/web UIKit with English strings.
+    Please translate all values to [TARGET LANGUAGE] while keeping:
+    - All keys exactly the same (do not rename any key)
+    - All format specifiers (%s, %d, %1$s, %1$d, %@, etc.) in the same positions
+    - The same file format (JSON / .strings / XML)
+    - Natural, user-facing language appropriate for a social app UI
+
+    Here is the English file:
+    [PASTE THE CONTENTS OF THE ENGLISH LOCALIZATION FILE]
+    ```
+
+    Replace `[TARGET LANGUAGE]` with your desired language (e.g. Japanese, French, Spanish, Arabic).
+  </Accordion>
+</AccordionGroup>
+
+## Migrating from `config.json` Text Overrides
+
+<Warning>
+**`config.json` text overrides are deprecated for string customization.** If you previously used `config.json` to override UI strings (e.g. button labels, error messages), you should migrate those overrides to the localization API described above — even if you don't plan to add new languages.
+
+Existing `config.json` text overrides are still resolved gracefully for now, but this auto-resolution **may be removed in a future release**. New UI components and features will only support string customization through the localization system.
+
+`config.json` remains available for other configuration such as theme and UI element visibility — only string/text overrides are being deprecated.
+</Warning>
+
+## Open Source Reference Files
+
+Use these English localization files as the source of truth when building translations for each platform.
+
+<Info>
+**Version alignment:** New UIKit releases may introduce new localization keys for new UI components or features. When upgrading, re-generate your translation files from the open source reference file that matches your UIKit version to ensure no keys are missing. Untranslated keys fall back to English silently, but keeping your translation files up to date ensures a fully localized experience.
+</Info>
+
+<CardGroup cols={3}>
+  <Card
+    title="Web"
+    icon="globe"
+    href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json"
+  >
+    `en.json`
+  </Card>
+  <Card
+    title="iOS"
+    icon="apple"
+    href="https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/main/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/en.lproj/AmityLocalizable.strings"
+  >
+    `AmityLocalizable.strings`
+  </Card>
+  <Card
+    title="Android"
+    icon="android"
+    href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml"
+  >
+    `strings.xml` (social + common keys)
+  </Card>
+</CardGroup>

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -24,7 +24,6 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     | Language | Locale Code | Coverage |
     |----------|-------------|----------|
     | English | `en` | Full (~889 keys) — always the fallback |
-    | Thai | `th` | Partial (~500 keys) — auto-detected for `th` / `th-*` browser locales |
 
     <Note>
       English is always the final fallback. Any key missing from a custom bundle resolves to its English value automatically.
@@ -41,16 +40,15 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     | `localeMap` | `Record<string, Record<string, string>>` | Map of locale code → bundle for automatic device-language detection via `navigator.language`. **Replaces** the default locale map when provided. |
 
     ```tsx
-    import { thLocaleBundle } from '@amityco/ui-kit';
-
     <AmityUIKitProvider
-      apiKey="..."
-      userId="..."
-      displayName="..."
-      apiRegion="us"
+      apiKey="API_KEY"
+      apiRegion="API_REGION"
+      userId="userId"
+      displayName="displayName"
+      configs={{}}
       localization={{
-        localeBundle: thLocaleBundle,
-      }}
+        localeBundle: myLocale,
+      }}          
     >
       <App />
     </AmityUIKitProvider>
@@ -59,30 +57,18 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     ## Scenarios
 
     <AccordionGroup>
-      <Accordion title="Use a built-in locale (Thai)">
-        ```tsx
-        import { thLocaleBundle } from '@amityco/ui-kit';
-
-        <AmityUIKitProvider
-          localization={{ localeBundle: thLocaleBundle }}
-        >
-          <App />
-        </AmityUIKitProvider>
-        ```
-      </Accordion>
-
       <Accordion title="Auto-detect device language">
         ```tsx
-        import { thLocaleBundle } from '@amityco/ui-kit';
+        import jaLocale from './locales/ja.json';
 
         <AmityUIKitProvider
-          localization={{ localeMap: { th: thLocaleBundle } }}
+          localization={{ localeMap: { ja: jaLocale } }}
         >
           <App />
         </AmityUIKitProvider>
         ```
 
-        The UIKit checks `navigator.language` — exact match first (e.g. `"th"`), then language-prefix match (e.g. `"th-TH"` → `"th"`). Falls back to English if no match is found.
+        The UIKit checks `navigator.language` — exact match first (e.g. `"ja"`), then language-prefix match (e.g. `"ja-JP"` → `"ja"`). Falls back to English if no match is found.
       </Accordion>
 
       <Accordion title="Override specific strings">
@@ -180,29 +166,24 @@ The social.plus UIKit uses a platform-native localization system on each platfor
 
         ```tsx
         import jaLocale from './locales/ja.json';
-        import { thLocaleBundle } from '@amityco/ui-kit';
 
         <AmityUIKitProvider
           localization={{
             localeMap: {
-              th: thLocaleBundle, // preserve built-in Thai auto-detection
-              ja: jaLocale,       // add Japanese
+              ja: jaLocale,
             },
           }}
         >
           <App />
         </AmityUIKitProvider>
         ```
-
-        <Warning>
-          Providing `localeMap` replaces the default locale map entirely. Include `th: thLocaleBundle` explicitly if you want to preserve built-in Thai auto-detection alongside your new language.
-        </Warning>
       </Step>
 
       <Step title="Verify coverage">
         Compare your translation file against [`en.json`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json) to identify missing keys. Any untranslated key silently falls back to English — no errors are thrown.
       </Step>
     </Steps>
+
   </Tab>
 
   <Tab title="iOS (Swift)">
@@ -278,6 +259,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
     ```
 
     For the full key list, refer to [`AmityLocalizable.strings`](https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/master/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/AmityLocalizable.strings) in the open source repository. Use this as the reference for all available keys and their default English values when building your translations.
+
   </Tab>
 
   <Tab title="Android (Kotlin)">
@@ -423,6 +405,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
       Keys are shared between `DefaultAmitySocialStringProvider` (social strings, ~1005 keys) and `DefaultAmityCommonStringProvider` (common strings, ~49 keys). Social keys start with `amity_social_`; common keys start with `amity_common_`. When overriding, use the correct provider for each key prefix.
     </Note>
 
-    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android), or see the sample Thai locale bundle in `sample/src/main/java/.../localization/AmitySocialThaiStrings.kt` as a complete override example.
+    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android).
+
   </Tab>
 </Tabs>

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -48,7 +48,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
       configs={{}}
       localization={{
         localeBundle: myLocale,
-      }}          
+      }}
     >
       <App />
     </AmityUIKitProvider>
@@ -405,7 +405,7 @@ The social.plus UIKit uses a platform-native localization system on each platfor
       Keys are shared between `DefaultAmitySocialStringProvider` (social strings, ~1005 keys) and `DefaultAmityCommonStringProvider` (common strings, ~49 keys). Social keys start with `amity_social_`; common keys start with `amity_common_`. When overriding, use the correct provider for each key prefix.
     </Note>
 
-    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android).
+    For the full key list, refer to `AmitySocialStrings.kt` and `AmityCommonStrings.kt` in the [Android UIKit source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android), or see the sample Thai locale bundle in `sample/src/main/java/.../localization/AmitySocialThaiStrings.kt` as a complete override example.
 
   </Tab>
 </Tabs>

--- a/uikit/customization/localization.mdx
+++ b/uikit/customization/localization.mdx
@@ -3,48 +3,237 @@ title: "Localization"
 description: "Customize UI strings and add language support to the social.plus UIKit"
 ---
 
-The social.plus UIKit ships with built-in English strings and a localization API that lets you add any language — or override individual strings — without forking the UIKit. Translation keys follow the same naming convention on Web, iOS, and Android.
+The social.plus UIKit ships with built-in English strings and a localization API that lets you add any language — or override individual strings — without forking the UIKit. English is the only built-in language. Any key missing from a custom locale bundle automatically resolves to its English value — no errors are thrown and no code changes are needed.
 
-## Built-in Languages
-
-| Language | Locale Code | Status |
-|----------|-------------|--------|
-| English | `en` | Full coverage — always the final fallback |
-
-English is the only built-in language. Any key missing from a custom locale bundle automatically resolves to its English value — no errors are thrown and no code changes are needed.
-
-## Three Independent Modules
-
-Localization keys are organized into three independent modules. Each module has its own string provider instance, so when registering locale bundles or overrides you provide keys to the correct module provider.
-
-| Module | Scope |
-|--------|-------|
-| Social | Posts, comments, communities, events, stories, livestream, clips, polls, feeds, notifications |
-| Common | Reactions, ads, time labels, shared buttons, dialogs, error states, empty states |
-| Chat | Messages, channels, message input, chat-specific features |
-
-### Format specifiers
-
-| Specifier | Meaning | Example |
-|-----------|---------|---------|
-| `%s` / `%1$s` / `%2$s` | Positional string substitution | `"By %s"` |
-| `%d` / `%1$d` / `%2$d` | Integer substitution | `"Follow requests (%1$d)"` |
-| `%@` | iOS-style string substitution (equivalent to `%s`) | `"Voted by %@ participants"` |
-
-Format specifiers must be preserved in the exact same positions when translating. The `%@` specifier is native to iOS; the Web UIKit normalizes it to `%s` automatically.
+### 
 
 ## Platform Implementation
 
 Select your platform below for API details and integration code.
 
 <Tabs>
+  <Tab title="iOS (Swift)">
+    ### String Providers
+
+    The iOS UIKit uses `AmityStringProvider` with three singleton instances — `.social`, `.common`, and `.chat` — matching the three modules. Each provider exposes the same API for registering locale bundles and overrides.
+
+    | Method | Behavior |
+    | --- | --- |
+    | `setLocale(_:bundle:)` | Register a locale bundle (replace semantics). Activates immediately. |
+    | `activateLocale(_:)` | Re-activate a previously registered locale by identifier. |
+    | `deactivateLocale()` | Deactivate the current locale. Keys fall through to library defaults. Does **not** delete the cached bundle. |
+    | `setOverrides(_:)` | Merge key-value overrides on top of any active locale. Multiple calls merge. |
+    | `clearOverrides()` | Remove all programmatic overrides. |
+
+    ### How to Add a New Language
+
+    #### Option A — Programmatic via String Provider API (recommended)
+
+    Provide a `[String: String]` dictionary of translated keys and register it with each provider. No fork required.
+
+    <Steps>
+      <Step title="Create a locale bundle">
+        Create a dictionary with the translated keys. You only need to include keys you're translating — missing keys fall back to the built-in English values automatically.
+
+        ```swift
+        struct MyJapaneseStrings {
+            static let social: [String: String] = [
+                "amity_social_button_comments": "コメント",
+                "amity_social_button_delete_comment": "コメントを削除",
+                "amity_social_button_edit_comment": "コメントを編集",
+            ]
+        
+            static let common: [String: String] = [
+                "amity_common_button_cancel": "キャンセル",
+                "amity_common_button_done": "完了",
+            ]
+        
+            static let chat: [String: String] = [
+                "amity_chat_edit_message": "メッセージを編集",
+            ]
+        }
+        ```
+      </Step>
+      <Step title="Register the locale bundle">
+        Call `setLocale` on each provider — typically at app launch or in response to a user language-switch action:
+
+        ```swift
+        AmityStringProvider.social.setLocale("ja", bundle: MyJapaneseStrings.social)
+        AmityStringProvider.common.setLocale("ja", bundle: MyJapaneseStrings.common)
+        AmityStringProvider.chat.setLocale("ja", bundle: MyJapaneseStrings.chat)
+        ```
+
+        To revert to the default English strings:
+
+        ```swift
+        AmityStringProvider.social.deactivateLocale()
+        AmityStringProvider.common.deactivateLocale()
+        AmityStringProvider.chat.deactivateLocale()
+        ```
+      </Step>
+    </Steps>
+
+    #### Option B — Override individual keys
+
+    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
+
+    ```swift
+    AmityStringProvider.social.setOverrides([
+        "amity_social_button_comments": "Replies",
+        "amity_social_modal_dialog_generic_error": "Something went wrong. Please try again.",
+    ])
+    
+    AmityStringProvider.common.setOverrides([
+        "amity_common_button_cancel": "Dismiss",
+    ])
+    ```
+
+    To clear overrides:
+
+    ```swift
+    AmityStringProvider.social.clearOverrides()
+    AmityStringProvider.common.clearOverrides()
+    ```
+
+    #### Option C — Bundle-based `.lproj` files
+
+    You can also provide translations via standard iOS `.lproj` directories in your app bundle. The UIKit checks `Bundle.main` for `AmityLocalizable.strings` before falling back to its framework bundle — no code changes needed.
+
+    ```text
+    MyApp/
+    └── Resources/
+        ├── en.lproj/AmityLocalizable.strings   ← English overrides (optional)
+        └── ja.lproj/AmityLocalizable.strings   ← Japanese translations
+    ```
+
+    ```text
+    /* ja.lproj/AmityLocalizable.strings */
+    "amity_common_button_cancel" = "キャンセル";
+    "amity_common_button_delete" = "削除";
+    "amity_social_button_comments" = "コメント";
+    ```
+
+    iOS automatically selects the correct `.lproj` folder based on the device language. Strings provided via `.lproj` are resolved at the library defaults level — programmatic overrides and locale bundles still take precedence.
+  </Tab>
+  <Tab title="Android (Kotlin)">
+    ### String Providers
+
+    String resolution is handled by two providers: `DefaultAmitySocialStringProvider` (social strings) and `DefaultAmityCommonStringProvider` (common strings). Both providers are singletons initialized in your `Application.onCreate()`.
+
+    | Method | Behavior |
+    | --- | --- |
+    | `setLocale(id, bundle)` | Register a locale bundle (replace semantics). Activates immediately. |
+    | `clearLocale()` | Deactivate the current locale. Keys fall through to library defaults. |
+    | `setOverrides(map)` | Merge key-value overrides on top of any active locale. |
+    | `clearOverrides()` | Remove all programmatic overrides. |
+
+    ### How to Add a New Language
+
+    #### Option A — Locale bundle via String Provider API (recommended)
+
+    Provide a `Map<String, String>` of translated keys and register it with the provider. No fork required.
+
+    <Steps>
+      <Step title="Initialize the providers">
+        Call both providers in your `Application.onCreate()`:
+
+        ```kotlin
+        class MyApplication : Application() {
+            override fun onCreate() {
+                super.onCreate()
+                DefaultAmitySocialStringProvider.initialize(this)
+                DefaultAmityCommonStringProvider.initialize(this)
+            }
+        }
+        ```
+      </Step>
+      <Step title="Create a locale bundle">
+        Create a Kotlin object (or a plain `Map<String, String>`) with the translated keys. You only need to include keys you're translating — missing keys fall back to the English `strings.xml` values automatically.
+
+        ```kotlin
+        object MyJapaneseStrings {
+            val social: Map<String, String> = mapOf(
+                "amity_social_button_comments" to "コメント",
+                "amity_social_button_delete_comment" to "コメントを削除",
+                "amity_social_button_edit_comment" to "コメントを編集",
+            )
+        
+            val common: Map<String, String> = mapOf(
+                "amity_common_button_cancel" to "キャンセル",
+                "amity_common_button_done" to "完了",
+            )
+        }
+        ```
+      </Step>
+      <Step title="Register the locale bundle">
+        Call `setLocale()` on both providers — typically in `Application.onCreate()` after initialization, or in response to a user language-switch action:
+
+        ```kotlin
+        DefaultAmitySocialStringProvider.setLocale("ja", MyJapaneseStrings.social)
+        DefaultAmityCommonStringProvider.setLocale("ja", MyJapaneseStrings.common)
+        ```
+
+        To revert to the default English resources:
+
+        ```kotlin
+        DefaultAmitySocialStringProvider.getInstance().clearLocale()
+        DefaultAmityCommonStringProvider.getInstance().clearLocale()
+        ```
+      </Step>
+    </Steps>
+
+    #### Option B — Override individual keys
+
+    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
+
+    ```kotlin
+    DefaultAmitySocialStringProvider.setOverrides(mapOf(
+        "amity_social_button_comments" to "Replies",
+        "amity_social_modal_dialog_generic_error" to "Something went wrong. Please try again.",
+    ))
+    
+    DefaultAmityCommonStringProvider.setOverrides(mapOf(
+        "amity_common_button_cancel" to "Dismiss",
+    ))
+    ```
+
+    To clear overrides:
+
+    ```kotlin
+    DefaultAmitySocialStringProvider.getInstance().clearOverrides()
+    DefaultAmityCommonStringProvider.getInstance().clearOverrides()
+    ```
+
+    #### Option C — Fork the UIKit repository
+
+    For full static translation using the Android resource system, clone the UIKit and add `values-<language-code>/` resource directories inside each module:
+
+    ```text
+    common/src/main/res/values-ja/strings.xml
+    social/src/main/res/values-ja/strings.xml
+    social-compose/src/main/res/values-ja/strings.xml
+    chat/src/main/res/values-ja/strings.xml
+    chat-compose/src/main/res/values-ja/strings.xml
+    ```
+
+    <Note>
+      Social keys start with `amity_social_`; common keys start with `amity_common_`. When calling provider methods, use the correct provider for each key prefix.
+    </Note>
+
+    For the full key list, refer to the English default `strings.xml` files in the [Android UIKit open source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource):
+
+    - [`social-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml) (social keys)
+    - [`common-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/common-compose/src/main/res/values/strings.xml) (common keys)
+
+    You can also refer to the comprehensive [`LOCALIZATION_GUIDE.md`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/LOCALIZATION_GUIDE.md) in the repository for detailed instructions and examples.
+  </Tab>
   <Tab title="Web (React)">
     ### Provider Props
 
     Configure localization via the `localization` prop on `AmityUIKitProvider`.
 
     | Prop | Type | Description |
-    |------|------|-------------|
+    | --- | --- | --- |
     | `localeBundle` | `Record<string, string>` | Explicitly set a locale bundle. Takes precedence over `localeMap` auto-detection. |
     | `overrides` | `Record<string, string>` | Merge-override individual keys on top of the active locale. |
     | `localeMap` | `Record<string, Record<string, string>>` | Map of locale code → bundle for automatic device-language detection via `navigator.language`. |
@@ -70,7 +259,7 @@ Select your platform below for API details and integration code.
       <Accordion title="Auto-detect device language">
         ```tsx
         import jaLocale from './locales/ja.json';
-
+        
         <AmityUIKitProvider
           localization={{ localeMap: { ja: jaLocale } }}
         >
@@ -104,10 +293,10 @@ Select your platform below for API details and integration code.
         ```tsx
         import { useLocale, useString } from '@amityco/ui-kit';
         import jaLocale from './locales/ja.json';
-
+        
         function LanguageSwitcher() {
           const { setLocaleBundle, clearLocaleBundle } = useLocale();
-
+        
           return (
             <>
               <button onClick={() => setLocaleBundle(jaLocale)}>日本語</button>
@@ -115,7 +304,7 @@ Select your platform below for API details and integration code.
             </>
           );
         }
-
+        
         // Any child component — automatically re-renders on locale change
         function CancelButton() {
           const label = useString('amity_common_button_cancel');
@@ -139,13 +328,12 @@ Select your platform below for API details and integration code.
         }
         ```
       </Step>
-
       <Step title="Register via localeMap">
         Pass the bundle via `localeMap` so the UIKit auto-detects it from `navigator.language`:
 
         ```tsx
         import jaLocale from './locales/ja.json';
-
+        
         <AmityUIKitProvider
           localization={{
             localeMap: {
@@ -157,233 +345,10 @@ Select your platform below for API details and integration code.
         </AmityUIKitProvider>
         ```
       </Step>
-
       <Step title="Verify coverage">
         Compare your translation file against [`en.json`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json) to identify missing keys. Any untranslated key silently falls back to English — no errors are thrown.
       </Step>
     </Steps>
-
-  </Tab>
-
-  <Tab title="iOS (Swift)">
-    ### String Providers
-
-    The iOS UIKit uses `AmityStringProvider` with three singleton instances — `.social`, `.common`, and `.chat` — matching the three modules. Each provider exposes the same API for registering locale bundles and overrides.
-
-    | Method | Behavior |
-    |--------|----------|
-    | `setLocale(_:bundle:)` | Register a locale bundle (replace semantics). Activates immediately. |
-    | `activateLocale(_:)` | Re-activate a previously registered locale by identifier. |
-    | `deactivateLocale()` | Deactivate the current locale. Keys fall through to library defaults. Does **not** delete the cached bundle. |
-    | `setOverrides(_:)` | Merge key-value overrides on top of any active locale. Multiple calls merge. |
-    | `clearOverrides()` | Remove all programmatic overrides. |
-
-    ### How to Add a New Language
-
-    #### Option A — Programmatic via String Provider API (recommended)
-
-    Provide a `[String: String]` dictionary of translated keys and register it with each provider. No fork required.
-
-    <Steps>
-      <Step title="Create a locale bundle">
-        Create a dictionary with the translated keys. You only need to include keys you're translating — missing keys fall back to the built-in English values automatically.
-
-        ```swift
-        struct MyJapaneseStrings {
-            static let social: [String: String] = [
-                "amity_social_button_comments": "コメント",
-                "amity_social_button_delete_comment": "コメントを削除",
-                "amity_social_button_edit_comment": "コメントを編集",
-            ]
-
-            static let common: [String: String] = [
-                "amity_common_button_cancel": "キャンセル",
-                "amity_common_button_done": "完了",
-            ]
-
-            static let chat: [String: String] = [
-                "amity_chat_edit_message": "メッセージを編集",
-            ]
-        }
-        ```
-      </Step>
-
-      <Step title="Register the locale bundle">
-        Call `setLocale` on each provider — typically at app launch or in response to a user language-switch action:
-
-        ```swift
-        AmityStringProvider.social.setLocale("ja", bundle: MyJapaneseStrings.social)
-        AmityStringProvider.common.setLocale("ja", bundle: MyJapaneseStrings.common)
-        AmityStringProvider.chat.setLocale("ja", bundle: MyJapaneseStrings.chat)
-        ```
-
-        To revert to the default English strings:
-
-        ```swift
-        AmityStringProvider.social.deactivateLocale()
-        AmityStringProvider.common.deactivateLocale()
-        AmityStringProvider.chat.deactivateLocale()
-        ```
-      </Step>
-    </Steps>
-
-    #### Option B — Override individual keys
-
-    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
-
-    ```swift
-    AmityStringProvider.social.setOverrides([
-        "amity_social_button_comments": "Replies",
-        "amity_social_modal_dialog_generic_error": "Something went wrong. Please try again.",
-    ])
-
-    AmityStringProvider.common.setOverrides([
-        "amity_common_button_cancel": "Dismiss",
-    ])
-    ```
-
-    To clear overrides:
-
-    ```swift
-    AmityStringProvider.social.clearOverrides()
-    AmityStringProvider.common.clearOverrides()
-    ```
-
-    #### Option C — Bundle-based `.lproj` files
-
-    You can also provide translations via standard iOS `.lproj` directories in your app bundle. The UIKit checks `Bundle.main` for `AmityLocalizable.strings` before falling back to its framework bundle — no code changes needed.
-
-    ```
-    MyApp/
-    └── Resources/
-        ├── en.lproj/AmityLocalizable.strings   ← English overrides (optional)
-        └── ja.lproj/AmityLocalizable.strings   ← Japanese translations
-    ```
-
-    ```
-    /* ja.lproj/AmityLocalizable.strings */
-    "amity_common_button_cancel" = "キャンセル";
-    "amity_common_button_delete" = "削除";
-    "amity_social_button_comments" = "コメント";
-    ```
-
-    iOS automatically selects the correct `.lproj` folder based on the device language. Strings provided via `.lproj` are resolved at the library defaults level — programmatic overrides and locale bundles still take precedence.
-
-  </Tab>
-
-  <Tab title="Android (Kotlin)">
-    ### String Providers
-
-    String resolution is handled by two providers: `DefaultAmitySocialStringProvider` (social strings) and `DefaultAmityCommonStringProvider` (common strings). Both providers are singletons initialized in your `Application.onCreate()`.
-
-    | Method | Behavior |
-    |--------|----------|
-    | `setLocale(id, bundle)` | Register a locale bundle (replace semantics). Activates immediately. |
-    | `clearLocale()` | Deactivate the current locale. Keys fall through to library defaults. |
-    | `setOverrides(map)` | Merge key-value overrides on top of any active locale. |
-    | `clearOverrides()` | Remove all programmatic overrides. |
-
-    ### How to Add a New Language
-
-    #### Option A — Locale bundle via String Provider API (recommended)
-
-    Provide a `Map<String, String>` of translated keys and register it with the provider. No fork required.
-
-    <Steps>
-      <Step title="Initialize the providers">
-        Call both providers in your `Application.onCreate()`:
-
-        ```kotlin
-        class MyApplication : Application() {
-            override fun onCreate() {
-                super.onCreate()
-                DefaultAmitySocialStringProvider.initialize(this)
-                DefaultAmityCommonStringProvider.initialize(this)
-            }
-        }
-        ```
-      </Step>
-
-      <Step title="Create a locale bundle">
-        Create a Kotlin object (or a plain `Map<String, String>`) with the translated keys. You only need to include keys you're translating — missing keys fall back to the English `strings.xml` values automatically.
-
-        ```kotlin
-        object MyJapaneseStrings {
-            val social: Map<String, String> = mapOf(
-                "amity_social_button_comments" to "コメント",
-                "amity_social_button_delete_comment" to "コメントを削除",
-                "amity_social_button_edit_comment" to "コメントを編集",
-            )
-
-            val common: Map<String, String> = mapOf(
-                "amity_common_button_cancel" to "キャンセル",
-                "amity_common_button_done" to "完了",
-            )
-        }
-        ```
-      </Step>
-
-      <Step title="Register the locale bundle">
-        Call `setLocale()` on both providers — typically in `Application.onCreate()` after initialization, or in response to a user language-switch action:
-
-        ```kotlin
-        DefaultAmitySocialStringProvider.setLocale("ja", MyJapaneseStrings.social)
-        DefaultAmityCommonStringProvider.setLocale("ja", MyJapaneseStrings.common)
-        ```
-
-        To revert to the default English resources:
-
-        ```kotlin
-        DefaultAmitySocialStringProvider.getInstance().clearLocale()
-        DefaultAmityCommonStringProvider.getInstance().clearLocale()
-        ```
-      </Step>
-    </Steps>
-
-    #### Option B — Override individual keys
-
-    To replace specific strings without providing a full locale bundle, use `setOverrides()`. Overrides take the highest priority and merge on top of any active locale.
-
-    ```kotlin
-    DefaultAmitySocialStringProvider.setOverrides(mapOf(
-        "amity_social_button_comments" to "Replies",
-        "amity_social_modal_dialog_generic_error" to "Something went wrong. Please try again.",
-    ))
-
-    DefaultAmityCommonStringProvider.setOverrides(mapOf(
-        "amity_common_button_cancel" to "Dismiss",
-    ))
-    ```
-
-    To clear overrides:
-
-    ```kotlin
-    DefaultAmitySocialStringProvider.getInstance().clearOverrides()
-    DefaultAmityCommonStringProvider.getInstance().clearOverrides()
-    ```
-
-    #### Option C — Fork the UIKit repository
-
-    For full static translation using the Android resource system, clone the UIKit and add `values-<language-code>/` resource directories inside each module:
-
-    ```
-    common/src/main/res/values-ja/strings.xml
-    social/src/main/res/values-ja/strings.xml
-    social-compose/src/main/res/values-ja/strings.xml
-    chat/src/main/res/values-ja/strings.xml
-    chat-compose/src/main/res/values-ja/strings.xml
-    ```
-
-    <Note>
-      Social keys start with `amity_social_`; common keys start with `amity_common_`. When calling provider methods, use the correct provider for each key prefix.
-    </Note>
-
-    For the full key list, refer to the English default `strings.xml` files in the [Android UIKit open source repository](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource):
-    - [`social-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml) (social keys)
-    - [`common-compose/.../values/strings.xml`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/common-compose/src/main/res/values/strings.xml) (common keys)
-
-    You can also refer to the comprehensive [`LOCALIZATION_GUIDE.md`](https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/LOCALIZATION_GUIDE.md) in the repository for detailed instructions and examples.
-
   </Tab>
 </Tabs>
 
@@ -393,14 +358,14 @@ You can use an AI assistant (e.g. ChatGPT, Claude, Copilot) to quickly generate 
 
 <AccordionGroup>
   <Accordion title="Example AI prompt" icon="sparkles">
-    ```
+    ```text
     I have a localization file for a mobile/web UIKit with English strings.
     Please translate all values to [TARGET LANGUAGE] while keeping:
     - All keys exactly the same (do not rename any key)
     - All format specifiers (%s, %d, %1$s, %1$d, %@, etc.) in the same positions
     - The same file format (JSON / .strings / XML)
     - Natural, user-facing language appropriate for a social app UI
-
+    
     Here is the English file:
     [PASTE THE CONTENTS OF THE ENGLISH LOCALIZATION FILE]
     ```
@@ -412,11 +377,11 @@ You can use an AI assistant (e.g. ChatGPT, Claude, Copilot) to quickly generate 
 ## Migrating from `config.json` Text Overrides
 
 <Warning>
-**`config.json` text overrides are deprecated for string customization.** If you previously used `config.json` to override UI strings (e.g. button labels, error messages), you should migrate those overrides to the localization API described above — even if you don't plan to add new languages.
+  **`config.json` text overrides are deprecated for string customization.** If you previously used `config.json` to override UI strings (e.g. button labels, error messages), you should migrate those overrides to the localization API described above — even if you don't plan to add new languages.
 
-Existing `config.json` text overrides are still resolved gracefully for now, but this auto-resolution **may be removed in a future release**. New UI components and features will only support string customization through the localization system.
+  Existing `config.json` text overrides are still resolved gracefully for now, but this auto-resolution **may be removed in a future release**. New UI components and features will only support string customization through the localization system.
 
-`config.json` remains available for other configuration such as theme and UI element visibility — only string/text overrides are being deprecated.
+  `config.json` remains available for other configuration such as theme and UI element visibility — only string/text overrides are being deprecated.
 </Warning>
 
 ## Open Source Reference Files
@@ -424,29 +389,19 @@ Existing `config.json` text overrides are still resolved gracefully for now, but
 Use these English localization files as the source of truth when building translations for each platform.
 
 <Info>
-**Version alignment:** New UIKit releases may introduce new localization keys for new UI components or features. When upgrading, re-generate your translation files from the open source reference file that matches your UIKit version to ensure no keys are missing. Untranslated keys fall back to English silently, but keeping your translation files up to date ensures a fully localized experience.
+  **Version alignment:** New UIKit releases may introduce new localization keys for new UI components or features. When upgrading, re-generate your translation files from the open source reference file that matches your UIKit version to ensure no keys are missing. Untranslated keys fall back to English silently, but keeping your translation files up to date ensures a fully localized experience.
 </Info>
 
 <CardGroup cols={3}>
-  <Card
-    title="Web"
-    icon="globe"
-    href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json"
-  >
+  <Card title="Web" icon="globe" href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/blob/master/src/v4/core/localization/defaults/en.json">
     `en.json`
   </Card>
-  <Card
-    title="iOS"
-    icon="apple"
-    href="https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/main/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/en.lproj/AmityLocalizable.strings"
-  >
+
+  <Card title="iOS" icon="apple" href="https://github.com/AmityCo/ASC-UIKit-iOS-OpenSource/blob/main/UpstraUIKit/AmityUIKit4/AmityUIKit4/Core/Localization/en.lproj/AmityLocalizable.strings">
     `AmityLocalizable.strings`
   </Card>
-  <Card
-    title="Android"
-    icon="android"
-    href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml"
-  >
-    `strings.xml` (social + common keys)
+
+  <Card title="Android" icon="android" href="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Android-OpenSource/blob/main/social-compose/src/main/res/values/strings.xml">
+    `strings.xml` (social \+ common keys)
   </Card>
 </CardGroup>


### PR DESCRIPTION
This pull request updates the localization documentation for the UIKit to simplify and clarify how to add and override language bundles, with a particular focus on removing Thai as a built-in example and generalizing the instructions. The changes also streamline code samples and remove references to maintaining built-in Thai support when customizing locales.

Localization documentation improvements:

* Removed Thai (`th`) as a built-in example and replaced it with Japanese (`ja`) in all code samples and documentation, making the instructions more generic and easier to follow for adding any language. [[1]](diffhunk://#diff-555fa46e6e98222f4c994cee19098d1ab386f9284c66bbda3861be04a61d85dfL27) [[2]](diffhunk://#diff-555fa46e6e98222f4c994cee19098d1ab386f9284c66bbda3861be04a61d85dfL62-R71) [[3]](diffhunk://#diff-555fa46e6e98222f4c994cee19098d1ab386f9284c66bbda3861be04a61d85dfL183-R186)
* Simplified and updated code samples to use a generic `myLocale` or `jaLocale` instead of `thLocaleBundle`, and clarified the configuration options in the `AmityUIKitProvider` example.
* Removed the warning about preserving built-in Thai auto-detection when overriding the `localeMap`, reflecting the shift to a more general approach for custom locales.

Reference and coverage instructions:

* Updated instructions to direct users to compare their translation file against the English reference and clarified fallback behavior for missing keys.
* Cleaned up Android documentation by removing the sample Thai override reference and focusing on the official key files as the source of truth.