### PR TITLE
docs(feed): add invalidateCache section for feed/post queries (Android)

### DIFF
--- a/social-plus-sdk/social/content-management/posts/retrieval/query-posts.mdx
+++ b/social-plus-sdk/social/content-management/posts/retrieval/query-posts.mdx
@@ -311,6 +311,49 @@ void paginationListener() {
 
 </CodeGroup>
 
+## Invalidate Cache
+
+<Info>
+  **Skip Stale Cache on Re-Entry**: By default, a post query serves cached posts immediately and clears the paging-id cache *after* the first page is fetched. This leaves a brief stale-cache window that can inflate the "New Posts" count when users re-enter a feed. Pass `invalidateCache(true)` to clear the cache *before* the first-page fetch instead, so the live collection starts from fresh data.
+</Info>
+
+Use `invalidateCache(true)` when you want a community or user feed to always reflect the latest server state on load — for example, after a pull-to-refresh or when returning to a feed that may have changed. The option defaults to `false`, so existing queries are unaffected.
+
+<CodeGroup>
+```kotlin Android
+fun queryCommunityFeedInvalidateCache(feedRepository: AmityFeedRepository) {
+    // Community feed — skip stale cache on re-entry
+    feedRepository
+        .getCommunityFeed(communityId = "<community-id>")
+        .invalidateCache(true) // clear the paging-id cache before fetching the first page
+        .build()
+        .query()
+        .doOnNext { pagingData: PagingData<AmityPost> ->
+            //Observe the changes here.
+        }
+        .subscribe()
+}
+
+fun queryUserFeedInvalidateCache(postRepository: AmityPostRepository) {
+    // User feed — skip stale cache on re-entry
+    postRepository
+        .getPosts()
+        .targetUser(userId = "steven")
+        .invalidateCache(true) // clear the paging-id cache before fetching the first page
+        .build()
+        .query()
+        .doOnNext { pagingData: PagingData<AmityPost> ->
+            //Observe the changes here.
+        }
+        .subscribe()
+}
+```
+</CodeGroup>
+
+<Note>
+  `invalidateCache` is currently available on **Android** only. Support for other platforms is under development.
+</Note>
+
 ## Parameter Usage Examples
 
 <AccordionGroup>

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -330,6 +330,46 @@ async function queryCustomRankingFeed() {
   ```
 </CodeGroup>
 
+### Invalidate Cache
+
+<Info>
+**Skip Stale Cache on Re-Entry**: By default, a feed query serves cached posts immediately and clears the paging-id cache *after* the first page is fetched. This leaves a brief stale-cache window that can inflate the "New Posts" count when users re-enter a feed. Pass `invalidateCache(true)` to clear the cache *before* the first-page fetch instead, so the live collection starts from fresh data.
+</Info>
+
+Use `invalidateCache(true)` when you want the feed to always reflect the latest server state on load — for example, after a pull-to-refresh or when returning to a feed that may have changed. The option defaults to `false`, so existing queries are unaffected.
+
+<CodeGroup>
+```kotlin Android
+fun queryGlobalFeedInvalidateCache(feedRepository: AmityFeedRepository) {
+    feedRepository
+        .getGlobalFeed()
+        .invalidateCache(true) // clear the paging-id cache before fetching the first page
+        .build()
+        .getPagingData()
+        .doOnNext { pagingData: PagingData<AmityPost> ->
+            //results
+        }
+        .subscribe()
+}
+
+fun queryCustomRankingFeedInvalidateCache(feedRepository: AmityFeedRepository) {
+    feedRepository
+        .getCustomRankingGlobalFeed()
+        .invalidateCache(true) // clear the paging-id cache before fetching the first page
+        .build()
+        .getPagingData()
+        .doOnNext { pagingData: PagingData<AmityPost> ->
+            //results
+        }
+        .subscribe()
+}
+```
+</CodeGroup>
+
+<Note>
+`invalidateCache` is currently available on **Android** only. Support for other platforms is under development.
+</Note>
+
 ## Related Documentation
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

Documents the new `invalidateCache(true)` builder option (Android) across the four feed/post query types, so customers can opt into clearing the paging-id cache **before** the first-page fetch — eliminating the stale-cache window that inflates "New Posts" counts on feed re-entry.

Android sample code only for now, per the rollout. Other platforms are noted as "under development."

## Changes

- **Feeds & Timelines** (`social/discovery-engagement/feed/overview.mdx`) — new **Invalidate Cache** subsection under Implementation, with Android samples for **Global Feed** and **Custom Ranking Feed**.
- **Query Posts** (`social/content-management/posts/retrieval/query-posts.mdx`) — new **Invalidate Cache** section with Android samples for **Community Feed** and **User Feed**.

## Reference

Sample code and API mirror the SDK PR: [Amity-Social-Cloud-SDK-Android#1090](https://github.com/AmityCo/Amity-Social-Cloud-SDK-Android/pull/1090)

🤖 Generated with [Claude Code](https://claude.com/claude-code)