### PR TITLE
fix(docs-ops): MDX-validity gate + token-resilient drift tier (follow-up to #153)

### DIFF
--- a/.docs-ops/CI_GATE.md
+++ b/.docs-ops/CI_GATE.md
@@ -143,17 +143,27 @@ The same `check-drift.py` script powers three layers — each one is independent
 
 ### What the Action enforces (coverage scope)
 
-The Action runs on `ubuntu-latest`. Each check self-gates on toolchain availability, so the **blocking** guarantee is:
+The Action runs on `ubuntu-latest` in **two tiers**:
 
-| Check | Enforced server-side? | Why |
+**Tier 1 — always, no token, BLOCKS.** Pure Python, runs on every PR regardless of secrets:
+
+| Check | Why |
+|---|---|
+| **MDX validity** (`check-mdx.py`) | unterminated code fences + unbalanced JSX tags (`Accordion`/`Tabs`/`CardGroup`/…) — i.e. **Mintlify build-breakers**. This is the layer that catches the class of bug that took down `send-a-message.mdx`. |
+
+**Tier 2 — only when `secrets.SDK_READONLY_PAT` is configured (needs the private TS SDK), BLOCKS:**
+
+| Check | Enforced? | Why |
 |---|---|---|
-| TS regex drift delta | ✅ **blocks** | pure Python; reads TS SDK source (checked out as a sibling) |
-| MDX structure | ✅ **blocks** | pure Python |
-| TS doc-as-test (`tsc`) | ✅ blocks when `tsc` is set up (best-effort node install in the job) |
-| Flutter / Android doc-as-test | ⚪ reports *unavailable* | needs `dart` / `kotlinc` on the runner |
-| iOS doc-as-test | ⚪ reports *unavailable* | needs **macOS** + `swiftc` |
+| TS regex drift delta | ✅ | reads TS SDK source (sibling checkout) |
+| MDX structure | ✅ | pure Python (runs inside `check-drift.py`) |
+| TS doc-as-test (`tsc`) | ✅ when `tsc` is set up | best-effort node install in the job |
+| Flutter / Android doc-as-test | ⚪ *unavailable* | needs `dart` / `kotlinc` |
+| iOS doc-as-test | ⚪ *unavailable* | needs **macOS** + `swiftc` |
 
-Uncovered layers are **surfaced in the PR comment** as `unavailable` — never silently assumed green. The Action depends on the existing `SDK_READONLY_PAT` secret (already used by `sdk-drift-watcher.yml`) for the SDK checkout.
+**If `SDK_READONLY_PAT` is NOT set, Tier 2 is SKIPPED with a notice in the PR comment — it does not fail the PR.** This is deliberate: a missing-secret config state is not a regression, and Tier 1 (MDX validity) still guards every PR. Add the secret to switch Tier 2 on. (The same checks run locally via the pre-push hook — see "For contributors" — where the SDK sibling is already present, so the full set runs with no token.)
+
+Uncovered Tier-2 layers are **surfaced in the PR comment** as `unavailable` — never silently assumed green.
 
 ### Extending coverage
 

--- a/.docs-ops/ci/check-mdx.py
+++ b/.docs-ops/ci/check-mdx.py
@@ -13,10 +13,13 @@ Exit 0 = clean, 1 = problems found (so it can gate locally + in CI).
 Needs no SDK source and no token, so it runs anywhere.
 
 Usage:
-  python3 .docs-ops/ci/check-mdx.py [paths...]   # default: scan all docs dirs
+  python3 .docs-ops/ci/check-mdx.py [paths...]          # default: scan all docs dirs
+  python3 .docs-ops/ci/check-mdx.py --changed-since REF  # only .mdx changed vs REF
+                                                         # (PR-gate mode; full-scan fallback)
 """
 import re
 import sys
+import subprocess
 import pathlib
 
 DOCS_DIRS = ["social-plus-sdk", "analytics-and-moderation", "uikit",
@@ -73,15 +76,40 @@ def check_file(path):
     return problems
 
 
+def changed_mdx(ref):
+    """`.mdx` files changed vs `ref` (added/modified, not deleted). None on failure."""
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=d", f"{ref}...HEAD", "--", "*.mdx"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return [pathlib.Path(p) for p in out.split() if p]
+
+
 def main(argv):
-    args = argv or DOCS_DIRS
-    roots = [pathlib.Path(a) for a in args]
-    files = []
-    for r in roots:
-        if r.is_dir():
-            files.extend(sorted(r.rglob("*.mdx")))
-        elif r.suffix == ".mdx" and r.exists():
-            files.append(r)
+    files = None
+    if argv and argv[0] == "--changed-since":
+        ref = argv[1] if len(argv) > 1 else "origin/main"
+        argv = []   # consume the flag so the full-scan fallback uses DOCS_DIRS
+        changed = changed_mdx(ref)
+        if changed is None:
+            print(f"⚠️  could not diff against {ref}; falling back to full scan", file=sys.stderr)
+        else:
+            files = [p for p in changed if p.exists()]
+            print(f"PR-gate mode: {len(files)} changed .mdx file(s) vs {ref}")
+            if not files:
+                print("no .mdx changed; nothing to check")
+                return 0
+    if files is None:
+        roots = [pathlib.Path(a) for a in (argv or DOCS_DIRS)]
+        files = []
+        for r in roots:
+            if r.is_dir():
+                files.extend(sorted(r.rglob("*.mdx")))
+            elif r.suffix == ".mdx" and r.exists():
+                files.append(r)
     total_bad = 0
     for f in files:
         probs = check_file(f)

--- a/.docs-ops/ci/check-mdx.py
+++ b/.docs-ops/ci/check-mdx.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+check-mdx.py — fast, dependency-free MDX validity gate.
+
+Catches the structural errors that break a Mintlify build BEFORE push/deploy:
+  1. UNTERMINATED CODE FENCE — an odd number of ``` fences in a file. This is
+     what broke send-a-message.mdx: an unclosed ```swift block swallowed the
+     rest of the page, so a later </Accordion> was never seen.
+  2. UNBALANCED JSX COMPONENT TAGS — <Accordion>/<Tabs>/<CardGroup>/... opened
+     but never closed (or vice versa), counted OUTSIDE code fences.
+
+Exit 0 = clean, 1 = problems found (so it can gate locally + in CI).
+Needs no SDK source and no token, so it runs anywhere.
+
+Usage:
+  python3 .docs-ops/ci/check-mdx.py [paths...]   # default: scan all docs dirs
+"""
+import re
+import sys
+import pathlib
+
+DOCS_DIRS = ["social-plus-sdk", "analytics-and-moderation", "uikit",
+             "use-cases", "api-reference", "essentials", "ai-mcp"]
+
+# Mintlify/MDX components that require a matching close tag.
+PAIRED = ["Accordion", "AccordionGroup", "Tabs", "Tab", "CardGroup", "Card",
+          "Steps", "Step", "Info", "Warning", "Note", "Tip", "Check",
+          "Frame", "Tooltip", "Expandable", "ResponseField", "ParamField",
+          "CodeGroup", "Columns"]
+
+FENCE = re.compile(r"^\s*```")
+
+
+def fence_balance(text):
+    """Return list of fence line-numbers if unbalanced (odd), else []."""
+    fences = [i + 1 for i, ln in enumerate(text.splitlines()) if FENCE.match(ln)]
+    return fences if len(fences) % 2 else []
+
+
+def strip_code(text):
+    """Remove fenced code blocks so we don't count tags inside code."""
+    out, in_fence = [], False
+    for ln in text.splitlines():
+        if FENCE.match(ln):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(ln)
+    return "\n".join(out)
+
+
+def tag_balance(text):
+    """Return list of (tag, open_count, close_count) for unbalanced paired tags."""
+    body = strip_code(text)
+    bad = []
+    for tag in PAIRED:
+        opens = len(re.findall(r"<" + tag + r"(?:\s[^>]*?)?>", body))
+        selfclose = len(re.findall(r"<" + tag + r"(?:\s[^>]*?)?/>", body))
+        closes = len(re.findall(r"</" + tag + r">", body))
+        if (opens - selfclose) != closes:
+            bad.append((tag, opens - selfclose, closes))
+    return bad
+
+
+def check_file(path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    problems = []
+    odd = fence_balance(text)
+    if odd:
+        problems.append(f"unterminated code fence (odd ``` count = {len(odd)}); fence lines: {odd[-3:]}")
+    for tag, o, c in tag_balance(text):
+        problems.append(f"unbalanced <{tag}>: {o} open vs {c} close")
+    return problems
+
+
+def main(argv):
+    args = argv or DOCS_DIRS
+    roots = [pathlib.Path(a) for a in args]
+    files = []
+    for r in roots:
+        if r.is_dir():
+            files.extend(sorted(r.rglob("*.mdx")))
+        elif r.suffix == ".mdx" and r.exists():
+            files.append(r)
+    total_bad = 0
+    for f in files:
+        probs = check_file(f)
+        if probs:
+            total_bad += 1
+            print(f"\n✗ {f}")
+            for p in probs:
+                print(f"    - {p}")
+    print(f"\nchecked {len(files)} .mdx files; {total_bad} with problems")
+    return 1 if total_bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/docs-ops-drift-check.yml
+++ b/.github/workflows/docs-ops-drift-check.yml
@@ -63,6 +63,7 @@ jobs:
         id: mdx
         continue-on-error: true   # let the comment post; the enforce step decides
         run: |
+          set -o pipefail   # without this, `| tee` would mask check-mdx's non-zero exit
           git fetch --no-tags --quiet origin "${{ github.base_ref }}" || true
           python3 .docs-ops/ci/check-mdx.py --changed-since "origin/${{ github.base_ref }}" | tee "$RUNNER_TEMP/mdx.txt"
 

--- a/.github/workflows/docs-ops-drift-check.yml
+++ b/.github/workflows/docs-ops-drift-check.yml
@@ -56,10 +56,15 @@ jobs:
           python-version: '3.12'
 
       # ---- Tier 1: MDX validity — ALWAYS runs, no token, blocking ----
+      # Scans only the .mdx files THIS PR changes (so a pre-existing break in an
+      # untouched file can't block an unrelated PR). Full-scan fallback if the
+      # base ref can't be resolved.
       - name: MDX validity (build-breaker check)
         id: mdx
         continue-on-error: true   # let the comment post; the enforce step decides
-        run: python3 .docs-ops/ci/check-mdx.py | tee "$RUNNER_TEMP/mdx.txt"
+        run: |
+          git fetch --no-tags --quiet origin "${{ github.base_ref }}" || true
+          python3 .docs-ops/ci/check-mdx.py --changed-since "origin/${{ github.base_ref }}" | tee "$RUNNER_TEMP/mdx.txt"
 
       # ---- Tier 2: SDK-dependent drift + doc-as-test — only with the token ----
       - name: Checkout TypeScript SDK

--- a/.github/workflows/docs-ops-drift-check.yml
+++ b/.github/workflows/docs-ops-drift-check.yml
@@ -1,32 +1,29 @@
 name: Docs-Ops Drift Gate
 
-# Server-enforced docs-ops gate (Phase 2.2). Runs the SAME check-drift.py that
-# powers the local pre-push hook, on every PR into main. With a branch-protection
-# rule requiring the "drift-gate" check, this blocks merges that introduce new
-# (file, stale-API-ref) pairs or break documented code blocks.
+# Server-enforced docs-ops gate. Runs on every PR into main. With a branch-
+# protection rule requiring the "drift-gate" check, it blocks merges that break
+# the docs.
 #
-# COVERAGE (what this job actually enforces on ubuntu):
-#   - TS regex drift delta ...... BLOCKS  (pure Python; reads TS SDK source)
-#   - MDX structure check ........ BLOCKS  (pure Python)
-#   - TS doc-as-test (tsc) ....... BLOCKS when toolchain present; best-effort setup below
-#   - Flutter / Android / iOS
-#     doc-as-test ................ report "unavailable" (non-blocking) — NOT enforced here.
-#                                  Enabling them needs dart / kotlinc, and macOS (swiftc)
-#                                  for iOS. See .docs-ops/CI_GATE.md "Extending coverage".
+# TWO TIERS:
+#   1. ALWAYS (no token, pure Python) — BLOCKS:
+#        - MDX validity (.docs-ops/ci/check-mdx.py): unterminated code fences +
+#          unbalanced JSX component tags. This catches Mintlify build-breakers.
+#   2. WHEN secrets.SDK_READONLY_PAT IS SET (needs the private TS SDK) — BLOCKS:
+#        - TS regex drift delta, TS doc-as-test, MDX-structure (check-drift.py).
+#      If the secret is NOT configured, this tier is SKIPPED with a clear notice
+#      in the PR comment — it does NOT fail the PR for a missing-secret config.
 #
-# Every layer's status is surfaced in the PR comment + job summary, so uncovered
-# platforms are visible, never silently assumed green.
+# Flutter/Android/iOS doc-as-test need their toolchains (+ macOS for iOS) and
+# report "unavailable" — see .docs-ops/CI_GATE.md "Extending coverage".
 
 on:
-  # No `paths:` filter on purpose. When this is a REQUIRED status check, a
-  # path-filtered run that is skipped leaves the check "pending" forever and
-  # blocks the PR. Running on every PR to main avoids that deadlock.
+  # No `paths:` filter on purpose. A skipped path-filtered run would leave a
+  # REQUIRED check pending forever and deadlock the PR.
   pull_request:
     branches: [main]
   workflow_dispatch: {}
 
 concurrency:
-  # One in-flight run per PR; a new push cancels the previous run.
   group: docs-ops-drift-gate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -36,52 +33,56 @@ jobs:
     permissions:
       contents: read
       pull-requests: write   # to post the sticky delta comment
+    env:
+      # 'true' only when the secret is configured; gates the SDK-dependent tier.
+      HAS_SDK_TOKEN: ${{ secrets.SDK_READONLY_PAT != '' }}
 
     defaults:
       run:
         working-directory: social-plus-docs
 
     steps:
-      # check-drift.py hardcodes the SDK location at REPO_ROOT.parent (the docs
-      # repo's parent dir). actions/checkout cannot write OUTSIDE $GITHUB_WORKSPACE,
-      # so we lay both repos out as SIBLINGS inside the workspace:
-      #   $GITHUB_WORKSPACE/social-plus-docs   (this repo, REPO_ROOT)
-      #   $GITHUB_WORKSPACE/AmityTypescriptSDK  (= REPO_ROOT.parent/AmityTypescriptSDK)
+      # Both repos are laid out as SIBLINGS inside the workspace because
+      # check-drift.py hardcodes the SDK at REPO_ROOT.parent and actions/checkout
+      # cannot write outside $GITHUB_WORKSPACE.
       - name: Checkout docs repo
         uses: actions/checkout@v4
         with:
           path: social-plus-docs
-          # Full history so check-drift.py can build a baseline worktree at origin/main.
-          fetch-depth: 0
-
-      - name: Checkout TypeScript SDK (drift extractor reads its source)
-        uses: actions/checkout@v4
-        with:
-          repository: AmityCo/AmityTypescriptSDK
-          path: AmityTypescriptSDK
-          token: ${{ secrets.SDK_READONLY_PAT }}   # read access to the SDK repo
+          fetch-depth: 0   # full history for the baseline worktree
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      # Best-effort TS doc-as-test toolchain. If this step fails, the doc-as-test
-      # layer reports "crashed"/"unavailable" (non-blocking) and the blocking
-      # guarantee falls back to TS regex drift + MDX. It does NOT silently pass —
-      # the status is printed in the PR comment.
+      # ---- Tier 1: MDX validity — ALWAYS runs, no token, blocking ----
+      - name: MDX validity (build-breaker check)
+        id: mdx
+        continue-on-error: true   # let the comment post; the enforce step decides
+        run: python3 .docs-ops/ci/check-mdx.py | tee "$RUNNER_TEMP/mdx.txt"
+
+      # ---- Tier 2: SDK-dependent drift + doc-as-test — only with the token ----
+      - name: Checkout TypeScript SDK
+        if: env.HAS_SDK_TOKEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: AmityCo/AmityTypescriptSDK
+          path: AmityTypescriptSDK
+          token: ${{ secrets.SDK_READONLY_PAT }}
+
       - uses: actions/setup-node@v4
+        if: env.HAS_SDK_TOKEN == 'true'
         with:
           node-version: '20'
       - name: Install TypeScript (tsc) for doc-as-test
+        if: env.HAS_SDK_TOKEN == 'true'
         continue-on-error: true
         run: npm install -g typescript
 
       - name: Run docs-ops drift gate
         id: gate
-        continue-on-error: true   # let the comment post even on failure; final step decides
-        # No SP_SDKS_ROOT env: check-drift.py sets it to REPO_ROOT.parent itself,
-        # overriding any value here. The sibling checkout layout above is what makes
-        # the SDK resolvable.
+        if: env.HAS_SDK_TOKEN == 'true'
+        continue-on-error: true
         run: |
           python3 .docs-ops/ci/check-drift.py \
             --base origin/main \
@@ -89,57 +90,66 @@ jobs:
 
       - name: Build report (summary + PR comment body)
         if: always()
-        id: report
+        env:
+          MDX_OUTCOME: ${{ steps.mdx.outcome }}
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          HAS_SDK_TOKEN: ${{ env.HAS_SDK_TOKEN }}
         run: |
-          python3 - "$RUNNER_TEMP/delta.json" > "$RUNNER_TEMP/comment.md" <<'PY'
-          import json, sys, pathlib
-          p = pathlib.Path(sys.argv[1])
-          if not p.exists():
-              print("### 🚨 Docs-Ops Drift Gate\n\nThe gate did not produce a delta report — it likely failed to run (could not resolve base, SDK checkout, or extractor crash). **Check the job logs.** Treating as a failure.")
-              sys.exit(0)
-          d = json.loads(p.read_text())
-          dr = d.get("drift_delta", {})
-          def dat(key):
-              x = d.get(key, {})
-              if not x.get("available"): return "⚪ unavailable (not enforced here)"
-              if x.get("crashed"):       return f"⚠️ crashed (non-blocking): {x.get('crash_reason','')[:120]}"
-              b = len(x.get("blocking_failures", []))
-              s = x.get("stats", {})
-              passed = s.get("blocks_passed", "?")
-              return ("❌ " if b else "✅ ") + f"{b} blocking, {passed} passed"
-          regressed = dr.get("regressed")
-          new_pairs = dr.get("new_pairs", [])
-          lines = []
-          lines.append("### " + ("❌ Docs-Ops Drift Gate — FAIL" if (regressed or any('❌' in dat(k) for k in ('doc_as_test_ts','doc_as_test_flutter','doc_as_test_android','doc_as_test_ios')) or d.get('mdx_structure',{}).get('blocking')) else "✅ Docs-Ops Drift Gate — PASS"))
-          lines.append("")
-          lines.append(f"**Regex drift:** baseline `{dr.get('baseline_total','?')}` → candidate `{dr.get('candidate_total','?')}` "
-                       f"(Δ {dr.get('delta_total','?')}), **{len(new_pairs)} new (file, ref) pair(s)**.")
-          if new_pairs:
-              lines.append("")
-              lines.append("<details><summary>New drift pairs (these block the merge)</summary>\n")
-              for pr in new_pairs[:50]:
-                  lines.append(f"- `{pr.get('file','?')}` → `{pr.get('ref','?')}`")
-              if len(new_pairs) > 50:
-                  lines.append(f"- …and {len(new_pairs)-50} more")
-              lines.append("\n</details>")
-          lines.append("")
-          lines.append("| Layer | Status |")
-          lines.append("|---|---|")
-          lines.append(f"| TS doc-as-test | {dat('doc_as_test_ts')} |")
-          lines.append(f"| Flutter doc-as-test | {dat('doc_as_test_flutter')} |")
-          lines.append(f"| Android doc-as-test | {dat('doc_as_test_android')} |")
-          lines.append(f"| iOS doc-as-test | {dat('doc_as_test_ios')} |")
-          mdx = d.get("mdx_structure", {})
-          lines.append(f"| MDX structure | {'❌ ' + str(len(mdx.get('violations',[]))) + ' violation(s)' if mdx.get('blocking') else '✅ clean'} |")
-          lines.append("")
-          lines.append("<sub>Layers marked _unavailable_ are not enforced by this job (missing toolchain / macOS). See `.docs-ops/CI_GATE.md`.</sub>")
-          print("\n".join(lines))
+          python3 - "$RUNNER_TEMP/delta.json" "$RUNNER_TEMP/mdx.txt" > "$RUNNER_TEMP/comment.md" <<'PY'
+          import json, os, sys, pathlib
+          delta_p, mdx_p = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+          mdx_outcome = os.environ.get("MDX_OUTCOME", "")
+          gate_outcome = os.environ.get("GATE_OUTCOME", "")
+          has_token = os.environ.get("HAS_SDK_TOKEN", "") == "true"
+          L = []
+          # ---- MDX validity (always) ----
+          mdx_txt = mdx_p.read_text() if mdx_p.exists() else ""
+          mdx_last = mdx_txt.strip().splitlines()[-1] if mdx_txt.strip() else "(no output)"
+          mdx_ok = (mdx_outcome == "success")
+          L.append("### " + ("✅" if mdx_ok else "❌") + " Docs-Ops Gate — MDX validity " + ("PASS" if mdx_ok else "FAIL"))
+          L.append("")
+          L.append(f"`{mdx_last}`")
+          if not mdx_ok:
+              L.append("\n<details><summary>MDX problems (block the merge)</summary>\n\n```")
+              L.append(mdx_txt[-2500:])
+              L.append("```\n</details>")
+          # ---- Drift / doc-as-test (token-gated) ----
+          L.append("")
+          if not has_token:
+              L.append("> ⚠️ **Drift + doc-as-test SKIPPED** — `SDK_READONLY_PAT` secret is not configured, "
+                       "so the private TS SDK can't be checked out. MDX validity above still gates. "
+                       "Add the secret to enable the full API-accuracy layer (see `.docs-ops/CI_GATE.md`).")
+          elif delta_p.exists():
+              d = json.loads(delta_p.read_text()); dr = d.get("drift_delta", {})
+              def dat(key):
+                  x = d.get(key, {})
+                  if not x.get("available"): return "⚪ unavailable"
+                  if x.get("crashed"):       return f"⚠️ crashed (non-blocking): {x.get('crash_reason','')[:100]}"
+                  b = len(x.get("blocking_failures", []))
+                  return ("❌ " if b else "✅ ") + f"{b} blocking, {x.get('stats',{}).get('blocks_passed','?')} passed"
+              new_pairs = dr.get("new_pairs", [])
+              L.append(f"**Regex drift:** baseline `{dr.get('baseline_total','?')}` → candidate `{dr.get('candidate_total','?')}` "
+                       f"(Δ {dr.get('delta_total','?')}), **{len(new_pairs)} new pair(s)**.")
+              if new_pairs:
+                  L.append("\n<details><summary>New drift pairs</summary>\n")
+                  for pr in new_pairs[:50]:
+                      L.append(f"- `{pr.get('file','?')}` → `{pr.get('ref','?')}`")
+                  L.append("\n</details>")
+              L.append("")
+              L.append("| Layer | Status |")
+              L.append("|---|---|")
+              for lbl, k in [("TS doc-as-test","doc_as_test_ts"),("Flutter","doc_as_test_flutter"),
+                             ("Android","doc_as_test_android"),("iOS","doc_as_test_ios")]:
+                  L.append(f"| {lbl} | {dat(k)} |")
+          else:
+              L.append("> ⚠️ Drift layer ran but produced no report — check the job logs.")
+          print("\n".join(L))
           PY
           cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post / update PR comment
         if: always() && github.event_name == 'pull_request'
-        continue-on-error: true   # a fork/permissions hiccup must not red the gate; only the verdict does
+        continue-on-error: true   # a fork/permissions hiccup must not red the gate
         uses: actions/github-script@v7
         with:
           script: |
@@ -159,11 +169,24 @@ jobs:
 
       - name: Enforce gate result
         if: always()
+        env:
+          MDX_OUTCOME: ${{ steps.mdx.outcome }}
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
         run: |
-          # check-drift.py exit: 0 = pass, 1 = regression/blocking failure, 2 = environmental.
-          # A server gate fails LOUDLY on both — green-when-broken is worse than red.
-          if [ "${{ steps.gate.outcome }}" != "success" ]; then
-            echo "::error::Docs-Ops drift gate failed (new drift, doc-as-test block, or environmental error). See the PR comment / job summary."
-            exit 1
+          # MDX validity ALWAYS blocks. Drift blocks only when it actually ran
+          # (GATE_OUTCOME == 'failure'); a skipped drift tier (no token) is a
+          # known config state, not a failure — green-when-misconfigured is
+          # acceptable HERE because MDX validity still guards every PR.
+          fail=0
+          if [ "$MDX_OUTCOME" != "success" ]; then
+            echo "::error::MDX validity failed — a page would break the Mintlify build. See the PR comment."
+            fail=1
           fi
-          echo "Docs-Ops drift gate passed."
+          if [ "$GATE_OUTCOME" = "failure" ]; then
+            echo "::error::Drift / doc-as-test gate failed — new API drift or a broken doc code block. See the PR comment."
+            fail=1
+          fi
+          if [ "$GATE_OUTCOME" = "skipped" ]; then
+            echo "::warning::Drift / doc-as-test tier skipped (SDK_READONLY_PAT not configured). MDX validity still enforced."
+          fi
+          [ "$fail" = "0" ] && echo "Docs-Ops gate passed." || exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,18 @@
 repos:
   - repo: local
     hooks:
+      - id: docs-ops-mdx-validity
+        name: docs-ops MDX validity (Mintlify build-breakers)
+        entry: python3 .docs-ops/ci/check-mdx.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+        description: |
+          Catches unterminated code fences and unbalanced JSX component tags
+          (Accordion/Tabs/CardGroup/...) that break the Mintlify build. Pure
+          Python, no SDK or network needed — runs in well under a second.
+
       - id: docs-ops-drift-check
         name: docs-ops drift check (TS accuracy)
         entry: python3 .docs-ops/ci/check-drift.py --quiet


### PR DESCRIPTION
Follow-up to #153 (already merged). #153 landed the gate but with two problems that surfaced immediately:

1. **It hard-failed every PR** with `Input required and not supplied: token` because `SDK_READONLY_PAT` isn't configured — failing PRs for a missing-secret config state, not for any real docs problem.
2. **No MDX-validity check** — a Mintlify build-breaker (unterminated code fence) reached a branch with nothing to catch it.

## Fixes in this PR

- **NEW `.docs-ops/ci/check-mdx.py`** — dependency-free check for unterminated code fences + unbalanced JSX component tags (Accordion/Tabs/CardGroup/…). This is the class of bug that broke `send-a-message.mdx`.
- **Two-tier gate:**
  - **Tier 1 (MDX validity)** — always runs, no token, **blocks**. Scans only the PR's changed `.mdx` (full-scan fallback).
  - **Tier 2 (drift + doc-as-test)** — runs only when `SDK_READONLY_PAT` is set; **skipped with a notice** otherwise instead of hard-failing.
- **Local enforcement:** `check-mdx.py` added to the pre-push hook (`.pre-commit-config.yaml`), so build-breakers are caught before push.
- Fixed a `| tee` + missing-`pipefail` bug that was masking the MDX check's exit code (verified the gate now actually blocks).

## Verified
Dispatch runs on this branch: gate correctly **fails** when MDX problems exist and **skips** the drift tier (no token) without hard-failing. A normal PR (no `.mdx` changes, like this one) goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)