### PR TITLE
docs(push): platform-precise registration guidance — TS SDK has no client registration API

### DIFF
--- a/social-plus-sdk/core-concepts/realtime-communication/push-notifications/register-and-unregister-push-notifications-on-a-device.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/push-notifications/register-and-unregister-push-notifications-on-a-device.mdx
@@ -28,8 +28,16 @@ Device registration is essential for delivering push notifications to your users
 - **Android**: [Android Setup Guide](./setup/android-setup)  
 - **React Native**: [React Native Setup Guide](./setup/react-native-setup)
 - **Flutter**: [Flutter Setup Guide](./setup/flutter-setup)
-- **Web**: [Web Setup Guide](./setup/web-setup)
 </Note>
+
+<Warning>
+**TypeScript SDK / Web**: `@amityco/ts-sdk` does not expose a client-side device
+registration API (`registerPushNotification` is iOS/Android/Flutter-native only).
+React Native apps register via `fcmToken` on `AmityUiKitProvider` or the native
+setup guides above; Web apps deliver notifications via backend
+[webhook events](/analytics-and-moderation/social+-apis-and-services/webhook-event)
+rather than device registration.
+</Warning>
 
 ## Device Registration
 

--- a/social-plus-sdk/technical-faq.mdx
+++ b/social-plus-sdk/technical-faq.mdx
@@ -338,7 +338,8 @@ Looking for a question that is not here? Use the <strong>Developer Forum</strong
         * In your app, ask for notification permission on first launch (UNUserNotificationCenter).
         * Implement application(_:didRegisterForRemoteNotificationsWithDeviceToken:) to get the APNs device token.
     5. Register token with your SDK
-        * Pass the APNs token to your SDK (e.g. Client.registerPushNotification(apnToken) or fcmToken={apnsToken} in AmityUiKitProvider (React Native))
+        * Native iOS: pass the APNs token via `client.registerPushNotification(withDeviceToken:)` (iOS SDK API — not available in the TypeScript SDK).
+        * React Native: pass the token as `fcmToken={apnsToken}` to `AmityUiKitProvider`; `@amityco/ts-sdk` does not expose a client-side push registration API.
     6.  Test real production push notifications.<br/>
         * Install a TestFlight (release) build on a physical iPhone (push notifications are not supported on simulators).
         * Trigger a real notification from your production backend or console, and verify that it is successfully delivered and displayed on the device.


### PR DESCRIPTION
**Source: measured benchmark evidence.** In the capability-matrix run (2026-06-03/04), 5/6 React Native push cells burned their 30-minute budget chasing `Client.registerPushNotification` from `@amityco/ts-sdk@7.21` — an API the TS SDK does not export. The agents got the idea from these docs.

Two fixes:

1. **`technical-faq.mdx`** — step 5 of the iOS push setup answer presented `Client.registerPushNotification(apnToken)` and the RN `fcmToken` prop as interchangeable. Split by platform: the API is iOS-native; React Native goes through `AmityUiKitProvider fcmToken`; the TS SDK has no client-side registration API.
2. **`register-and-unregister-push-notifications-on-a-device.mdx`** — removed the broken `./setup/web-setup` link (no such page) and added a Warning callout covering the TS SDK/Web story explicitly (RN → fcmToken prop or native setup guides; Web → backend [webhook events](https://docs.social.plus/analytics-and-moderation/social+-apis-and-services/webhook-event)).

Gate: `tools/check_internal_links.py` green (295 files, 1822 links scanned).

Benchmark evidence: `social-plus-foundry/benchmarks/capability-matrix/RESULTS.md` Row 5 #3, streams in `harness/results/evidence-pushvise-attest-loop/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)