### PR TITLE
docs: clarity sweep — tail (getting-started + video-new, 5 pages)

### DIFF
--- a/social-plus-sdk/getting-started/overview.mdx
+++ b/social-plus-sdk/getting-started/overview.mdx
@@ -3,7 +3,7 @@ title: "Installation & Quick Start"
 description: "Install social.plus SDK and start building social features in minutes. Follow our straightforward setup guide."
 ---
 
-Ready to add powerful social features to your app? This guide will get you up and running with social.plus SDK quickly, whether you're building for mobile, web, or cross-platform.
+Install the social.plus SDK and add social features to your app, whether you're building for mobile, web, or cross-platform. This guide covers setup and your first integration.
 
 <Note>
   **New to social.plus SDK?** Check out our [SDK Overview](/social-plus-sdk/overview) to learn about all available features and choose what's right for your project.

--- a/social-plus-sdk/getting-started/visitor-mode.mdx
+++ b/social-plus-sdk/getting-started/visitor-mode.mdx
@@ -3,6 +3,8 @@ title: "Visitor Mode"
 description: "Enable visitor mode to allow anonymous users to browse public content without signing in. Server-side read-only controls protect platform integrity."
 ---
 
+Visitor mode lets anonymous users browse public content read-only, without signing in. Access is controlled server-side to protect platform integrity.
+
 <Warning>
 **Visitor mode is not enabled by default.** To enable visitor mode for your network, please contact [support@social.plus](mailto:support@social.plus) with your network details.
 </Warning>

--- a/social-plus-sdk/video-new/analytics/overview.mdx
+++ b/social-plus-sdk/video-new/analytics/overview.mdx
@@ -5,7 +5,7 @@ description: "Track watch minutes and viewer engagement for live and recorded ro
 
 # Livestream Analytics
 
-The social.plus Video SDK provides comprehensive analytics capabilities for tracking viewer engagement and watch time during live and recorded room playback. This feature enables you to collect valuable insights about how users interact with your video content.
+The social.plus Video SDK tracks viewer engagement and watch time for live and recorded room playback, so you can measure how users interact with your video content.
 
 ## Overview
 

--- a/social-plus-sdk/video-new/broadcasting/overview.mdx
+++ b/social-plus-sdk/video-new/broadcasting/overview.mdx
@@ -5,7 +5,7 @@ description: "Introduction to room-based live broadcasting with co-hosting capab
 
 # Broadcasting Overview
 
-The Social Plus Video SDK provides comprehensive room-based broadcasting capabilities that enable interactive live streaming with co-hosting support across all platforms.
+The social.plus Video SDK provides room-based broadcasting: interactive live streaming with co-hosting support across all platforms.
 
 ## What is Room Broadcasting?
 

--- a/social-plus-sdk/video-new/migration-guide.mdx
+++ b/social-plus-sdk/video-new/migration-guide.mdx
@@ -4,9 +4,7 @@ description: "Migrate from legacy Stream to the new Room-based livestreaming sys
 ---
 
 
-<Info>
-  **New Architecture, Better Experience**: The new Room-based livestreaming system replaces the legacy Stream feature, delivering significant improvements in video quality, latency, and interactive capabilities.
-</Info>
+Migrate from the legacy Stream feature to the new Room-based livestreaming system. Rooms improve video quality and latency and add interactive capabilities such as co-hosting.
 
 ## Why Upgrade?
 


### PR DESCRIPTION
Final clarity batch, closing out the sweep (after chat #154, social #156, core-concepts #158).

Re-scanned current main for still-flagged + `docs.json`-live pages: 12 remained, **5 warranted edits**:
- `getting-started/overview.mdx` — "powerful" opener → functional
- `getting-started/visitor-mode.mdx` — functional opener inserted before the prerequisite `<Warning>`
- `video-new/analytics/overview.mdx` — "comprehensive" opener → functional
- `video-new/broadcasting/overview.mdx` — "comprehensive" → functional (+ "Social Plus" → "social.plus")
- `video-new/migration-guide.mdx` — redundant marketing `<Info>` removed, functional opener added

**Deliberately skipped** (component-first is *correct*, not a defect): the 5 SDK changelogs (open with `<Update>`), `developer-forum.mdx` (redirect stub), `technical-faq.mdx` (FAQ landing).

Verified: full corpus MDX-valid, 0 em-dashes / 0 marketing words in any opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)