### PR TITLE
docs(nav): add 29 live-but-unlinked pages to navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -74,9 +74,11 @@
               {
                 "group": "Live Data & Notifications",
                 "pages": [
+                  "social-plus-sdk/core-concepts/realtime-communication/overview",
                   {
                     "group": "Push Notifications",
                     "pages": [
+                      "social-plus-sdk/core-concepts/realtime-communication/push-notifications/overview",
                       "social-plus-sdk/core-concepts/realtime-communication/push-notifications/register-and-unregister-push-notifications-on-a-device",
                       {
                         "group": "Platform Setup",
@@ -115,6 +117,15 @@
                       "social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/typescript",
                       "social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/flutter"
                     ]
+                  },
+                  {
+                    "group": "Presence",
+                    "pages": [
+                      "social-plus-sdk/core-concepts/realtime-communication/presence-state/overview",
+                      "social-plus-sdk/core-concepts/realtime-communication/presence-state/user-presence",
+                      "social-plus-sdk/core-concepts/realtime-communication/presence-state/channel-presence",
+                      "social-plus-sdk/core-concepts/realtime-communication/presence-state/heartbeat-sync"
+                    ]
                   }
                 ]
               },
@@ -126,7 +137,8 @@
                     "pages": [
                       "social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file",
                       "social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling",
-                      "social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling"
+                      "social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling",
+                      "social-plus-sdk/core-concepts/content-handling/files-images-and-videos/audio-handling"
                     ]
                   },
                   "social-plus-sdk/core-concepts/content-handling/reactions",
@@ -388,6 +400,7 @@
               {
                 "group": "Channels",
                 "pages": [
+                  "social-plus-sdk/chat/conversation-management/channels/overview",
                   "social-plus-sdk/chat/conversation-management/overview",
                   {
                     "group": "Channel Operations",
@@ -464,13 +477,38 @@
                   "social-plus-sdk/core-concepts/content-handling/reactions",
                   "social-plus-sdk/core-concepts/content-handling/mentions"
                 ]
+              },
+              {
+                "group": "Moderation & Safety",
+                "pages": [
+                  "social-plus-sdk/chat/moderation-safety/overview",
+                  "social-plus-sdk/chat/moderation-safety/content-moderation/channel-moderation",
+                  "social-plus-sdk/chat/moderation-safety/member-management/roles-and-permission",
+                  "social-plus-sdk/chat/moderation-safety/member-management/ban-unban-a-list-of-channel-members",
+                  "social-plus-sdk/chat/moderation-safety/member-management/mute-unmute-a-list-of-channel-members"
+                ]
               }
             ]
           },
           {
             "group": "Video",
             "pages": [
-              "social-plus-sdk/video-new/migration-guide",
+              "social-plus-sdk/video-new/overview",
+              {
+                "group": "Getting Started",
+                "pages": [
+                  "social-plus-sdk/video-new/getting-started/overview"
+                ]
+              },
+              {
+                "group": "Core Concepts",
+                "pages": [
+                  "social-plus-sdk/video-new/core-concepts/overview",
+                  "social-plus-sdk/video-new/core-concepts/streaming-basics",
+                  "social-plus-sdk/video-new/core-concepts/lifecycle-management",
+                  "social-plus-sdk/video-new/core-concepts/permissions"
+                ]
+              },
               {
                 "group": "Livestream Viewing & Broadcasting",
                 "pages": [
@@ -481,7 +519,8 @@
                   "social-plus-sdk/video-new/broadcasting/co-host-management",
                   "social-plus-sdk/video-new/broadcasting/manage-rooms",
                   "social-plus-sdk/video-new/broadcasting/live-viewing",
-                  "social-plus-sdk/video-new/broadcasting/recorded-playback"
+                  "social-plus-sdk/video-new/broadcasting/recorded-playback",
+                  "social-plus-sdk/video-new/broadcasting/product-tagging"
                 ]
               },
               {
@@ -489,7 +528,32 @@
                 "pages": [
                   "social-plus-sdk/video-new/analytics/overview"
                 ]
-              }
+              },
+              {
+                "group": "Platform-Specific",
+                "pages": [
+                  "social-plus-sdk/video-new/platform-specific/ios-specific",
+                  "social-plus-sdk/video-new/platform-specific/android-specific",
+                  "social-plus-sdk/video-new/platform-specific/flutter-specific",
+                  "social-plus-sdk/video-new/platform-specific/react-native-specific",
+                  "social-plus-sdk/video-new/platform-specific/web-specific"
+                ]
+              },
+              {
+                "group": "Notifications",
+                "pages": [
+                  "social-plus-sdk/video-new/notifications/stream-events",
+                  "social-plus-sdk/video-new/notifications/push-notifications"
+                ]
+              },
+              {
+                "group": "Troubleshooting",
+                "pages": [
+                  "social-plus-sdk/video-new/troubleshooting/events",
+                  "social-plus-sdk/video-new/troubleshooting/notifications"
+                ]
+              },
+              "social-plus-sdk/video-new/migration-guide"
             ]
           },
           {


### PR DESCRIPTION
Fills the navigation gaps surfaced during orphan cleanup (#160): pages that exist and are linked from live content but were missing from `docs.json` nav. Added to their natural homes:

**Video (`video-new`)** — completes the current video product in nav:
- Section overview, **Getting Started**, **Core Concepts** (overview, streaming-basics, lifecycle-management, permissions), **Platform-Specific** (iOS/Android/Flutter/RN/Web), **Notifications** (stream-events, push), **Troubleshooting** (events, notifications), broadcasting/product-tagging.

**Core concepts:**
- `realtime-communication/overview`, a new **Presence** group (overview, user/channel presence, heartbeat-sync), `push-notifications/overview`, `content-handling/audio-handling`.

**Chat:**
- New **Moderation & Safety** group (overview, channel-moderation, roles, ban/mute lists) + `channels/overview`.

## Verification
- **0 broken nav refs** (every added entry resolves to a real file).
- Structural JSON edit (round-trips clean → minimal diff), MDX-valid.
- Non-nav live pages: 44 → **15**. The remaining 15 are superseded legacy duplicates (`social/feed`, `posts/query-post`, `reactions/README`, `notification-tray/README`, `video/README`, etc.) — left for a deliberate repoint + archive pass, not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)