### PR TITLE
feat(docs): default to light theme

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,6 +13,9 @@
     "light": "#6366f1",
     "dark": "#3b41ec"
   },
+  "appearance": {
+    "default": "light"
+  },
   "favicon": "/favicon.svg",
   "navigation": {
     "tabs": [


### PR DESCRIPTION
Sets the Mintlify docs to open in **light mode** by default (`appearance.default: "light"` in `docs.json`).

The light/dark **toggle is retained** — users can still switch to dark.

If you'd rather force light-only and hide the toggle entirely, say the word and I'll add `"strict": true` to the appearance block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)