### PR TITLE
feat(docs-ops): wire server-side drift gate (Phase 2.2)

### DIFF
--- a/.docs-ops/CI_GATE.md
+++ b/.docs-ops/CI_GATE.md
@@ -136,12 +136,34 @@ The same `check-drift.py` script powers three layers — each one is independent
 | Layer | Where it runs | Bypassable? | Who sets up |
 |---|---|---|---|
 | **Local pre-push hook** | Contributor's machine on `git push` | Yes (`--no-verify`) | Each contributor, one-time |
-| **GitHub Action** (final step, not yet wired) | Server on every PR | No (without branch protection edit) | Repo admin |
-| **Branch protection** (final step) | Server on merge | No without repo-admin role | Repo admin in GitHub UI |
+| **GitHub Action** (`docs-ops-drift-check.yml`) | Server on every PR into `main` | No (with branch protection on) | ✅ wired |
+| **Branch protection** | Server on merge | No without repo-admin role | Repo admin in GitHub UI (one toggle — see below) |
 
-**Today (Phase 2.1)** — local layer is live. Awareness depends on contributors running `pre-commit install`.
+**Today (Phase 2.2)** — the GitHub Action `.github/workflows/docs-ops-drift-check.yml` runs `check-drift.py` on every PR into `main`, posts a sticky delta comment, and exits non-zero on any regression. It becomes a *merge blocker* the moment the branch-protection rule below is enabled — that toggle is the only remaining step, and it's a repo-admin action in the GitHub UI.
 
-**Next (Phase 2.2)** — GitHub Action will call the same script in CI, post the delta as a PR comment, and (with branch protection enabled) block merges. With all four platforms covered (TS + Flutter + Android + iOS), this is the next milestone: server-enforced gating via GitHub Action + branch protection rule. **Note:** the iOS check requires a macOS runner — the Phase 2.2 Action should use `runs-on: macos-latest` (or a matrix) to ensure iOS coverage is not silently skipped on Linux runners.
+### What the Action enforces (coverage scope)
+
+The Action runs on `ubuntu-latest`. Each check self-gates on toolchain availability, so the **blocking** guarantee is:
+
+| Check | Enforced server-side? | Why |
+|---|---|---|
+| TS regex drift delta | ✅ **blocks** | pure Python; reads TS SDK source (checked out as a sibling) |
+| MDX structure | ✅ **blocks** | pure Python |
+| TS doc-as-test (`tsc`) | ✅ blocks when `tsc` is set up (best-effort node install in the job) |
+| Flutter / Android doc-as-test | ⚪ reports *unavailable* | needs `dart` / `kotlinc` on the runner |
+| iOS doc-as-test | ⚪ reports *unavailable* | needs **macOS** + `swiftc` |
+
+Uncovered layers are **surfaced in the PR comment** as `unavailable` — never silently assumed green. The Action depends on the existing `SDK_READONLY_PAT` secret (already used by `sdk-drift-watcher.yml`) for the SDK checkout.
+
+### Extending coverage
+
+To enforce more platforms server-side, add toolchains to the job (and a matrix for iOS):
+
+- **Flutter** — add a Dart/Flutter setup step (`subosito/flutter-action`) + `dart pub get` in `.docs-ops/integration-tests/flutter/`; check out the Flutter SDK sibling.
+- **Android** — install a Kotlin compiler (`kotlinc`) and check out the Android SDK sibling.
+- **iOS** — add a second job on `runs-on: macos-latest` (macOS runners cost ~10× ubuntu minutes — a deliberate cost decision) running only the iOS doc-as-test leg, and require it as a separate status check.
+
+Each added platform flips its row from *unavailable* to *blocks* automatically — `check-drift.py` already orchestrates all four; it's purely a question of which toolchains the runner has.
 
 ## For contributors
 
@@ -177,9 +199,15 @@ When you review a docs PR:
 
 ## For repo admins
 
-Once you're happy with the local layer, enable the server layer:
+The Action (`.github/workflows/docs-ops-drift-check.yml`) is wired and runs on every PR into `main`. It does **not** block merges until you require it as a status check. To turn it into a real merge blocker:
 
-1. Wire `.github/workflows/docs-ops-drift-check.yml` (TBD — Phase 2.2).
-2. In GitHub → Settings → Branches → branch protection rule for `main` → require status check `docs-ops-drift-check` to pass before merge.
+1. Open one PR so the check runs at least once (GitHub only lists checks it has seen).
+2. GitHub → **Settings → Branches → Branch protection rules → `main`** (add a rule if none).
+3. Enable **"Require status checks to pass before merging."**
+4. In the search box, add the status check named **`drift-gate`** (the job id).
+5. (Recommended) also enable **"Require branches to be up to date before merging"** so the gate runs against current `main`.
+6. Save.
 
-After that, the gate is genuinely enforced. Contributors who bypass locally still get caught at PR time.
+Prerequisite: the repo secret **`SDK_READONLY_PAT`** must exist (it already does — `sdk-drift-watcher.yml` uses it). It needs read access to `AmityCo/AmityTypescriptSDK`.
+
+After that, the gate is genuinely enforced. Contributors who bypass the local hook with `--no-verify` still get caught at PR time.

--- a/.github/workflows/docs-ops-drift-check.yml
+++ b/.github/workflows/docs-ops-drift-check.yml
@@ -1,0 +1,169 @@
+name: Docs-Ops Drift Gate
+
+# Server-enforced docs-ops gate (Phase 2.2). Runs the SAME check-drift.py that
+# powers the local pre-push hook, on every PR into main. With a branch-protection
+# rule requiring the "drift-gate" check, this blocks merges that introduce new
+# (file, stale-API-ref) pairs or break documented code blocks.
+#
+# COVERAGE (what this job actually enforces on ubuntu):
+#   - TS regex drift delta ...... BLOCKS  (pure Python; reads TS SDK source)
+#   - MDX structure check ........ BLOCKS  (pure Python)
+#   - TS doc-as-test (tsc) ....... BLOCKS when toolchain present; best-effort setup below
+#   - Flutter / Android / iOS
+#     doc-as-test ................ report "unavailable" (non-blocking) — NOT enforced here.
+#                                  Enabling them needs dart / kotlinc, and macOS (swiftc)
+#                                  for iOS. See .docs-ops/CI_GATE.md "Extending coverage".
+#
+# Every layer's status is surfaced in the PR comment + job summary, so uncovered
+# platforms are visible, never silently assumed green.
+
+on:
+  # No `paths:` filter on purpose. When this is a REQUIRED status check, a
+  # path-filtered run that is skipped leaves the check "pending" forever and
+  # blocks the PR. Running on every PR to main avoids that deadlock.
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  # One in-flight run per PR; a new push cancels the previous run.
+  group: docs-ops-drift-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # to post the sticky delta comment
+
+    defaults:
+      run:
+        working-directory: social-plus-docs
+
+    steps:
+      # check-drift.py hardcodes the SDK location at REPO_ROOT.parent (the docs
+      # repo's parent dir). actions/checkout cannot write OUTSIDE $GITHUB_WORKSPACE,
+      # so we lay both repos out as SIBLINGS inside the workspace:
+      #   $GITHUB_WORKSPACE/social-plus-docs   (this repo, REPO_ROOT)
+      #   $GITHUB_WORKSPACE/AmityTypescriptSDK  (= REPO_ROOT.parent/AmityTypescriptSDK)
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          path: social-plus-docs
+          # Full history so check-drift.py can build a baseline worktree at origin/main.
+          fetch-depth: 0
+
+      - name: Checkout TypeScript SDK (drift extractor reads its source)
+        uses: actions/checkout@v4
+        with:
+          repository: AmityCo/AmityTypescriptSDK
+          path: AmityTypescriptSDK
+          token: ${{ secrets.SDK_READONLY_PAT }}   # read access to the SDK repo
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Best-effort TS doc-as-test toolchain. If this step fails, the doc-as-test
+      # layer reports "crashed"/"unavailable" (non-blocking) and the blocking
+      # guarantee falls back to TS regex drift + MDX. It does NOT silently pass —
+      # the status is printed in the PR comment.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install TypeScript (tsc) for doc-as-test
+        continue-on-error: true
+        run: npm install -g typescript
+
+      - name: Run docs-ops drift gate
+        id: gate
+        continue-on-error: true   # let the comment post even on failure; final step decides
+        # No SP_SDKS_ROOT env: check-drift.py sets it to REPO_ROOT.parent itself,
+        # overriding any value here. The sibling checkout layout above is what makes
+        # the SDK resolvable.
+        run: |
+          python3 .docs-ops/ci/check-drift.py \
+            --base origin/main \
+            --json-out "$RUNNER_TEMP/delta.json"
+
+      - name: Build report (summary + PR comment body)
+        if: always()
+        id: report
+        run: |
+          python3 - "$RUNNER_TEMP/delta.json" > "$RUNNER_TEMP/comment.md" <<'PY'
+          import json, sys, pathlib
+          p = pathlib.Path(sys.argv[1])
+          if not p.exists():
+              print("### 🚨 Docs-Ops Drift Gate\n\nThe gate did not produce a delta report — it likely failed to run (could not resolve base, SDK checkout, or extractor crash). **Check the job logs.** Treating as a failure.")
+              sys.exit(0)
+          d = json.loads(p.read_text())
+          dr = d.get("drift_delta", {})
+          def dat(key):
+              x = d.get(key, {})
+              if not x.get("available"): return "⚪ unavailable (not enforced here)"
+              if x.get("crashed"):       return f"⚠️ crashed (non-blocking): {x.get('crash_reason','')[:120]}"
+              b = len(x.get("blocking_failures", []))
+              s = x.get("stats", {})
+              passed = s.get("blocks_passed", "?")
+              return ("❌ " if b else "✅ ") + f"{b} blocking, {passed} passed"
+          regressed = dr.get("regressed")
+          new_pairs = dr.get("new_pairs", [])
+          lines = []
+          lines.append("### " + ("❌ Docs-Ops Drift Gate — FAIL" if (regressed or any('❌' in dat(k) for k in ('doc_as_test_ts','doc_as_test_flutter','doc_as_test_android','doc_as_test_ios')) or d.get('mdx_structure',{}).get('blocking')) else "✅ Docs-Ops Drift Gate — PASS"))
+          lines.append("")
+          lines.append(f"**Regex drift:** baseline `{dr.get('baseline_total','?')}` → candidate `{dr.get('candidate_total','?')}` "
+                       f"(Δ {dr.get('delta_total','?')}), **{len(new_pairs)} new (file, ref) pair(s)**.")
+          if new_pairs:
+              lines.append("")
+              lines.append("<details><summary>New drift pairs (these block the merge)</summary>\n")
+              for pr in new_pairs[:50]:
+                  lines.append(f"- `{pr.get('file','?')}` → `{pr.get('ref','?')}`")
+              if len(new_pairs) > 50:
+                  lines.append(f"- …and {len(new_pairs)-50} more")
+              lines.append("\n</details>")
+          lines.append("")
+          lines.append("| Layer | Status |")
+          lines.append("|---|---|")
+          lines.append(f"| TS doc-as-test | {dat('doc_as_test_ts')} |")
+          lines.append(f"| Flutter doc-as-test | {dat('doc_as_test_flutter')} |")
+          lines.append(f"| Android doc-as-test | {dat('doc_as_test_android')} |")
+          lines.append(f"| iOS doc-as-test | {dat('doc_as_test_ios')} |")
+          mdx = d.get("mdx_structure", {})
+          lines.append(f"| MDX structure | {'❌ ' + str(len(mdx.get('violations',[]))) + ' violation(s)' if mdx.get('blocking') else '✅ clean'} |")
+          lines.append("")
+          lines.append("<sub>Layers marked _unavailable_ are not enforced by this job (missing toolchain / macOS). See `.docs-ops/CI_GATE.md`.</sub>")
+          print("\n".join(lines))
+          PY
+          cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post / update PR comment
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true   # a fork/permissions hiccup must not red the gate; only the verdict does
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.RUNNER_TEMP + '/comment.md', 'utf8');
+            const marker = '<!-- docs-ops-drift-gate -->';
+            const full = marker + '\n' + body;
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({owner, repo, issue_number});
+            const existing = comments.data.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body: full});
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number, body: full});
+            }
+
+      - name: Enforce gate result
+        if: always()
+        run: |
+          # check-drift.py exit: 0 = pass, 1 = regression/blocking failure, 2 = environmental.
+          # A server gate fails LOUDLY on both — green-when-broken is worse than red.
+          if [ "${{ steps.gate.outcome }}" != "success" ]; then
+            echo "::error::Docs-Ops drift gate failed (new drift, doc-as-test block, or environmental error). See the PR comment / job summary."
+            exit 1
+          fi
+          echo "Docs-Ops drift gate passed."


### PR DESCRIPTION
## What

Promotes the docs-ops gate from a **local-only pre-push hook** to a **server-enforced GitHub Action** on every PR into `main` — the durability keystone that protects the 585→0 drift cleanup from silently regressing when a PR merges without the local hook installed.

## How it works

`.github/workflows/docs-ops-drift-check.yml` runs the **same `check-drift.py`** that powers the local hook, against `origin/main`, on every PR. It posts a sticky delta comment + job summary and exits non-zero on any regression.

### Coverage (what blocks, on `ubuntu-latest`)

| Check | Enforced? | Why |
|---|---|---|
| TS regex drift delta | ✅ **blocks** | pure Python; reads TS SDK source (sibling checkout) |
| MDX structure | ✅ **blocks** | pure Python |
| TS doc-as-test (`tsc`) | ✅ blocks when toolchain present (best-effort node setup) |
| Flutter / Android doc-as-test | ⚪ `unavailable` | needs `dart` / `kotlinc` |
| iOS doc-as-test | ⚪ `unavailable` | needs **macOS** + `swiftc` |

Uncovered layers are **surfaced in the PR comment**, never silently assumed green.

## Design notes

- **No `paths:` filter** — a skipped path-filtered run leaves a *required* check "pending forever" and deadlocks the PR. Runs on every PR to `main` instead.
- **Sibling checkout layout** — `check-drift.py` hardcodes the SDK at `REPO_ROOT.parent`, and `actions/checkout` can't write outside `$GITHUB_WORKSPACE`, so both repos are checked out as siblings *inside* the workspace (`social-plus-docs` + `AmityTypescriptSDK`).
- **Fails loud on environmental errors** — green-when-broken is worse than red.
- Reuses the existing `SDK_READONLY_PAT` secret (no new secret).

## Validation

Ran the real `check-drift.py` against local SDK siblings: **exit 0 / PASS** on this branch (no docs changed), confirming it won't red-light every PR on day one. The report renderer was verified against real `compute_delta` output (incl. the `new_pairs` dict shape) for both pass and regression cases.

## ⚠️ Remaining step (repo admin)

This Action runs but does **not** block merges until required. After this lands:
**Settings → Branches → `main` → Require status checks → add `drift-gate`.**
Full steps documented in `.docs-ops/CI_GATE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)