### PR TITLE
docs: clarity sweep — core-concepts/ section (15 live pages)

### DIFF
--- a/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file.mdx
@@ -1,9 +1,9 @@
 ---
 title: "File Handling"
-description: "Comprehensive guide to file handling in social.plus SDK with upload, download, and management capabilities"
+description: "Upload, download, and manage files up to 1 GB using FileRepository in the social.plus SDK."
 ---
 
-social.plus provides a robust file management system that enables seamless handling of various file types including documents, media files, and attachments. This guide covers comprehensive file operations with practical examples across all supported platforms.
+Use `FileRepository` to upload, download, and manage file attachments (documents, media, and other file types) in the social.plus SDK. Uploads support real-time progress tracking, automatic retry, and resume for large files.
 
 <Note>
 **File Size Limits**: Maximum file size is 1 GB per upload. Larger files should be chunked or compressed before upload.

--- a/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Image Handling"
-description: "Advanced image handling with social.plus SDK including upload, processing, optimization, and accessibility features"
+description: "Upload and manage images (JPEG, PNG, GIF, WebP, up to 100 MB) using FileRepository in the social.plus SDK."
 ---
 
-social.plus provides comprehensive image handling capabilities with automatic optimization, multiple format support, and accessibility features. This guide covers everything from basic uploads to advanced image processing workflows.
+Use `FileRepository` to upload images (JPEG, PNG, GIF, WebP) and retrieve them in multiple auto-generated sizes. The SDK handles format conversion, compression, and alt text for accessibility.
 
 <Note>
 **Image Limits**: Maximum file size is 100MB per image. Supported formats: JPEG, PNG, GIF, WebP with automatic optimization and multi-resolution generation.

--- a/social-plus-sdk/core-concepts/content-handling/mentions.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/mentions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Mentions"
-description: "Implement user mentions in posts, comments, and messages to boost engagement and enable direct communication within your social application"
+description: "Tag users or channels in posts, comments, and messages using mentionUsers() and mentionChannel() with the AmityMention object."
 ---
 
-Mentions allow users to tag other users in messages, comments, and posts. It's a powerful tool for fostering engagement and collaboration within your social application, enabling users to directly alert others to new content or important updates.
+Tag users in posts, comments, and messages using `mentionUsers(userIds)`, or notify an entire channel using `mentionChannel(channelId)`. The `AmityMention` object represents each mention and is passed through the content metadata.
 
 <Note>
 **Mention Support**: User mentions are supported in posts, comments, and messages. Channel mentions are available in messages only.

--- a/social-plus-sdk/core-concepts/content-handling/poll.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/poll.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Polls"
-description: "Create interactive polls to boost user engagement and gather community feedback in your social.plus application"
+description: "Create single- or multiple-choice polls inside posts using AmityPollCreateOptions, with configurable answer options and expiration time."
 ---
+
+Create single- or multiple-choice polls inside posts using `AmityPollCreateOptions` and `pollRepository.createPoll()`. Polls support up to 10 answer options, configurable expiration, and owner-only lifecycle management.
 
 <Info>
   **Note**: Polls are currently supported within posts only. Standalone polls

--- a/social-plus-sdk/core-concepts/content-handling/reactions.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/reactions.mdx
@@ -7,7 +7,7 @@ import AddReaction from '/snippets/social/reactions/add-reaction.mdx';
 import RemoveReaction from '/snippets/social/reactions/remove-reaction.mdx';
 
 
-Enable rich emotional responses to posts, stories, and comments through a comprehensive reaction system. Manage reactions with querying capabilities, add/remove functionality, and detailed analytics to foster engagement and community interaction.
+Use `ReactionRepository` to query, add, and remove reactions on posts, stories, comments, and messages. Each reaction records the user, timestamp, reaction name, and any associated metadata.
 
 <CardGroup cols={3}>
   <Card title="Query Reactions" icon="magnifying-glass">

--- a/social-plus-sdk/core-concepts/foundation/logging.mdx
+++ b/social-plus-sdk/core-concepts/foundation/logging.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Logging & Errors"
-description: "Learn comprehensive logging & error handling strategies for robust social.plus applications."
+description: "Monitor network activity and handle errors in the social.plus SDK using observeNetworkActivities()."
 ---
 
 # Logging
 
 ## Network Activity Monitoring
 
-Monitor and debug network activities in your social.plus SDK integration with comprehensive logging capabilities.
+Use `observeNetworkActivities()` to inspect all HTTP requests and responses in your social.plus SDK integration during development.
 
 <Info>
 **Best Practice**: Enable network logging during development to troubleshoot issues, but disable it in production to avoid performance overhead.

--- a/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/overview.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/overview.mdx
@@ -4,9 +4,7 @@ description: "Configure user, channel, and community-level push notification pre
 ---
 
 
-Manage comprehensive push notification settings across different levels of your social.plus SDK application to provide users with granular control over their notification experience.
-
-This section covers how to implement flexible notification settings that allow users, channel moderators, and community administrators to customize their notification preferences.
+Configure push notification preferences at three levels: user, channel, and community. Settings at each level control which events trigger notifications and can be overridden or restricted by higher-level policies.
 
 ## Available Settings
 

--- a/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
@@ -5,10 +5,10 @@ description: "Subscribe to live data updates and build responsive applications w
 
 ## Overview
 
-social.plus SDK provides a powerful real-time event system that keeps your application synchronized with live data changes. When users modify profiles, create posts, send messages, or perform other actions, these changes are instantly reflected across all connected devices.
+social.plus SDK delivers real-time event updates for social and chat data models (communities, posts, comments, channels, messages, and user profiles) across all connected devices without manual polling.
 
 <Info>
-Real-time events work seamlessly with [Live Objects & Collections](../live-objects-collections) to provide automatic UI updates without manual data fetching.
+Real-time events work with [Live Objects & Collections](../live-objects-collections) to provide automatic UI updates without manual data fetching.
 </Info>
 
 ## Supported Data Models

--- a/social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx
+++ b/social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx
@@ -3,6 +3,8 @@ title: "PII Detection"
 description: "Automatically detect and optionally redact personally identifiable information (PII) in user-generated text across posts, comments, and messages."
 ---
 
+PII Detection classifies sensitive data (emails, phone numbers, names, and similar categories) within post, comment, and message text, and exposes a redaction helper so client apps can mask or highlight detected content before display or export.
+
 <Info>
 Automatically locate and classify personally identifiable information (PII) within text content (Posts, Comments, Messages) and optionally redact it before display or export.
 </Info>

--- a/social-plus-sdk/core-concepts/user-management/roles-permissions.mdx
+++ b/social-plus-sdk/core-concepts/user-management/roles-permissions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Roles & Permissions"
-description: "Implement role-based access control with social.plus SDK's comprehensive permission system for moderation and user management."
+description: "Manage role-based access control in the social.plus SDK using hasPermission() to check what actions a user can perform."
 ---
 
-social.plus SDK provides a comprehensive role-based access control system that allows you to manage user permissions across your social features. This system enables you to create hierarchical moderation structures and fine-grained access control.
+Use `hasPermission()` to check whether the current user can perform a specific action (such as delete, ban, or mute) within a channel or community. User capabilities are determined by their assigned role, which carries a fixed set of permissions.
 
 ## Overview
 

--- a/social-plus-sdk/core-concepts/user-management/user-identity.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-identity.mdx
@@ -3,7 +3,7 @@ title: "User Identity"
 description: "Understand how social.plus SDK handles user identity and data management without storing personal information."
 ---
 
-social.plus SDK uses a **decentralized user management approach** that gives you complete control over your user data while providing powerful social features.
+social.plus SDK does not store personal user data. Each user is represented by a `userId` (a string you supply from your own system) that remains immutable for the lifetime of the account.
 
 ## Core Principles
 

--- a/social-plus-sdk/core-concepts/user-management/user-operations/create-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/create-user.mdx
@@ -3,7 +3,7 @@ title: "Create User"
 description: "Learn how to create new users in social.plus SDK through the login method"
 ---
 
-social.plus SDK creates new users automatically through the `login` method. This seamless approach handles both new user creation and existing user authentication in a single operation.
+social.plus SDK creates new users through the `login` method. A single call to `login` creates the account if the `userId` does not exist, or authenticates the user if it does.
 
 <Info>
 The `login` method serves dual purposes: it creates new users when they don't exist and authenticates existing users when they do.

--- a/social-plus-sdk/core-concepts/user-management/user-operations/delete-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/delete-user.mdx
@@ -3,7 +3,7 @@ title: "Delete User"
 description: "Learn how to permanently delete users and their associated data from social.plus SDK"
 ---
 
-The Delete User API permanently removes users from the system. This is a powerful administrative function that should be used with extreme caution, as all data associated with the user will be permanently lost.
+The Delete User API permanently removes a user and their associated data from the system. This operation is irreversible: all profile data, content, and channel memberships are deleted and cannot be restored.
 
 <Danger>
 This action performs a **hard delete** and **all deleted data will be lost permanently and cannot be recovered**. Use this feature only when absolutely necessary.

--- a/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
@@ -5,7 +5,7 @@ description: "Learn how to search for users by display name and query user colle
 
 ## Overview
 
-Discover users in your community through powerful search and query capabilities. social.plus SDK provides methods to search users by display name and retrieve user collections with various sorting options.
+Use `UserRepository.searchUsers()` to find users by display name, or query the full user list sorted by display name, creation date (newest first), or creation date (oldest first). Search keywords must be at least 3 characters.
 
 <Info>
 Deleted users are automatically excluded from all search and query results to maintain data integrity.

--- a/social-plus-sdk/core-concepts/user-management/user-operations/update-user-information.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/update-user-information.mdx
@@ -3,7 +3,7 @@ title: "Update User Information"
 description: "Update user profiles, avatars, and metadata using the social.plus SDK"
 ---
 
-Update the authenticated user's profile — display name, description, avatar, and custom metadata. Only the current user can update their own profile.
+Update the authenticated user's profile (display name, description, avatar, and custom metadata) using `editUser()` on iOS/Android or `UserRepository.updateUser()` on TypeScript. Only the current user can update their own profile.
 
 **Image Upload**: Before setting an avatar, you must first upload the image file. Refer to the [Image Upload guide](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling#image-upload) for detailed instructions.
 


### PR DESCRIPTION
Third section of the docs clarity sweep (after `chat/` #154 and `social/` #156). The live `core-concepts/` pages: **15 pages** (docs.json-scoped — 4 orphaned `presence-state/` + `audio-handling` pages skipped per the "live pages only" rule).

Per page: functional opener (action + entry-point API), de-fluffed `description`, redundant marketing callouts removed / factual ones de-fluffed, **no em-dashes**, **no "Spaces"**.

Also fixes the leftover em-dash in `update-user-information.mdx` (swept in the original sample, before the no-em-dash rule).

## Verification
- Only `core-concepts/*.mdx` changed (15 files).
- Full corpus MDX-valid (`check-mdx.py`).
- 0 em-dashes / 0 marketing words / 0 "Spaces" in any opener (independently grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)