### PR TITLE
Audit content foundation SDK docs

### DIFF
--- a/.docs-ops/evals/ts-accuracy-drift.json
+++ b/.docs-ops/evals/ts-accuracy-drift.json
@@ -4,7 +4,7 @@
   "surface_used": ".docs-ops/sdk-surface/typescript.json",
   "stats": {
     "files_scanned": 482,
-    "ts_blocks_scanned": 1541,
+    "ts_blocks_scanned": 1538,
     "files_with_issues": 1,
     "total_issues": 1
   },

--- a/.docs-ops/integration-tests/android/extract-blocks.py
+++ b/.docs-ops/integration-tests/android/extract-blocks.py
@@ -232,6 +232,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_discovery", [])
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
+        + pages_data.get("audited_content_foundation", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/android/pages.json
+++ b/.docs-ops/integration-tests/android/pages.json
@@ -47,6 +47,11 @@
     "social-plus-sdk/social/communities-spaces/organization/community-moderation.mdx",
     "social-plus-sdk/social/communities-spaces/organization/community-invitation.mdx"
   ],
+  "audited_content_foundation": [
+    "social-plus-sdk/social/content-management/overview.mdx",
+    "social-plus-sdk/social/content-management/content-sharing.mdx",
+    "social-plus-sdk/social/content-management/posts/overview.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/android/results/latest.json
+++ b/.docs-ops/integration-tests/android/results/latest.json
@@ -1,9 +1,9 @@
 {
-  "run_at": "2026-06-20T09:31:11.598433+00:00",
+  "run_at": "2026-06-20T09:57:53.101844+00:00",
   "stats": {
-    "blocks_extracted": 122,
+    "blocks_extracted": 123,
     "blocks_skipped": 6,
-    "blocks_passed": 122,
+    "blocks_passed": 123,
     "blocks_failed": 0,
     "total_warnings": 4,
     "pass_rate": 100.0,
@@ -234,6 +234,12 @@
     },
     "social-plus-sdk/social/communities-spaces/organization/query-community-members.mdx": {
       "passed": 3,
+      "failed": 0,
+      "skipped": 0,
+      "warnings": 0
+    },
+    "social-plus-sdk/social/content-management/content-sharing.mdx": {
+      "passed": 1,
       "failed": 0,
       "skipped": 0,
       "warnings": 0

--- a/.docs-ops/integration-tests/extract-blocks.py
+++ b/.docs-ops/integration-tests/extract-blocks.py
@@ -48,6 +48,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_discovery", [])
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
+        + pages_data.get("audited_content_foundation", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/flutter/extract-blocks.py
+++ b/.docs-ops/integration-tests/flutter/extract-blocks.py
@@ -55,6 +55,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_discovery", [])
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
+        + pages_data.get("audited_content_foundation", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/flutter/pages.json
+++ b/.docs-ops/integration-tests/flutter/pages.json
@@ -46,6 +46,11 @@
     "social-plus-sdk/social/communities-spaces/organization/community-moderation.mdx",
     "social-plus-sdk/social/communities-spaces/organization/community-invitation.mdx"
   ],
+  "audited_content_foundation": [
+    "social-plus-sdk/social/content-management/overview.mdx",
+    "social-plus-sdk/social/content-management/content-sharing.mdx",
+    "social-plus-sdk/social/content-management/posts/overview.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/flutter/results/latest.json
+++ b/.docs-ops/integration-tests/flutter/results/latest.json
@@ -1,9 +1,9 @@
 {
-  "run_at": "2026-06-20T09:28:00.322670+00:00",
+  "run_at": "2026-06-20T09:54:40.897479+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/Amity-Social-Cloud-SDK-Flutter-Internal",
   "preamble_version": "36859d1b",
   "stats": {
-    "pages_scanned": 52,
+    "pages_scanned": 55,
     "blocks_extracted": 73,
     "blocks_skipped": 0,
     "blocks_passed": 73,

--- a/.docs-ops/integration-tests/ios/pages.json
+++ b/.docs-ops/integration-tests/ios/pages.json
@@ -47,6 +47,11 @@
     "social-plus-sdk/social/communities-spaces/organization/community-moderation.mdx",
     "social-plus-sdk/social/communities-spaces/organization/community-invitation.mdx"
   ],
+  "audited_content_foundation": [
+    "social-plus-sdk/social/content-management/overview.mdx",
+    "social-plus-sdk/social/content-management/content-sharing.mdx",
+    "social-plus-sdk/social/content-management/posts/overview.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/ios/results/latest.json
+++ b/.docs-ops/integration-tests/ios/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-06-20T09:31:34.015109+00:00",
+  "generated_at": "2026-06-20T09:58:15.605010+00:00",
   "toolchain": "swiftc -typecheck",
   "sdk_version": "AmitySDK 8.1.1 (xcframework binary)",
   "xcfw_url": "https://sdk.amity.co/sdk-release/ios-frameworks/8.1.1/AmitySDK.xcframework.zip",
   "stats": {
-    "blocks_extracted": 117,
-    "blocks_passed": 117,
-    "blocks_warned": 117,
+    "blocks_extracted": 118,
+    "blocks_passed": 118,
+    "blocks_warned": 118,
     "blocks_failed": 0,
     "blocks_skipped": 5
   },
@@ -993,6 +993,20 @@
           "col": 13,
           "severity": "warning",
           "message": "initialization of immutable value 'invitations' was never used; consider replacing with assignment to '_' or removing it"
+        }
+      ]
+    },
+    {
+      "file": "content-sharing-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/content-sharing.mdx",
+      "block_index": 1,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 34,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
         }
       ]
     },
@@ -2353,6 +2367,10 @@
     {
       "file": "community-invitation-block-7.swift",
       "source_page": "social-plus-sdk/social/communities-spaces/organization/community-invitation.mdx"
+    },
+    {
+      "file": "content-sharing-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/content-sharing.mdx"
     },
     {
       "file": "authentication-block-1.swift",

--- a/.docs-ops/integration-tests/pages.json
+++ b/.docs-ops/integration-tests/pages.json
@@ -44,6 +44,11 @@
     "social-plus-sdk/social/communities-spaces/organization/community-moderation.mdx",
     "social-plus-sdk/social/communities-spaces/organization/community-invitation.mdx"
   ],
+  "audited_content_foundation": [
+    "social-plus-sdk/social/content-management/overview.mdx",
+    "social-plus-sdk/social/content-management/content-sharing.mdx",
+    "social-plus-sdk/social/content-management/posts/overview.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/results/latest.json
+++ b/.docs-ops/integration-tests/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "run_at": "2026-06-20T09:26:56.452579+00:00",
+  "run_at": "2026-06-20T09:53:36.299560+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK",
   "preamble_version": "6e720279",
   "stats": {
-    "pages_scanned": 52,
-    "blocks_extracted": 126,
+    "pages_scanned": 55,
+    "blocks_extracted": 130,
     "blocks_skipped": 0,
-    "blocks_passed": 126,
+    "blocks_passed": 130,
     "blocks_failed": 0,
     "pass_rate": 1.0
   },
@@ -181,6 +181,11 @@
       "passed": 3,
       "failed": 0
     },
+    "social-plus-sdk/social/content-management/content-sharing.mdx": {
+      "blocks": 1,
+      "passed": 1,
+      "failed": 0
+    },
     "social-plus-sdk/social/content-management/posts/moderation/delete-post.mdx": {
       "blocks": 1,
       "passed": 1,
@@ -199,6 +204,11 @@
     "social-plus-sdk/social/content-management/posts/moderation/post-review.mdx": {
       "blocks": 4,
       "passed": 4,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/overview.mdx": {
+      "blocks": 3,
+      "passed": 3,
       "failed": 0
     },
     "social-plus-sdk/social/content-management/posts/retrieval/get-post.mdx": {

--- a/.docs-ops/sdk-audit/tracker.csv
+++ b/.docs-ops/sdk-audit/tracker.csv
@@ -115,10 +115,10 @@ social-plus-sdk/social/content-management/comments/overview.mdx,social,content-m
 social-plus-sdk/social/content-management/comments/retrieval/get-comment.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/comments/retrieval/get-latest-comment.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/comments/retrieval/query-comments.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/content-sharing.mdx,social,content-management,not_started,no,no,no,,,,
+social-plus-sdk/social/content-management/content-sharing.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source for shareable-link configuration across TS iOS Android plus Flutter source search. Proof: TS 130/130; Android 123/123 skipped 6; Flutter 73/73; iOS 118/118 skipped 5.","Replaced Android placeholder; TS helper API documented; iOS/Android pattern-map behavior and unsupported Flutter public API noted."
 social-plus-sdk/social/content-management/moderation/content-flagging.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/moderation/overview.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/overview.mdx,social,content-management,not_started,no,no,no,,,,
+social-plus-sdk/social/content-management/overview.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source spot checks for posts comments stories sharing structureType and localCommentCount across TS iOS Android Flutter. Proof: TS 130/130; Android 123/123 skipped 6; Flutter 73/73; iOS 118/118 skipped 5.","Info-only entry page. Platform coverage narrowed and unsupported Flutter shareable-link structureType localCommentCount claims removed."
 social-plus-sdk/social/content-management/posts/analytics/post-impressions.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/audio-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/clip-post.mdx,social,content-management,not_started,no,no,no,,,,
@@ -135,7 +135,7 @@ social-plus-sdk/social/content-management/posts/moderation/delete-post.mdx,socia
 social-plus-sdk/social/content-management/posts/moderation/edit-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/moderation/pin-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/moderation/post-review.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/posts/overview.mdx,social,content-management,not_started,no,no,no,,,,
+social-plus-sdk/social/content-management/posts/overview.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source for post data types createPost getPosts structureType localCommentCount and realtime topics across TS iOS Android Flutter. Proof: TS 130/130; Android 123/123 skipped 6; Flutter 73/73; iOS 118/118 skipped 5.","Post type matrix corrected per SDK; invalid async getPosts example replaced with live collection callback; platform gaps for Flutter fields documented."
 social-plus-sdk/social/content-management/posts/retrieval/get-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/retrieval/query-posts.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/retrieval/viewing-content.mdx,social,content-management,not_started,no,no,no,,,,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -35476,285 +35476,129 @@ Network settings determine whether following is direct or request-based. This ca
 
 ### [Overview](https://learn.social.plus/social-plus-sdk/social/content-management/overview)
 
-> Create, manage, and moderate posts, comments, and stories across iOS, Android, TypeScript, and Flutter
+> Create, retrieve, moderate, and measure posts, comments, stories, and share links with the Social+ SDKs
 
-Use the Content Management APIs to create, retrieve, edit, moderate, and delete posts, comments, and stories. This section covers the full content lifecycle, from media upload and post creation to review workflows and analytics.
+Content Management is the SDK surface for user-generated social content. Use it to build feeds, post creation flows, comment threads, story experiences, content reporting, review queues, and shareable links.
 
-    Create rich posts with threaded comments, reactions, and real-time
-    engagement
-    Ephemeral content with images, videos, and interactive elements for timely
-    engagement
-    Generate shareable links for posts, profiles, communities, and live streams
-    with custom URL patterns
-    Unified flagging, review workflows, and admin tools for maintaining
-    community standards
-    Live objects, collections, and instant updates across all content types
+The exact method names and supported content types vary by platform, so the pages in this section show platform-specific snippets instead of treating every SDK as identical.
 
-  Content Management supports **cross-platform development** (iOS, Android,
-  TypeScript, Flutter), **real-time synchronization**, **moderation tools**
-  (flagging and review workflows), and **media handling** for posts, comments,
-  and stories.
+    Create text, media, poll, live, room, mixed, and custom posts where supported by each SDK.
+    Add, query, edit, and delete comments and replies on posts or other supported targets.
+    Publish and retrieve short-lived story content for users and communities.
+    Fetch network-level shareable-link configuration for supported content types.
+    Let users flag content and let moderators review or manage posts where the SDK exposes review APIs.
+    Mark posts and stories as viewed and read engagement counters exposed by the SDK.
 
-## Core Features
+## Platform Coverage
 
-        Create various types of posts with rich content - Text, image, video,
-        and file posts - Interactive polls and live streams - Custom post types
-        and metadata - Multi-media post compositions
-        Enable user interactions with posts - View and display posts - Query and
-        search posts - Handle mentions in posts - Track user engagement
-        title="Post Actions"
-        icon="gears"
-        href="./posts/moderation/edit-post"
-      >
-        Manage post lifecycle and operations - Edit and update posts - Delete
-        and archive posts - Pin important posts - Post review and approval
-        title="Post Analytics"
-        icon="chart-line"
-        href="./posts/analytics/post-impressions"
-      >
-        Track post performance and engagement - Post impression tracking -
-        Engagement metrics - Performance analytics - Content insights
+| Area | Current SDK coverage |
+| --- | --- |
+| Posts | TypeScript, iOS, Android, and Flutter. Supported post types differ by SDK; see [Posts Overview](./posts/overview). |
+| Comments | TypeScript, iOS, Android, and Flutter. |
+| Stories | TypeScript, iOS, Android, and Flutter. |
+| Shareable links | TypeScript, iOS, and Android expose shareable-link configuration. A Flutter public API was not found in the current Flutter SDK source. |
+| Post `structureType` | TypeScript, iOS, and Android expose this field. Flutter's current public post model exposes `type` but not `structureType`. |
+| Post `localCommentCount` | TypeScript, iOS, and Android expose a locally computed live comment count. Flutter's current public post model does not expose this field. |
 
-{" "}
-      title="Comment Creation"
-      icon="plus"
-      href="./comments/creation/create-comment"
-    >
-      Create and post comments with rich content - Text comments with mentions -
-      Media attachments and files - Reply to existing comments - Real-time
-      comment posting
-      title="Comment Retrieval"
-      icon="eye"
-      href="./comments/retrieval/query-comments"
-    >
-      Query and fetch comments efficiently - Get specific comments by ID - Query
-      comments with filters - Fetch latest comments - Pagination and sorting
-      title="Comment Actions"
-      icon="gears"
-      href="./comments/actions/edit-comment"
-    >
-      Manage comment lifecycle operations - Edit existing comments - Delete
-      comments (soft/hard) - Comment status management - Bulk operations
-      Enhanced comment capabilities - User mentions and notifications - Comment
-      reactions and likes - Threaded comment displays - Live object
-      synchronization
+  This section documents SDK behavior only. Console configuration, API-only workflows, and UIKit behavior can differ and are covered elsewhere.
 
-{" "}
-      title="Story Creation"
-      icon="camera"
-      href="./stories/creation/create-story"
-    >
-      Create engaging ephemeral content - Image stories (up to 1GB) - Video
-      stories (up to 2GB) - Interactive hyperlinks - Community targeting
-      title="Story Retrieval"
-      icon="eye"
-      href="./stories/retrieval/get-stories"
-    >
-      Access and display stories - Get active stories - Story target queries -
-      Global story feeds - Real-time story updates
-      title="Story Analytics"
-      icon="chart-line"
-      href="./stories/analytics/story-impressions"
-    >
-      Track story performance - View impressions and reach - Click-through rates
-      - User engagement metrics - Comprehensive analytics
-      title="Story Management"
-      icon="gears"
-      href="./stories/actions/delete-story"
-    >
-      Manage story lifecycle - Story deletion and cleanup - Content moderation -
-      Expiry management - Status tracking
+## Integration Path
 
-        title="Content Flagging"
-        icon="flag"
-        href="./moderation/content-flagging"
-      >
-        Unified flagging system for all content - Flag posts and comments - 9
-        detailed reporting reasons - Cross-platform support (iOS, Android,
-        TypeScript, Flutter) - User reporting workflows
-        title="Post Review Process"
-        icon="gavel"
-        href="./posts/moderation/post-review"
-      >
-        Administrative content review - Content approval workflows - Moderation
-        management - Admin console integration - Community guidelines
-        enforcement
+    Decide whether the content belongs to a user feed, a community feed, or another target supported by the page you are implementing.
+    Image, video, file, audio, and clip posts reference uploaded files. Use the content-handling upload pages before calling the post creation APIs.
+    Use the post, comment, or story repository for the content type. Prefer the platform-specific page for exact method names and return types.
+    Use live objects or live collections for feeds, detail views, and comment threads that should update while the user is looking at them.
+    Add flagging, review, delete, pin, and impression tracking only where your product workflow and platform SDK support those actions.
 
-## Getting Started
+## Related Topics
 
-    **Essential Features**: Comments + Stories + Basic Moderation 1. **Setup
-    Comments**: Start with [creating
-    comments](./comments/creation/create-comment) and [querying
-    comments](./comments/retrieval/query-comments) 2. **Add Stories**: Implement
-    [story creation](./stories/creation/create-story) for ephemeral content 3.
-    **Enable Moderation**: Add [content flagging](./moderation/content-flagging)
-    for both comments and stories 4. **Real-time Updates**: Setup live objects
-    for instant content synchronization
-
-{" "}
-  **Enhanced Features**: Full comment system + Rich stories + Comprehensive
-  moderation 1. **Advanced Comments**: Add [comment
-  editing](./comments/actions/edit-comment),
-  [deletion](./comments/actions/delete-comment), and [latest comment
-  retrieval](./comments/retrieval/get-latest-comment) 2. **Rich Stories**:
-  Implement [story analytics](./stories/analytics/story-impressions), [story
-  targets](./stories/retrieval/get-story-targets), and [interactive
-  elements](./stories/overview) 3. **Content Management**: Setup comprehensive
-  [review processes](./moderation/review-process) and admin workflows 4.
-  **Cross-platform Support**: Implement across iOS, Android, TypeScript, and
-  Flutter platforms
-
-    **Full-scale Features**: Complete content ecosystem with advanced analytics
-    1. **Content Ecosystem**: Integrate comments, stories, and moderation into
-    unified content flows 2. **Advanced Analytics**: Implement [story
-    impressions](./stories/analytics/story-impressions) and engagement tracking
-    3. **Moderation Workflows**: Setup automated content review and community
-    guidelines enforcement 4. **Performance Optimization**: Use live
-    collections, caching, and efficient content delivery
-
-## Best Practices
-
-    - **Real-time Updates**: Use live objects for instant comment
-    synchronization - **Efficient Querying**: Implement pagination and proper
-    filtering for comment retrieval - **User Experience**: Enable smooth comment
-    editing and deletion workflows - **Content Safety**: Pre-moderate comments
-    in sensitive contexts
-
-{" "}
-  - **Media Optimization**: Compress images and videos before upload (max 1GB
-  images, 2GB videos) - **Ephemeral Strategy**: Use stories for time-sensitive
-  content and promotions - **Interactive Elements**: Add hyperlinks to drive
-  engagement and navigation - **Analytics Tracking**: Monitor story impressions
-  and click-through rates
-
-{" "}
-  - **Unified Flagging**: Use consistent flagging system across comments and
-  stories - **Clear Guidelines**: Provide detailed community standards and flag
-  reasons - **Review Workflows**: Establish efficient moderation processes for
-  admin teams - **User Education**: Make reporting accessible and educate users
-  on proper usage
-
-    - **Platform Consistency**: Maintain feature parity across iOS, Android,
-    TypeScript, and Flutter - **Error Handling**: Implement comprehensive error
-    handling for all content operations - **Performance**: Use live collections
-    and caching for optimal content delivery - **Testing**: Test content flows
-    across all supported platforms
+    Start with text posts, then add media or custom post types.
+    Load feeds and filter by target, type, status, or mixed media structure.
+    Subscribe to social topics when the UI needs remote updates.
 
 ---
 
 ### [Content Sharing](https://learn.social.plus/social-plus-sdk/social/content-management/content-sharing)
 
-> Generate shareable links for posts, profiles, communities, and live streams with custom URL patterns
+> Fetch shareable-link configuration and build links for supported social content
 
-Enable users to share content from your app with customizable URL patterns that match your brand and technical requirements. The SDK can generate shareable links for various content types including posts, user profiles, communities, and live streams.
+Shareable links are configured at the network level. The SDKs fetch the configured domain and URL patterns so your app can build links to Social+ content using your own routing scheme.
 
-    Configure branded URL patterns that match your app's domain and structure
-    Generate links for posts, profiles, communities, and live streams
+The current SDKs expose this configuration differently:
 
-## Overview
+| Platform | SDK surface |
+| --- | --- |
+| TypeScript | `Client.getShareableLinkConfiguration()` returns helper methods such as `generateLink`, `getPattern`, and `isEnabled`. |
+| iOS | `client.getShareableLinkConfiguration()` returns `domain` and `patterns`. |
+| Android | `AmityCoreClient.getShareableLinkConfiguration().getShareableLink()` returns `domain` and `patterns`. |
+| Flutter | No public shareable-link configuration API was found in the current Flutter SDK source. |
 
-Content sharing allows users to share links to content from your app:
+  The SDK reads the configured patterns. It does not create the destination screens in your app. Your app still needs routes that can open the generated URLs.
 
-- **Custom URL Configuration**: Define URL patterns that match your brand
-- **Multiple Content Types**: Support for posts, user profiles, communities, and live streams
-- **Cross-Platform Support**: Generate consistent links across all platforms
+## Supported Pattern Keys
 
-  URL patterns are configured at the application level and can be customized to
-  match your app's domain structure and branding requirements.
+TypeScript maps content types to these pattern keys:
 
-## Supported Content Types
+| Content type | Pattern key | Placeholder |
+| --- | --- | --- |
+| Post | `posts` | `{postId}` |
+| Community | `communities` | `{communityId}` |
+| User | `users` | `{userId}` |
+| Livestream | `livestream` | `{livestream}` |
+| Event | `events` | `{eventId}` |
 
-| Content Type      | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| **Posts**         | All post types (text, image, video, clip, etc.) |
-| **User Profiles** | User profile pages                              |
-| **Communities**   | Community pages and profiles                    |
-| **Live Streams**  | Live streaming content                          |
+iOS and Android return the backend `patterns` map directly. Check that the key you need exists before generating a link.
 
-    Set up custom URL patterns in your app configuration
-    Use the SDK to generate shareable links for content
+## Generate a Post Link
 
-## Implementation
+```typescript TypeScript
+import { AmitySharableContentType, Client } from "@amityco/ts-sdk";
+
+async function getPostShareLink(postId: string) {
+  const config = await Client.getShareableLinkConfiguration();
+
+  return config.generateLink(AmitySharableContentType.POST, postId);
+}
+```
 
 ```swift iOS
-func getShareableLink() {
-    Task {
-        let config = try await client.getShareableLinkConfiguration()
-    }
+let postId = "post-id"
+let config = try await client.getShareableLinkConfiguration()
+
+if let pattern = config.patterns["posts"] {
+    let link = config.domain + pattern.replacingOccurrences(
+        of: "{postId}",
+        with: postId
+    )
+    showInfo(link)
 }
 ```
 
 ```kotlin Android
-// Android implementation coming soon
+AmityCoreClient.getShareableLinkConfiguration()
+    .getShareableLink()
+    .subscribe({ config ->
+        val pattern = config.getPatterns()["posts"]
+        val link = pattern?.let {
+            config.getDomain() + it.replace("{postId}", postId)
+        }
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
-
-```typescript TypeScript
-import { Client } from "@amityco/ts-sdk";
-
-// Only required to do once in the lifetime of the application
-const getPostSharableLink = async (postId: string) => {
-  const config = await Client.getShareableLinkConfiguration();
-
-  const { domain, patterns } = config;
-
-  const postLink = domain + patterns.post.replace("{postId}", postId);
-
-  return postLink;
-};
-```
-
 
 ## Best Practices
 
-    - **Fallback Handling**: Provide meaningful fallbacks for invalid or deleted content
-    - **Loading States**: Show loading indicators while resolving shared links
-    - **Error Messages**: Display clear error messages for failed link opens
-    - **Context Preservation**: Maintain user context when opening shared content
-
-    - **Link Caching**: Cache generated links to avoid repeated API calls
-    - **Batch Generation**: Generate multiple links in batch operations when possible
-    - **Lazy Loading**: Generate links only when sharing functionality is accessed
-    - **Error Handling**: Implement retry logic for failed link generation
-
-## Common Use Cases
-
-- **Social Sharing**: Enable users to share posts and content on external platforms
-- **Content Discovery**: Allow users to share interesting content with friends
-- **Community Growth**: Share community links to attract new members
-- **User Onboarding**: Share user profiles for networking and connections
-- **Live Event Promotion**: Share live stream links for event promotion
-
-## Troubleshooting
-
-    **Problem**: Share links fail to generate or return errors
-
-    **Solutions**:
-    - Verify URL patterns are properly configured
-    - Check content ID validity and existence
-    - Ensure proper authentication and permissions
-    - Validate network connectivity
-
-```typescript
-try {
-  const shareLink = await getShareLink(contentId);
-} catch (error) {
-  if (error.code === 'CONTENT_NOT_FOUND') {
-    // Handle deleted or invalid content
-  } else if (error.code === 'INVALID_URL_PATTERN') {
-    // Check URL pattern configuration
-  }
-}
-```
+- Treat missing patterns as a disabled share target for that content type.
+- Generate links only after the content exists and you have the final content ID.
+- Keep app route handling separate from link generation so deleted or restricted content can show a useful fallback screen.
+- Cache the configuration during a session if your sharing UI needs it often.
 
 ## Related Topics
 
-    Learn about creating and managing different types of posts
-    Discover community features and management capabilities
-    title="User Management"
-    href="../../core-concepts/user-management/overview"
-    icon="user"
-  >
-    Understand user profiles and identity management
+    Learn how posts are modeled and created.
+    Share community destinations after configuring community URL patterns.
+    Share user profile destinations after configuring user URL patterns.
 
 ---
 
@@ -36059,260 +35903,127 @@ Flagged content automatically appears in the social.plus Console for administrat
 
 ### [Posts Overview](https://learn.social.plus/social-plus-sdk/social/content-management/posts/overview)
 
-> Comprehensive guide to creating, managing, and interacting with posts in your social platform.
+> Understand post targets, content types, structure types, live comment counts, and the platform-specific post APIs
 
-Posts are the foundation of content creation and sharing in social.plus. A post can include text, images, videos, files, polls, live streams, or custom content—enabling users to express themselves, share information, and connect with others in a network or community.
+Posts are the primary content objects in Social+. A post belongs to a target, such as a user feed or community feed, and can contain text, uploaded media, poll data, live or room references, or custom data depending on the SDK.
 
-**Looking for a step-by-step walkthrough?** The [Rich Content Creation](/use-cases/social/rich-content-creation) guide walks you through building a complete post-creation flow end-to-end.
+  Looking for a product walkthrough? The [Rich Content Creation](/use-cases/social/rich-content-creation) guide covers an end-to-end content flow. This page focuses on SDK surfaces and data behavior.
 
-    Simple text-based posts with formatting support
-    Photo sharing with multiple image support and filters
-    Video content with streaming and playback controls
-    Share audio files, podcasts, and voice messages
-    Short-form video content up to 15 minutes
-    title="File Posts"
-    icon="paperclip-vertical"
-    href="./creation/file-post"
-  >
-    Document and file sharing capabilities
-    Interactive polls and surveys for user engagement
-    title="Live Stream Posts"
-    icon="circle-video"
-    href="./creation/live-stream-post"
-  >
-    Real-time live streaming integration
-    Combine multiple media types in a single post
-    Extend functionality with custom post types
+## Post Types
 
-  Posts support real-time events and Live Object features. See [Live
-  Objects/Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview)
-  and [Realtime
-  Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview)
-  for more.
+| Type | Current SDK notes |
+| --- | --- |
+| Text | Supported by TypeScript, iOS, Android, and Flutter. |
+| Image | Supported by TypeScript, iOS, Android, and Flutter after image upload. |
+| Video | Supported by TypeScript, iOS, Android, and Flutter after video upload. |
+| File | Supported by TypeScript, iOS, Android, and Flutter after file upload. |
+| Poll | Supported by TypeScript, iOS, Android, and Flutter when a poll exists. |
+| Live stream or room | TypeScript and Android expose both live stream and room data types. iOS exposes room creation and deprecated live-stream creation. Flutter exposes live-stream post creation in the current source. |
+| Audio | Supported by TypeScript, iOS, and Android after audio upload. A Flutter audio post creator was not found in the current source. |
+| Clip | Supported by TypeScript, iOS, and Android after clip upload. A Flutter clip post creator was not found in the current source. |
+| Mixed media | TypeScript, iOS, and Android expose mixed attachment/media flows. A Flutter mixed-media post creator was not found in the current source. |
+| Custom | Supported by TypeScript, iOS, Android, and Flutter for app-specific data. |
+
+## Create a Text Post
+
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
+
+const { data: createdPost } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Hello community",
+  },
+});
+```
 
 ## Post Structure
 
-Posts use a parent-child relationship:
-
-- The parent post acts as a container (e.g., for text or metadata)
-- Each image, video, or file is a separate child post
-- Both parent and child posts support reactions and comments
-
-Example: An image post with three images will have one parent post (text container) and three child posts (each with an image).
+Media posts use a parent-child structure. The parent post carries the target, text, metadata, counters, and other feed-level fields. Uploaded image, video, file, audio, or clip attachments are represented as child posts.
 
 ```mermaid
 graph TD
-    A[Parent Post] --> B[Text Content]
-    A --> C[Child Post 1]
-    A --> D[Child Post 2]
-    A --> E[Child Post 3]
-    C --> F[Image]
-    D --> G[Image]
-    E --> H[Image]
-    A --> I[Reactions]
-    A --> J[Comments]
-    C --> K[Child Reactions]
+    A["Parent post"] --> B["Text and metadata"]
+    A --> C["Child post: image"]
+    A --> D["Child post: video"]
+    A --> E["Child post: file"]
+    A --> F["Comments"]
+    A --> G["Reactions"]
 ```
 
-  Users can interact (react, comment) with both parent and child posts, enabling
-  rich engagement.
+Common post fields include:
 
-## Post Structure Types
+| Field | Notes |
+| --- | --- |
+| `postId` | Unique post ID. |
+| `parentPostId` | Parent ID for a child post; empty or null for parent posts depending on platform. |
+| `targetId` / `targetID` | Feed target ID, such as a community ID or user ID. TypeScript and iOS use `targetId`; some platform models expose differently cased names. |
+| `targetType` | Target type, commonly `community` or `user`. |
+| `dataType` / `type` | Content type such as `text`, `image`, `video`, `file`, `poll`, or custom type. Flutter exposes this as `type`. |
+| `structureType` | Composition type exposed by TypeScript, iOS, and Android. Flutter's current public post model does not expose this field. |
+| `data` | Type-specific post data. |
+| `metadata` | App-defined metadata. |
+| `commentsCount` | Server comment count at fetch time. |
+| `localCommentCount` | Locally computed live count exposed by TypeScript, iOS, and Android. |
+| `childrenPosts` / `children` | Child posts for media attachments. Field name varies by SDK. |
+| `isDeleted` | Soft-delete state. |
 
-Every post has a `structureType` field that automatically classifies its content composition. This enables precise filtering and querying of posts based on their media content.
+## Structure Type
 
-    Posts containing a single type of content or attachment:
+`structureType` classifies a post by its attachment composition.
 
-    | Structure Type | Description | Use Case |
-    |----------------|-------------|----------|
-    | `text` | Text-only content, no attachments | Announcements, discussions, status updates |
-    | `image` | Only image attachments (1-10 images) | Photo galleries, visual content |
-    | `video` | Only video attachments | Video tutorials, recordings |
-    | `audio` | Only audio attachments | Podcasts, voice messages, audio content |
-    | `file` | Only file attachments | Document sharing, PDFs, presentations |
-    | `liveStream` | Live streaming content | Live broadcasts, real-time events |
-    | `poll` | Poll/survey content | Voting, feedback collection |
-    | `clip` | Short-form video content (up to 15 min) | Quick videos, highlights |
+| Platform | Current behavior |
+| --- | --- |
+| TypeScript | Typed values are `text`, `image`, `video`, `file`, `audio`, and `mixed`. |
+| iOS | Exposes `structureType` as a string on `AmityPost`. |
+| Android | Exposes `getStructureType()` with values including `TEXT`, `IMAGE`, `VIDEO`, `AUDIO`, `FILE`, `LIVESTREAM`, `POLL`, `CLIP`, `ROOM`, `MIXED`, and `UNKNOWN`. |
+| Flutter | No public `structureType` field was found in the current public `AmityPost` model. |
 
-    **Example Query**: Get only photo posts (pure images)
-```typescript
-const posts = await PostRepository.getPosts({
-  dataTypes: ['image'],
-  includeMixedStructure: false // Only pure image posts
-});
+Use `includeMixedStructure` when querying a single media type and you also want posts whose `structureType` is `mixed`.
+
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
+
+const stopObserving = PostRepository.getPosts(
+  {
+    targetType: "community",
+    targetId: communityId,
+    dataTypes: ["image"],
+    includeMixedStructure: true,
+  },
+  ({ data }) => {
+    renderResults(data);
+  }
+);
 ```
-
-    **Structure Type**: `mixed`
-
-    Posts that combine multiple media types in a single post. A post is classified as `mixed` when it contains 2 or more distinct attachment types (image, video, audio, file).
-
-    **Examples of Mixed Posts**:
-    - Tutorial with images + instructional video
-    - Product showcase with photos + demo video + spec sheet PDF
-    - Event coverage with photos + highlight video + audio interview
-    - Educational content with diagrams + explanatory video + downloadable resources
-
-    **Creation**: Use `createMixedMediaPost()` or `createMixedAttachmentPost()` to combine different media types.
-
-    **Querying**: Control whether mixed posts appear in filtered results using `includeMixedStructure`:
-```typescript
-// Include mixed posts that contain images
-const posts = await PostRepository.getPosts({
-  dataTypes: ['image'],
-  includeMixedStructure: true // Includes pure + mixed with images
-});
-```
-
-    Learn more: [Mixed Media Posts](/social-plus-sdk/social/content-management/posts/creation/mixed-media-post)
-
-    **Automatic Classification**
-    - The `structureType` is automatically assigned based on post attachments
-    - No manual specification needed
-    - Updates automatically when post is edited
-
-    **Query Filtering**
-    - By default, single-type queries return only pure structure posts
-    - Use `includeMixedStructure: true` to include mixed posts containing that type
-    - Multi-type queries automatically include mixed posts
-
-    See [Query Posts](/social-plus-sdk/social/content-management/posts/retrieval/query-posts#mixed-media-filtering) for filtering details.
-
-
-### Post Data Model
-
-| Name                 | Data Type             | Description                                  |
-| -------------------- | --------------------- | -------------------------------------------- |
-| `postId`             | String                | ID of the post                               |
-| `parentPostId`       | String                | ID of the parent post (null if parent)       |
-| `postedUserId`       | String                | ID of the user who posted                    |
-| `targetID`           | String                | ID of the target (e.g., community, user)     |
-| `targetType`         | String                | Type of target (e.g., community, user)       |
-| `dataType`           | String                | Data type of post (text, image, video, etc.) |
-| `structureType`      | String                | Structure classification (text, image, video, audio, file, liveStream, poll, clip, mixed). Automatically determined based on attachments. |
-| `data`               | Object                | Data of the post                             |
-| `metadata`           | Object                | Metadata of the post                         |
-| `flagCount`          | Integer               | Number of times the post is flagged          |
-| `editedAt`           | Date                  | Date/time the post was edited                |
-| `createdAt`          | Date                  | Date/time the post was created               |
-| `updatedAt`          | Date                  | Date/time the post was updated               |
-| `reactions`          | Object                | Information about the post reactions         |
-| `reactionsCount`     | Integer               | Number of reactions to the post              |
-| `myReactions`        | Array of strings      | Reactions by the current user                |
-| `commentsCount`      | Integer               | Number of comments to the post (server value)               |
-| `localCommentCount`  | Integer               | Locally-computed comment count that updates in real time. See [Live Comment Count](#live-comment-count) below. |
-| `comments`           | Array of AmityComment | The first three comments for previewing      |
-| `childrenPosts`      | Object                | Child posts (e.g., images, videos)           |
-| `isDeleted`          | Boolean               | True if the post is deleted                  |
-| `hasFlaggedComment`  | Boolean               | True if the post has flagged comments        |
-| `hasFlaggedChildren` | Boolean               | True if the post has flagged children        |
-| `tags`               | Array of strings      | Arbitrary tags for querying/filtering posts  |
-| `feedId`             | String                | ID of the post's feed                        |
 
 ## Live Comment Count
 
-The `localCommentCount` property provides a real-time comment count on a post. It updates instantly when comments are created or deleted — both from the current user's own actions and from real-time events received from other users — so your UI always reflects the latest activity without refetching the entire post.
+`localCommentCount` is a client-side count that starts from the server `commentsCount` value and then updates as the SDK observes comment create/delete events. It is exposed by TypeScript, iOS, and Android in the current SDKs.
 
-To receive these updates, you must observe the post through a **Live Object** (via `getPost()`) or a **Live Collection** (via `queryPosts()`). The SDK delivers `localCommentCount` changes through the same observation callback you already use for other post property updates. See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview) for details.
+Use it for active feed or detail screens where a live counter matters. Use `commentsCount` when you only need the server value returned with the fetched post.
 
-### How It Works
+To receive remote updates, the app must both observe the post or feed and subscribe to an appropriate realtime topic.
 
-`localCommentCount` starts with the server's `commentsCount` value when a post is loaded. From that point on, the SDK adjusts the count locally as comment events arrive:
+```typescript TypeScript
+import { getCommunityTopic, getPostTopic, SubscriptionLevels } from "@amityco/ts-sdk";
 
-```mermaid
-flowchart LR
-    A["Post loaded from server\ncommentsCount = 12"] --> B["localCommentCount = 12"]
-    B --> C{"Comment events"}
-    C -->|"Comment created"| D["localCommentCount = 13"]
-    C -->|"Comment deleted"| E["localCommentCount = 11"]
-    C -->|"Post re-fetched from server"| F["Re-calibrated to latest\nserver commentsCount"]
+const communityTopic = getCommunityTopic(
+  community,
+  SubscriptionLevels.POST_AND_COMMENT
+);
+
+const postCommentTopic = getPostTopic(post, SubscriptionLevels.COMMENT);
 ```
 
-- **Local actions**: When the current user creates or deletes a comment, the count updates immediately after the server confirms the action.
-- **Remote events**: When another user creates or deletes a comment, the SDK receives a real-time event and adjusts the count.
-- **Re-calibration**: Every time the post object is refreshed from the server (e.g., via a query or pagination), `localCommentCount` resets to the server's `commentsCount`, ensuring eventual consistency.
-
-`localCommentCount` includes **all comment levels** — both top-level comments and replies. It matches how `commentsCount` works on the server.
-
-### When to Use `localCommentCount` vs `commentsCount`
-
-| Property | Updates from real-time events? | Best for |
-|---|---|---|
-| `commentsCount` | No — reflects the server value at the time the post was last fetched | Static displays or cases where you always re-fetch the post before showing the count |
-| `localCommentCount` | Yes — updates instantly via local actions and real-time events | Displaying live counters in feeds, post detail views, and active discussions |
-
-For most UI use cases, **prefer `localCommentCount`** to give users an immediate sense of activity. The value will re-calibrate to the server count automatically whenever the post is refreshed.
-
-### Prerequisites
-
-Two things must be in place for `localCommentCount` to deliver live updates:
-
-    You must be observing the post through `getPost()` (Live Object) or `queryPosts()` (Live Collection). The SDK delivers `localCommentCount` changes through the observation callback — if you're not observing, you won't receive updates.
-    To receive other users' comment activity, subscribe to the relevant post and comment topic. Without a subscription, `localCommentCount` will only reflect the current user's own actions.
-
-Choose the subscription scope that matches your UI:
-
-    Subscribe to all post and comment events in a community — ideal for community feeds where you want live counters on every post.
-
-```typescript
-import { getCommunityTopic, SubscriptionLevels } from '@amityco/ts-sdk';
-
-// Subscribe to all post + comment events in this community
-const topic = getCommunityTopic(community, SubscriptionLevels.POST_AND_COMMENT);
-```
-    Subscribe to comment events on a specific post — ideal for post detail views or expanded threads.
-
-```typescript
-import { getPostTopic, SubscriptionLevels } from '@amityco/ts-sdk';
-
-// Subscribe to comment events on this specific post
-const topic = getPostTopic(post, SubscriptionLevels.COMMENT);
-```
-
-Real-time events are **not available for global feed queries**. Use community-level or post-level subscriptions instead. See [Social Real-time Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/social-realtime-events) for the full list of subscription topics.
-
-### Limitations
-
-    Because the count is computed locally from a stream of events, it may temporarily diverge from the true server count in high-traffic scenarios (e.g., hundreds of comments per second). The SDK automatically re-calibrates whenever fresh post data is fetched from the server, so any drift is short-lived.
-    Updates are delivered through the Live Object or Live Collection observation callback. If you fetch a post without observing it, you won't receive `localCommentCount` changes. Additionally, without subscribing to the relevant post/comment real-time topic, the count will only reflect the current user's own create/delete actions.
-    Real-time events are scoped to communities, individual posts, or user feeds. If you display posts from a global feed query, `localCommentCount` will still work for the current user's own actions but won't receive remote events until you subscribe at a tighter scope (community or post level).
-
-## Quick Start Guide
-
-    Select the appropriate post type based on your content:
-    - **Text**: For discussions and announcements
-    - **Image**: For photo sharing and visual content
-    - **Video**: For video content and tutorials
-    - **Audio**: For podcasts, voice messages, and audio content
-    - **Clip**: For short-form video content up to 15 minutes
-    - **Poll**: For community engagement and feedback
-    - **File**: For document sharing
-    - **Live Stream**: For real-time broadcasts
-    - **Mixed Media**: For combining multiple media types (images + videos + audio + files)
-    - **Custom**: For advanced or app-specific content
-    Use the creation guides for your chosen post type:
-```typescript
-// Example: Creating a text post
-const post = await PostRepository.createPost({
-  type: 'text',
-  data: {
-  text: 'hello!',
-  },
-  targetType: 'community',
-  targetId: 'community-id'
-});
-```
-    Use management tools to edit, delete, or moderate your posts
-    Monitor engagement through analytics and impression tracking
+  Global feed queries do not provide a single global post/comment realtime topic. Subscribe at a community, user, or post scope when the UI needs remote events.
 
 ## Related Topics
 
-    Enable discussions and conversations on your posts
-    Keep content quality high with automated and manual moderation
-    title="Reactions"
-    href="/social-plus-sdk/core-concepts/content-handling/reactions"
-    icon="heart"
-  >
-    Let users express themselves with likes, loves, and custom reactions
+    Start with the simplest post creation path.
+    Load feeds and filter by type, target, review status, or mixed structure.
+    Track post views and meaningful views where supported.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -156,13 +156,13 @@
 
 ## Social — Content Management Overview
 
-- [Overview](https://learn.social.plus/social-plus-sdk/social/content-management/overview): Create, manage, and moderate posts, comments, and stories across iOS, Android, TypeScript, and Flutter
-- [Content Sharing](https://learn.social.plus/social-plus-sdk/social/content-management/content-sharing): Generate shareable links for posts, profiles, communities, and live streams with custom URL patterns
+- [Overview](https://learn.social.plus/social-plus-sdk/social/content-management/overview): Create, retrieve, moderate, and measure posts, comments, stories, and share links with the Social+ SDKs
+- [Content Sharing](https://learn.social.plus/social-plus-sdk/social/content-management/content-sharing): Fetch shareable-link configuration and build links for supported social content
 - [Content Flagging](https://learn.social.plus/social-plus-sdk/social/content-management/moderation/content-flagging): Flag or unflag posts and comments with 9 flag reasons including a custom 'Others' option. Flagged content appears in the Admin Console.
 
 ## Social — Posts
 
-- [Posts Overview](https://learn.social.plus/social-plus-sdk/social/content-management/posts/overview): Comprehensive guide to creating, managing, and interacting with posts in your social platform.
+- [Posts Overview](https://learn.social.plus/social-plus-sdk/social/content-management/posts/overview): Understand post targets, content types, structure types, live comment counts, and the platform-specific post APIs
 - [Text Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/text-post): Create simple text-based posts with mentions, hashtags, links, and rich formatting
 - [Image Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/image-post): Create posts with up to 10 images (JPEG, PNG, WebP, up to 100MB each). Images must be uploaded before post creation. Each image becomes a child post.
 - [Video Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/video-post): Create posts with up to 10 videos (up to 2GB and 2 hours each). Videos must be uploaded before post creation. HDR not supported on iOS.

--- a/social-plus-sdk/social/content-management/content-sharing.mdx
+++ b/social-plus-sdk/social/content-management/content-sharing.mdx
@@ -1,148 +1,94 @@
 ---
 title: "Content Sharing"
-description: "Generate shareable links for posts, profiles, communities, and live streams with custom URL patterns"
+description: "Fetch shareable-link configuration and build links for supported social content"
 ---
 
-Enable users to share content from your app with customizable URL patterns that match your brand and technical requirements. The SDK can generate shareable links for various content types including posts, user profiles, communities, and live streams.
+Shareable links are configured at the network level. The SDKs fetch the configured domain and URL patterns so your app can build links to Social+ content using your own routing scheme.
 
-<CardGroup cols={2}>
-  <Card title="Custom URL Patterns" icon="link">
-    Configure branded URL patterns that match your app's domain and structure
-  </Card>
-  <Card title="Multi-Content Support" icon="share-nodes">
-    Generate links for posts, profiles, communities, and live streams
-  </Card>
-</CardGroup>
+The current SDKs expose this configuration differently:
 
-## Overview
-
-Content sharing allows users to share links to content from your app:
-
-- **Custom URL Configuration**: Define URL patterns that match your brand
-- **Multiple Content Types**: Support for posts, user profiles, communities, and live streams
-- **Cross-Platform Support**: Generate consistent links across all platforms
+| Platform | SDK surface |
+| --- | --- |
+| TypeScript | `Client.getShareableLinkConfiguration()` returns helper methods such as `generateLink`, `getPattern`, and `isEnabled`. |
+| iOS | `client.getShareableLinkConfiguration()` returns `domain` and `patterns`. |
+| Android | `AmityCoreClient.getShareableLinkConfiguration().getShareableLink()` returns `domain` and `patterns`. |
+| Flutter | No public shareable-link configuration API was found in the current Flutter SDK source. |
 
 <Info>
-  URL patterns are configured at the application level and can be customized to
-  match your app's domain structure and branding requirements.
+  The SDK reads the configured patterns. It does not create the destination screens in your app. Your app still needs routes that can open the generated URLs.
 </Info>
 
-## Supported Content Types
+## Supported Pattern Keys
 
-| Content Type      | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| **Posts**         | All post types (text, image, video, clip, etc.) |
-| **User Profiles** | User profile pages                              |
-| **Communities**   | Community pages and profiles                    |
-| **Live Streams**  | Live streaming content                          |
+TypeScript maps content types to these pattern keys:
 
-<Steps>
-  <Step title="Configure URL Patterns">
-    Set up custom URL patterns in your app configuration
-  </Step>
-  <Step title="Query Share Links">
-    Use the SDK to generate shareable links for content
-  </Step>
-</Steps>
+| Content type | Pattern key | Placeholder |
+| --- | --- | --- |
+| Post | `posts` | `{postId}` |
+| Community | `communities` | `{communityId}` |
+| User | `users` | `{userId}` |
+| Livestream | `livestream` | `{livestream}` |
+| Event | `events` | `{eventId}` |
 
-## Implementation
+iOS and Android return the backend `patterns` map directly. Check that the key you need exists before generating a link.
+
+## Generate a Post Link
 
 <CodeGroup>
+```typescript TypeScript
+import { AmitySharableContentType, Client } from "@amityco/ts-sdk";
+
+async function getPostShareLink(postId: string) {
+  const config = await Client.getShareableLinkConfiguration();
+
+  return config.generateLink(AmitySharableContentType.POST, postId);
+}
+```
+
 ```swift iOS
-func getShareableLink() {
-    Task {
-        let config = try await client.getShareableLinkConfiguration()
-    }
+let postId = "post-id"
+let config = try await client.getShareableLinkConfiguration()
+
+if let pattern = config.patterns["posts"] {
+    let link = config.domain + pattern.replacingOccurrences(
+        of: "{postId}",
+        with: postId
+    )
+    showInfo(link)
 }
 ```
 
 ```kotlin Android
-// Android implementation coming soon
+AmityCoreClient.getShareableLinkConfiguration()
+    .getShareableLink()
+    .subscribe({ config ->
+        val pattern = config.getPatterns()["posts"]
+        val link = pattern?.let {
+            config.getDomain() + it.replace("{postId}", postId)
+        }
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
-
-```typescript TypeScript
-import { Client } from "@amityco/ts-sdk";
-
-// Only required to do once in the lifetime of the application
-const getPostSharableLink = async (postId: string) => {
-  const config = await Client.getShareableLinkConfiguration();
-
-  const { domain, patterns } = config;
-
-  const postLink = domain + patterns.post.replace("{postId}", postId);
-
-  return postLink;
-};
-```
-
 </CodeGroup>
 
 ## Best Practices
 
-<AccordionGroup>
-  <Accordion title="User Experience">
-    - **Fallback Handling**: Provide meaningful fallbacks for invalid or deleted content
-    - **Loading States**: Show loading indicators while resolving shared links
-    - **Error Messages**: Display clear error messages for failed link opens
-    - **Context Preservation**: Maintain user context when opening shared content
-  </Accordion>
-
-  <Accordion title="Performance">
-    - **Link Caching**: Cache generated links to avoid repeated API calls
-    - **Batch Generation**: Generate multiple links in batch operations when possible
-    - **Lazy Loading**: Generate links only when sharing functionality is accessed
-    - **Error Handling**: Implement retry logic for failed link generation
-  </Accordion>
-</AccordionGroup>
-
-## Common Use Cases
-
-- **Social Sharing**: Enable users to share posts and content on external platforms
-- **Content Discovery**: Allow users to share interesting content with friends
-- **Community Growth**: Share community links to attract new members
-- **User Onboarding**: Share user profiles for networking and connections
-- **Live Event Promotion**: Share live stream links for event promotion
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="Link Generation Failures" icon="link-slash">
-    **Problem**: Share links fail to generate or return errors
-    
-    **Solutions**:
-    - Verify URL patterns are properly configured
-    - Check content ID validity and existence
-    - Ensure proper authentication and permissions
-    - Validate network connectivity
-    
-    ```typescript
-    try {
-      const shareLink = await getShareLink(contentId);
-    } catch (error) {
-      if (error.code === 'CONTENT_NOT_FOUND') {
-        // Handle deleted or invalid content
-      } else if (error.code === 'INVALID_URL_PATTERN') {
-        // Check URL pattern configuration
-      }
-    }
-    ```
-  </Accordion>
-</AccordionGroup>
+- Treat missing patterns as a disabled share target for that content type.
+- Generate links only after the content exists and you have the final content ID.
+- Keep app route handling separate from link generation so deleted or restricted content can show a useful fallback screen.
+- Cache the configuration during a session if your sharing UI needs it often.
 
 ## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Posts Overview" href="./posts/overview" icon="pen-to-square">
-    Learn about creating and managing different types of posts
+    Learn how posts are modeled and created.
   </Card>
   <Card title="Communities" href="../communities-spaces/overview" icon="users">
-    Discover community features and management capabilities
+    Share community destinations after configuring community URL patterns.
   </Card>
-  <Card
-    title="User Management"
-    href="../../core-concepts/user-management/overview"
-    icon="user"
-  >
-    Understand user profiles and identity management
+  <Card title="User Management" href="../../core-concepts/user-management/overview" icon="user">
+    Share user profile destinations after configuring user URL patterns.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/social/content-management/overview.mdx
+++ b/social-plus-sdk/social/content-management/overview.mdx
@@ -1,244 +1,78 @@
 ---
 title: "Overview"
-description: "Create, manage, and moderate posts, comments, and stories across iOS, Android, TypeScript, and Flutter"
+description: "Create, retrieve, moderate, and measure posts, comments, stories, and share links with the Social+ SDKs"
 ---
 
-Use the Content Management APIs to create, retrieve, edit, moderate, and delete posts, comments, and stories. This section covers the full content lifecycle, from media upload and post creation to review workflows and analytics.
+Content Management is the SDK surface for user-generated social content. Use it to build feeds, post creation flows, comment threads, story experiences, content reporting, review queues, and shareable links.
+
+The exact method names and supported content types vary by platform, so the pages in this section show platform-specific snippets instead of treating every SDK as identical.
 
 <CardGroup cols={3}>
-  <Card title="Posts & Comments" icon="pen-to-square">
-    Create rich posts with threaded comments, reactions, and real-time
-    engagement
+  <Card title="Posts" icon="pen-to-square" href="./posts/overview">
+    Create text, media, poll, live, room, mixed, and custom posts where supported by each SDK.
   </Card>
-  <Card title="Stories" icon="image">
-    Ephemeral content with images, videos, and interactive elements for timely
-    engagement
+  <Card title="Comments" icon="message" href="./comments/overview">
+    Add, query, edit, and delete comments and replies on posts or other supported targets.
+  </Card>
+  <Card title="Stories" icon="image" href="./stories/overview">
+    Publish and retrieve short-lived story content for users and communities.
   </Card>
   <Card title="Content Sharing" icon="share" href="./content-sharing">
-    Generate shareable links for posts, profiles, communities, and live streams
-    with custom URL patterns
+    Fetch network-level shareable-link configuration for supported content types.
   </Card>
-  <Card title="Content Moderation" icon="shield">
-    Unified flagging, review workflows, and admin tools for maintaining
-    community standards
+  <Card title="Moderation" icon="shield" href="./moderation/content-flagging">
+    Let users flag content and let moderators review or manage posts where the SDK exposes review APIs.
   </Card>
-  <Card title="Real-time Features" icon="bolt">
-    Live objects, collections, and instant updates across all content types
+  <Card title="Analytics" icon="chart-line" href="./posts/analytics/post-impressions">
+    Mark posts and stories as viewed and read engagement counters exposed by the SDK.
   </Card>
 </CardGroup>
 
+## Platform Coverage
+
+| Area | Current SDK coverage |
+| --- | --- |
+| Posts | TypeScript, iOS, Android, and Flutter. Supported post types differ by SDK; see [Posts Overview](./posts/overview). |
+| Comments | TypeScript, iOS, Android, and Flutter. |
+| Stories | TypeScript, iOS, Android, and Flutter. |
+| Shareable links | TypeScript, iOS, and Android expose shareable-link configuration. A Flutter public API was not found in the current Flutter SDK source. |
+| Post `structureType` | TypeScript, iOS, and Android expose this field. Flutter's current public post model exposes `type` but not `structureType`. |
+| Post `localCommentCount` | TypeScript, iOS, and Android expose a locally computed live comment count. Flutter's current public post model does not expose this field. |
+
 <Info>
-  Content Management supports **cross-platform development** (iOS, Android,
-  TypeScript, Flutter), **real-time synchronization**, **moderation tools**
-  (flagging and review workflows), and **media handling** for posts, comments,
-  and stories.
+  This section documents SDK behavior only. Console configuration, API-only workflows, and UIKit behavior can differ and are covered elsewhere.
 </Info>
 
-## Core Features
+## Integration Path
 
-<Tabs>
-  <Tab title="Posts">
-    <CardGroup cols={2}>
-      <Card title="Post Creation" icon="plus" href="./posts/creation/text-post">
-        Create various types of posts with rich content - Text, image, video,
-        and file posts - Interactive polls and live streams - Custom post types
-        and metadata - Multi-media post compositions
-      </Card>
-      <Card title="Post Retrieval" icon="eye" href="./posts/retrieval/get-post">
-        Enable user interactions with posts - View and display posts - Query and
-        search posts - Handle mentions in posts - Track user engagement
-      </Card>
-      <Card
-        title="Post Actions"
-        icon="gears"
-        href="./posts/moderation/edit-post"
-      >
-        Manage post lifecycle and operations - Edit and update posts - Delete
-        and archive posts - Pin important posts - Post review and approval
-      </Card>
-      <Card
-        title="Post Analytics"
-        icon="chart-line"
-        href="./posts/analytics/post-impressions"
-      >
-        Track post performance and engagement - Post impression tracking -
-        Engagement metrics - Performance analytics - Content insights
-      </Card>
-    </CardGroup>
-  </Tab>
+<Steps>
+  <Step title="Choose the target">
+    Decide whether the content belongs to a user feed, a community feed, or another target supported by the page you are implementing.
+  </Step>
+  <Step title="Upload media first">
+    Image, video, file, audio, and clip posts reference uploaded files. Use the content-handling upload pages before calling the post creation APIs.
+  </Step>
+  <Step title="Create or query content">
+    Use the post, comment, or story repository for the content type. Prefer the platform-specific page for exact method names and return types.
+  </Step>
+  <Step title="Observe live data when the UI needs updates">
+    Use live objects or live collections for feeds, detail views, and comment threads that should update while the user is looking at them.
+  </Step>
+  <Step title="Add moderation and analytics">
+    Add flagging, review, delete, pin, and impression tracking only where your product workflow and platform SDK support those actions.
+  </Step>
+</Steps>
 
-{" "}
-<Tab title="Comments">
-  <CardGroup cols={2}>
-    <Card
-      title="Comment Creation"
-      icon="plus"
-      href="./comments/creation/create-comment"
-    >
-      Create and post comments with rich content - Text comments with mentions -
-      Media attachments and files - Reply to existing comments - Real-time
-      comment posting
-    </Card>
-    <Card
-      title="Comment Retrieval"
-      icon="eye"
-      href="./comments/retrieval/query-comments"
-    >
-      Query and fetch comments efficiently - Get specific comments by ID - Query
-      comments with filters - Fetch latest comments - Pagination and sorting
-    </Card>
-    <Card
-      title="Comment Actions"
-      icon="gears"
-      href="./comments/actions/edit-comment"
-    >
-      Manage comment lifecycle operations - Edit existing comments - Delete
-      comments (soft/hard) - Comment status management - Bulk operations
-    </Card>
-    <Card title="Advanced Features" icon="sparkles" href="./comments/overview">
-      Enhanced comment capabilities - User mentions and notifications - Comment
-      reactions and likes - Threaded comment displays - Live object
-      synchronization
-    </Card>
-  </CardGroup>
-</Tab>
+## Related Topics
 
-{" "}
-<Tab title="Stories">
-  <CardGroup cols={2}>
-    <Card
-      title="Story Creation"
-      icon="camera"
-      href="./stories/creation/create-story"
-    >
-      Create engaging ephemeral content - Image stories (up to 1GB) - Video
-      stories (up to 2GB) - Interactive hyperlinks - Community targeting
-    </Card>
-    <Card
-      title="Story Retrieval"
-      icon="eye"
-      href="./stories/retrieval/get-stories"
-    >
-      Access and display stories - Get active stories - Story target queries -
-      Global story feeds - Real-time story updates
-    </Card>
-    <Card
-      title="Story Analytics"
-      icon="chart-line"
-      href="./stories/analytics/story-impressions"
-    >
-      Track story performance - View impressions and reach - Click-through rates
-      - User engagement metrics - Comprehensive analytics
-    </Card>
-    <Card
-      title="Story Management"
-      icon="gears"
-      href="./stories/actions/delete-story"
-    >
-      Manage story lifecycle - Story deletion and cleanup - Content moderation -
-      Expiry management - Status tracking
-    </Card>
-  </CardGroup>
-</Tab>
-
-  <Tab title="Moderation">
-    <CardGroup cols={2}>
-      <Card
-        title="Content Flagging"
-        icon="flag"
-        href="./moderation/content-flagging"
-      >
-        Unified flagging system for all content - Flag posts and comments - 9
-        detailed reporting reasons - Cross-platform support (iOS, Android,
-        TypeScript, Flutter) - User reporting workflows
-      </Card>
-      <Card
-        title="Post Review Process"
-        icon="gavel"
-        href="./posts/moderation/post-review"
-      >
-        Administrative content review - Content approval workflows - Moderation
-        management - Admin console integration - Community guidelines
-        enforcement
-      </Card>
-    </CardGroup>
-  </Tab>
-</Tabs>
-
-## Getting Started
-
-<AccordionGroup>
-  <Accordion title="Basic Content App">
-    **Essential Features**: Comments + Stories + Basic Moderation 1. **Setup
-    Comments**: Start with [creating
-    comments](./comments/creation/create-comment) and [querying
-    comments](./comments/retrieval/query-comments) 2. **Add Stories**: Implement
-    [story creation](./stories/creation/create-story) for ephemeral content 3.
-    **Enable Moderation**: Add [content flagging](./moderation/content-flagging)
-    for both comments and stories 4. **Real-time Updates**: Setup live objects
-    for instant content synchronization
-  </Accordion>
-
-{" "}
-<Accordion title="Advanced Content Platform">
-  **Enhanced Features**: Full comment system + Rich stories + Comprehensive
-  moderation 1. **Advanced Comments**: Add [comment
-  editing](./comments/actions/edit-comment),
-  [deletion](./comments/actions/delete-comment), and [latest comment
-  retrieval](./comments/retrieval/get-latest-comment) 2. **Rich Stories**:
-  Implement [story analytics](./stories/analytics/story-impressions), [story
-  targets](./stories/retrieval/get-story-targets), and [interactive
-  elements](./stories/overview) 3. **Content Management**: Setup comprehensive
-  [review processes](./moderation/review-process) and admin workflows 4.
-  **Cross-platform Support**: Implement across iOS, Android, TypeScript, and
-  Flutter platforms
-</Accordion>
-
-  <Accordion title="Enterprise Content System">
-    **Full-scale Features**: Complete content ecosystem with advanced analytics
-    1. **Content Ecosystem**: Integrate comments, stories, and moderation into
-    unified content flows 2. **Advanced Analytics**: Implement [story
-    impressions](./stories/analytics/story-impressions) and engagement tracking
-    3. **Moderation Workflows**: Setup automated content review and community
-    guidelines enforcement 4. **Performance Optimization**: Use live
-    collections, caching, and efficient content delivery
-  </Accordion>
-</AccordionGroup>
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Comment Management">
-    - **Real-time Updates**: Use live objects for instant comment
-    synchronization - **Efficient Querying**: Implement pagination and proper
-    filtering for comment retrieval - **User Experience**: Enable smooth comment
-    editing and deletion workflows - **Content Safety**: Pre-moderate comments
-    in sensitive contexts
-  </Accordion>
-
-{" "}
-<Accordion title="Story Content">
-  - **Media Optimization**: Compress images and videos before upload (max 1GB
-  images, 2GB videos) - **Ephemeral Strategy**: Use stories for time-sensitive
-  content and promotions - **Interactive Elements**: Add hyperlinks to drive
-  engagement and navigation - **Analytics Tracking**: Monitor story impressions
-  and click-through rates
-</Accordion>
-
-{" "}
-<Accordion title="Content Moderation">
-  - **Unified Flagging**: Use consistent flagging system across comments and
-  stories - **Clear Guidelines**: Provide detailed community standards and flag
-  reasons - **Review Workflows**: Establish efficient moderation processes for
-  admin teams - **User Education**: Make reporting accessible and educate users
-  on proper usage
-</Accordion>
-
-  <Accordion title="Cross-Platform Development">
-    - **Platform Consistency**: Maintain feature parity across iOS, Android,
-    TypeScript, and Flutter - **Error Handling**: Implement comprehensive error
-    handling for all content operations - **Performance**: Use live collections
-    and caching for optimal content delivery - **Testing**: Test content flows
-    across all supported platforms
-  </Accordion>
-</AccordionGroup>
+<CardGroup cols={3}>
+  <Card title="Post Creation" icon="plus" href="./posts/creation/text-post">
+    Start with text posts, then add media or custom post types.
+  </Card>
+  <Card title="Query Posts" icon="list" href="./posts/retrieval/query-posts">
+    Load feeds and filter by target, type, status, or mixed media structure.
+  </Card>
+  <Card title="Realtime Events" icon="bolt" href="../../core-concepts/realtime-communication/realtime-events/social-realtime-events">
+    Subscribe to social topics when the UI needs remote updates.
+  </Card>
+</CardGroup>

--- a/social-plus-sdk/social/content-management/posts/overview.mdx
+++ b/social-plus-sdk/social/content-management/posts/overview.mdx
@@ -1,337 +1,136 @@
 ---
 title: "Posts Overview"
-description: "Comprehensive guide to creating, managing, and interacting with posts in your social platform."
+description: "Understand post targets, content types, structure types, live comment counts, and the platform-specific post APIs"
 ---
 
-Posts are the foundation of content creation and sharing in social.plus. A post can include text, images, videos, files, polls, live streams, or custom content—enabling users to express themselves, share information, and connect with others in a network or community.
+Posts are the primary content objects in Social+. A post belongs to a target, such as a user feed or community feed, and can contain text, uploaded media, poll data, live or room references, or custom data depending on the SDK.
 
 <Tip>
-**Looking for a step-by-step walkthrough?** The [Rich Content Creation](/use-cases/social/rich-content-creation) guide walks you through building a complete post-creation flow end-to-end.
+  Looking for a product walkthrough? The [Rich Content Creation](/use-cases/social/rich-content-creation) guide covers an end-to-end content flow. This page focuses on SDK surfaces and data behavior.
 </Tip>
 
-<CardGroup cols={2}>
-  <Card title="Text Posts" icon="text-size" href="./creation/text-post">
-    Simple text-based posts with formatting support
-  </Card>
-  <Card title="Image Posts" icon="image" href="./creation/image-post">
-    Photo sharing with multiple image support and filters
-  </Card>
-  <Card title="Video Posts" icon="video" href="./creation/video-post">
-    Video content with streaming and playback controls
-  </Card>
-  <Card title="Audio Posts" icon="file-audio" href="./creation/audio-post">
-    Share audio files, podcasts, and voice messages
-  </Card>
-  <Card title="Clip Posts" icon="play" href="./creation/clip-post">
-    Short-form video content up to 15 minutes
-  </Card>
-  <Card
-    title="File Posts"
-    icon="paperclip-vertical"
-    href="./creation/file-post"
-  >
-    Document and file sharing capabilities
-  </Card>
-  <Card title="Poll Posts" icon="chart-bar" href="./creation/poll-post">
-    Interactive polls and surveys for user engagement
-  </Card>
-  <Card
-    title="Live Stream Posts"
-    icon="circle-video"
-    href="./creation/live-stream-post"
-  >
-    Real-time live streaming integration
-  </Card>
-  <Card title="Mixed Media Posts" icon="layer-group" href="./creation/mixed-media-post">
-    Combine multiple media types in a single post
-  </Card>
-  <Card title="Custom Posts" icon="puzzle-piece" href="./creation/custom-post">
-    Extend functionality with custom post types
-  </Card>
-</CardGroup>
+## Post Types
 
-<Info>
-  Posts support real-time events and Live Object features. See [Live
-  Objects/Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview)
-  and [Realtime
-  Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview)
-  for more.
-</Info>
+| Type | Current SDK notes |
+| --- | --- |
+| Text | Supported by TypeScript, iOS, Android, and Flutter. |
+| Image | Supported by TypeScript, iOS, Android, and Flutter after image upload. |
+| Video | Supported by TypeScript, iOS, Android, and Flutter after video upload. |
+| File | Supported by TypeScript, iOS, Android, and Flutter after file upload. |
+| Poll | Supported by TypeScript, iOS, Android, and Flutter when a poll exists. |
+| Live stream or room | TypeScript and Android expose both live stream and room data types. iOS exposes room creation and deprecated live-stream creation. Flutter exposes live-stream post creation in the current source. |
+| Audio | Supported by TypeScript, iOS, and Android after audio upload. A Flutter audio post creator was not found in the current source. |
+| Clip | Supported by TypeScript, iOS, and Android after clip upload. A Flutter clip post creator was not found in the current source. |
+| Mixed media | TypeScript, iOS, and Android expose mixed attachment/media flows. A Flutter mixed-media post creator was not found in the current source. |
+| Custom | Supported by TypeScript, iOS, Android, and Flutter for app-specific data. |
+
+## Create a Text Post
+
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
+
+const { data: createdPost } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Hello community",
+  },
+});
+```
 
 ## Post Structure
 
-Posts use a parent-child relationship:
-
-- The parent post acts as a container (e.g., for text or metadata)
-- Each image, video, or file is a separate child post
-- Both parent and child posts support reactions and comments
-
-Example: An image post with three images will have one parent post (text container) and three child posts (each with an image).
+Media posts use a parent-child structure. The parent post carries the target, text, metadata, counters, and other feed-level fields. Uploaded image, video, file, audio, or clip attachments are represented as child posts.
 
 ```mermaid
 graph TD
-    A[Parent Post] --> B[Text Content]
-    A --> C[Child Post 1]
-    A --> D[Child Post 2]
-    A --> E[Child Post 3]
-    C --> F[Image]
-    D --> G[Image]
-    E --> H[Image]
-    A --> I[Reactions]
-    A --> J[Comments]
-    C --> K[Child Reactions]
+    A["Parent post"] --> B["Text and metadata"]
+    A --> C["Child post: image"]
+    A --> D["Child post: video"]
+    A --> E["Child post: file"]
+    A --> F["Comments"]
+    A --> G["Reactions"]
 ```
 
-<Info>
-  Users can interact (react, comment) with both parent and child posts, enabling
-  rich engagement.
-</Info>
+Common post fields include:
 
-## Post Structure Types
+| Field | Notes |
+| --- | --- |
+| `postId` | Unique post ID. |
+| `parentPostId` | Parent ID for a child post; empty or null for parent posts depending on platform. |
+| `targetId` / `targetID` | Feed target ID, such as a community ID or user ID. TypeScript and iOS use `targetId`; some platform models expose differently cased names. |
+| `targetType` | Target type, commonly `community` or `user`. |
+| `dataType` / `type` | Content type such as `text`, `image`, `video`, `file`, `poll`, or custom type. Flutter exposes this as `type`. |
+| `structureType` | Composition type exposed by TypeScript, iOS, and Android. Flutter's current public post model does not expose this field. |
+| `data` | Type-specific post data. |
+| `metadata` | App-defined metadata. |
+| `commentsCount` | Server comment count at fetch time. |
+| `localCommentCount` | Locally computed live count exposed by TypeScript, iOS, and Android. |
+| `childrenPosts` / `children` | Child posts for media attachments. Field name varies by SDK. |
+| `isDeleted` | Soft-delete state. |
 
-Every post has a `structureType` field that automatically classifies its content composition. This enables precise filtering and querying of posts based on their media content.
+## Structure Type
 
-<AccordionGroup>
-  <Accordion title="Pure Structure Types" icon="file">
-    Posts containing a single type of content or attachment:
-    
-    | Structure Type | Description | Use Case |
-    |----------------|-------------|----------|
-    | `text` | Text-only content, no attachments | Announcements, discussions, status updates |
-    | `image` | Only image attachments (1-10 images) | Photo galleries, visual content |
-    | `video` | Only video attachments | Video tutorials, recordings |
-    | `audio` | Only audio attachments | Podcasts, voice messages, audio content |
-    | `file` | Only file attachments | Document sharing, PDFs, presentations |
-    | `liveStream` | Live streaming content | Live broadcasts, real-time events |
-    | `poll` | Poll/survey content | Voting, feedback collection |
-    | `clip` | Short-form video content (up to 15 min) | Quick videos, highlights |
-    
-    **Example Query**: Get only photo posts (pure images)
-    ```typescript
-    const posts = await PostRepository.getPosts({
-      dataTypes: ['image'],
-      includeMixedStructure: false // Only pure image posts
-    });
-    ```
-  </Accordion>
-  
-  <Accordion title="Mixed Structure Type" icon="layer-group">
-    **Structure Type**: `mixed`
-    
-    Posts that combine multiple media types in a single post. A post is classified as `mixed` when it contains 2 or more distinct attachment types (image, video, audio, file).
-    
-    **Examples of Mixed Posts**:
-    - Tutorial with images + instructional video
-    - Product showcase with photos + demo video + spec sheet PDF
-    - Event coverage with photos + highlight video + audio interview
-    - Educational content with diagrams + explanatory video + downloadable resources
-    
-    **Creation**: Use `createMixedMediaPost()` or `createMixedAttachmentPost()` to combine different media types.
-    
-    **Querying**: Control whether mixed posts appear in filtered results using `includeMixedStructure`:
-    ```typescript
-    // Include mixed posts that contain images
-    const posts = await PostRepository.getPosts({
-      dataTypes: ['image'],
-      includeMixedStructure: true // Includes pure + mixed with images
-    });
-    ```
-    
-    Learn more: [Mixed Media Posts](/social-plus-sdk/social/content-management/posts/creation/mixed-media-post)
-  </Accordion>
-  
-  <Accordion title="Structure Type Behavior" icon="info-circle">
-    **Automatic Classification**
-    - The `structureType` is automatically assigned based on post attachments
-    - No manual specification needed
-    - Updates automatically when post is edited
-    
-    **Query Filtering**
-    - By default, single-type queries return only pure structure posts
-    - Use `includeMixedStructure: true` to include mixed posts containing that type
-    - Multi-type queries automatically include mixed posts
-    
-    See [Query Posts](/social-plus-sdk/social/content-management/posts/retrieval/query-posts#mixed-media-filtering) for filtering details.
-  </Accordion>
-</AccordionGroup>
+`structureType` classifies a post by its attachment composition.
 
+| Platform | Current behavior |
+| --- | --- |
+| TypeScript | Typed values are `text`, `image`, `video`, `file`, `audio`, and `mixed`. |
+| iOS | Exposes `structureType` as a string on `AmityPost`. |
+| Android | Exposes `getStructureType()` with values including `TEXT`, `IMAGE`, `VIDEO`, `AUDIO`, `FILE`, `LIVESTREAM`, `POLL`, `CLIP`, `ROOM`, `MIXED`, and `UNKNOWN`. |
+| Flutter | No public `structureType` field was found in the current public `AmityPost` model. |
 
-### Post Data Model
+Use `includeMixedStructure` when querying a single media type and you also want posts whose `structureType` is `mixed`.
 
-| Name                 | Data Type             | Description                                  |
-| -------------------- | --------------------- | -------------------------------------------- |
-| `postId`             | String                | ID of the post                               |
-| `parentPostId`       | String                | ID of the parent post (null if parent)       |
-| `postedUserId`       | String                | ID of the user who posted                    |
-| `targetID`           | String                | ID of the target (e.g., community, user)     |
-| `targetType`         | String                | Type of target (e.g., community, user)       |
-| `dataType`           | String                | Data type of post (text, image, video, etc.) |
-| `structureType`      | String                | Structure classification (text, image, video, audio, file, liveStream, poll, clip, mixed). Automatically determined based on attachments. |
-| `data`               | Object                | Data of the post                             |
-| `metadata`           | Object                | Metadata of the post                         |
-| `flagCount`          | Integer               | Number of times the post is flagged          |
-| `editedAt`           | Date                  | Date/time the post was edited                |
-| `createdAt`          | Date                  | Date/time the post was created               |
-| `updatedAt`          | Date                  | Date/time the post was updated               |
-| `reactions`          | Object                | Information about the post reactions         |
-| `reactionsCount`     | Integer               | Number of reactions to the post              |
-| `myReactions`        | Array of strings      | Reactions by the current user                |
-| `commentsCount`      | Integer               | Number of comments to the post (server value)               |
-| `localCommentCount`  | Integer               | Locally-computed comment count that updates in real time. See [Live Comment Count](#live-comment-count) below. |
-| `comments`           | Array of AmityComment | The first three comments for previewing      |
-| `childrenPosts`      | Object                | Child posts (e.g., images, videos)           |
-| `isDeleted`          | Boolean               | True if the post is deleted                  |
-| `hasFlaggedComment`  | Boolean               | True if the post has flagged comments        |
-| `hasFlaggedChildren` | Boolean               | True if the post has flagged children        |
-| `tags`               | Array of strings      | Arbitrary tags for querying/filtering posts  |
-| `feedId`             | String                | ID of the post's feed                        |
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
+
+const stopObserving = PostRepository.getPosts(
+  {
+    targetType: "community",
+    targetId: communityId,
+    dataTypes: ["image"],
+    includeMixedStructure: true,
+  },
+  ({ data }) => {
+    renderResults(data);
+  }
+);
+```
 
 ## Live Comment Count
 
-The `localCommentCount` property provides a real-time comment count on a post. It updates instantly when comments are created or deleted — both from the current user's own actions and from real-time events received from other users — so your UI always reflects the latest activity without refetching the entire post.
+`localCommentCount` is a client-side count that starts from the server `commentsCount` value and then updates as the SDK observes comment create/delete events. It is exposed by TypeScript, iOS, and Android in the current SDKs.
 
-To receive these updates, you must observe the post through a **Live Object** (via `getPost()`) or a **Live Collection** (via `queryPosts()`). The SDK delivers `localCommentCount` changes through the same observation callback you already use for other post property updates. See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview) for details.
+Use it for active feed or detail screens where a live counter matters. Use `commentsCount` when you only need the server value returned with the fetched post.
 
-### How It Works
+To receive remote updates, the app must both observe the post or feed and subscribe to an appropriate realtime topic.
 
-`localCommentCount` starts with the server's `commentsCount` value when a post is loaded. From that point on, the SDK adjusts the count locally as comment events arrive:
+```typescript TypeScript
+import { getCommunityTopic, getPostTopic, SubscriptionLevels } from "@amityco/ts-sdk";
 
-```mermaid
-flowchart LR
-    A["Post loaded from server\ncommentsCount = 12"] --> B["localCommentCount = 12"]
-    B --> C{"Comment events"}
-    C -->|"Comment created"| D["localCommentCount = 13"]
-    C -->|"Comment deleted"| E["localCommentCount = 11"]
-    C -->|"Post re-fetched from server"| F["Re-calibrated to latest\nserver commentsCount"]
+const communityTopic = getCommunityTopic(
+  community,
+  SubscriptionLevels.POST_AND_COMMENT
+);
+
+const postCommentTopic = getPostTopic(post, SubscriptionLevels.COMMENT);
 ```
 
-- **Local actions**: When the current user creates or deletes a comment, the count updates immediately after the server confirms the action.
-- **Remote events**: When another user creates or deletes a comment, the SDK receives a real-time event and adjusts the count.
-- **Re-calibration**: Every time the post object is refreshed from the server (e.g., via a query or pagination), `localCommentCount` resets to the server's `commentsCount`, ensuring eventual consistency.
-
-<Info>
-`localCommentCount` includes **all comment levels** — both top-level comments and replies. It matches how `commentsCount` works on the server.
-</Info>
-
-### When to Use `localCommentCount` vs `commentsCount`
-
-| Property | Updates from real-time events? | Best for |
-|---|---|---|
-| `commentsCount` | No — reflects the server value at the time the post was last fetched | Static displays or cases where you always re-fetch the post before showing the count |
-| `localCommentCount` | Yes — updates instantly via local actions and real-time events | Displaying live counters in feeds, post detail views, and active discussions |
-
-<Tip>
-For most UI use cases, **prefer `localCommentCount`** to give users an immediate sense of activity. The value will re-calibrate to the server count automatically whenever the post is refreshed.
-</Tip>
-
-### Prerequisites
-
-Two things must be in place for `localCommentCount` to deliver live updates:
-
-<Steps>
-  <Step title="Observe the post via Live Object or Live Collection">
-    You must be observing the post through `getPost()` (Live Object) or `queryPosts()` (Live Collection). The SDK delivers `localCommentCount` changes through the observation callback — if you're not observing, you won't receive updates.
-  </Step>
-  <Step title="Subscribe to real-time events">
-    To receive other users' comment activity, subscribe to the relevant post and comment topic. Without a subscription, `localCommentCount` will only reflect the current user's own actions.
-  </Step>
-</Steps>
-
-Choose the subscription scope that matches your UI:
-
-<Tabs>
-  <Tab title="Community Feed">
-    Subscribe to all post and comment events in a community — ideal for community feeds where you want live counters on every post.
-
-    ```typescript
-    import { getCommunityTopic, SubscriptionLevels } from '@amityco/ts-sdk';
-
-    // Subscribe to all post + comment events in this community
-    const topic = getCommunityTopic(community, SubscriptionLevels.POST_AND_COMMENT);
-    ```
-  </Tab>
-  <Tab title="Single Post">
-    Subscribe to comment events on a specific post — ideal for post detail views or expanded threads.
-
-    ```typescript
-    import { getPostTopic, SubscriptionLevels } from '@amityco/ts-sdk';
-
-    // Subscribe to comment events on this specific post
-    const topic = getPostTopic(post, SubscriptionLevels.COMMENT);
-    ```
-  </Tab>
-</Tabs>
-
 <Note>
-Real-time events are **not available for global feed queries**. Use community-level or post-level subscriptions instead. See [Social Real-time Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/social-realtime-events) for the full list of subscription topics.
+  Global feed queries do not provide a single global post/comment realtime topic. Subscribe at a community, user, or post scope when the UI needs remote events.
 </Note>
-
-### Limitations
-
-<AccordionGroup>
-  <Accordion title="Eventual consistency, not absolute accuracy" icon="clock">
-    Because the count is computed locally from a stream of events, it may temporarily diverge from the true server count in high-traffic scenarios (e.g., hundreds of comments per second). The SDK automatically re-calibrates whenever fresh post data is fetched from the server, so any drift is short-lived.
-  </Accordion>
-  <Accordion title="Requires Live Object/Collection observation and real-time subscription" icon="wifi">
-    Updates are delivered through the Live Object or Live Collection observation callback. If you fetch a post without observing it, you won't receive `localCommentCount` changes. Additionally, without subscribing to the relevant post/comment real-time topic, the count will only reflect the current user's own create/delete actions.
-  </Accordion>
-  <Accordion title="Not supported on global feed" icon="globe">
-    Real-time events are scoped to communities, individual posts, or user feeds. If you display posts from a global feed query, `localCommentCount` will still work for the current user's own actions but won't receive remote events until you subscribe at a tighter scope (community or post level).
-  </Accordion>
-</AccordionGroup>
-
-## Quick Start Guide
-
-<Steps>
-  <Step title="Choose Post Type">
-    Select the appropriate post type based on your content:
-    - **Text**: For discussions and announcements
-    - **Image**: For photo sharing and visual content
-    - **Video**: For video content and tutorials
-    - **Audio**: For podcasts, voice messages, and audio content
-    - **Clip**: For short-form video content up to 15 minutes
-    - **Poll**: For community engagement and feedback
-    - **File**: For document sharing
-    - **Live Stream**: For real-time broadcasts
-    - **Mixed Media**: For combining multiple media types (images + videos + audio + files)
-    - **Custom**: For advanced or app-specific content
-  </Step>
-  <Step title="Create Content">
-    Use the creation guides for your chosen post type:
-    ```typescript
-    // Example: Creating a text post
-    const post = await PostRepository.createPost({
-      type: 'text',
-      data: {
-      text: 'hello!',
-      },
-      targetType: 'community',
-      targetId: 'community-id'
-    });
-    ```
-  </Step>
-  <Step title="Manage Post">
-    Use management tools to edit, delete, or moderate your posts
-  </Step>
-  <Step title="Track Performance">
-    Monitor engagement through analytics and impression tracking
-  </Step>
-</Steps>
 
 ## Related Topics
 
 <CardGroup cols={3}>
-  <Card title="Comments" href="../comments/overview" icon="message">
-    Enable discussions and conversations on your posts
+  <Card title="Text Posts" icon="text-size" href="./creation/text-post">
+    Start with the simplest post creation path.
   </Card>
-  <Card title="Moderation" href="../moderation/overview" icon="shield">
-    Keep content quality high with automated and manual moderation
+  <Card title="Query Posts" icon="list" href="./retrieval/query-posts">
+    Load feeds and filter by type, target, review status, or mixed structure.
   </Card>
-  <Card
-    title="Reactions"
-    href="/social-plus-sdk/core-concepts/content-handling/reactions"
-    icon="heart"
-  >
-    Let users express themselves with likes, loves, and custom reactions
+  <Card title="Post Impressions" icon="chart-line" href="./analytics/post-impressions">
+    Track post views and meaningful views where supported.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Audit the Content Management overview, Content Sharing, and Posts Overview pages against current SDK surfaces
- Replace stale shareable-link docs with verified TypeScript, iOS, and Android snippets, and document the current Flutter API gap
- Correct post type, structureType, localCommentCount, and getPosts/live-collection behavior by platform
- Add the foundation content pages to audited proof inventories and regenerate AI docs output

## Validation
- TypeScript snippets: 130/130 passed
- Android snippets: 123/123 passed, 6 skipped, 4 warnings
- Flutter snippets: 73/73 passed
- iOS snippets: 118/118 passed, 5 skipped
- python3 -m py_compile for SDK proof extractors
- JSON validation for docs.json and pages inventories
- git diff --check
- python3 tools/check_internal_links.py
- python3 .docs-ops/ci/check-mdx.py
- python3 .docs-ops/ci/check-drift.py --base HEAD --skip-fetch --require-doc-as-test all