### PR TITLE
Audit core post creation SDK docs

### DIFF
--- a/.docs-ops/evals/ts-accuracy-drift.json
+++ b/.docs-ops/evals/ts-accuracy-drift.json
@@ -4,7 +4,7 @@
   "surface_used": ".docs-ops/sdk-surface/typescript.json",
   "stats": {
     "files_scanned": 482,
-    "ts_blocks_scanned": 1538,
+    "ts_blocks_scanned": 1526,
     "files_with_issues": 1,
     "total_issues": 1
   },

--- a/.docs-ops/integration-tests/android/extract-blocks.py
+++ b/.docs-ops/integration-tests/android/extract-blocks.py
@@ -233,6 +233,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
         + pages_data.get("audited_content_foundation", [])
+        + pages_data.get("audited_post_creation_core", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/android/pages.json
+++ b/.docs-ops/integration-tests/android/pages.json
@@ -52,6 +52,11 @@
     "social-plus-sdk/social/content-management/content-sharing.mdx",
     "social-plus-sdk/social/content-management/posts/overview.mdx"
   ],
+  "audited_post_creation_core": [
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/android/results/latest.json
+++ b/.docs-ops/integration-tests/android/results/latest.json
@@ -1,9 +1,9 @@
 {
-  "run_at": "2026-06-20T09:57:53.101844+00:00",
+  "run_at": "2026-06-20T10:22:01.574504+00:00",
   "stats": {
-    "blocks_extracted": 123,
+    "blocks_extracted": 127,
     "blocks_skipped": 6,
-    "blocks_passed": 123,
+    "blocks_passed": 127,
     "blocks_failed": 0,
     "total_warnings": 4,
     "pass_rate": 100.0,
@@ -239,6 +239,24 @@
       "warnings": 0
     },
     "social-plus-sdk/social/content-management/content-sharing.mdx": {
+      "passed": 1,
+      "failed": 0,
+      "skipped": 0,
+      "warnings": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx": {
+      "passed": 1,
+      "failed": 0,
+      "skipped": 0,
+      "warnings": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx": {
+      "passed": 2,
+      "failed": 0,
+      "skipped": 0,
+      "warnings": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx": {
       "passed": 1,
       "failed": 0,
       "skipped": 0,

--- a/.docs-ops/integration-tests/extract-blocks.py
+++ b/.docs-ops/integration-tests/extract-blocks.py
@@ -49,6 +49,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
         + pages_data.get("audited_content_foundation", [])
+        + pages_data.get("audited_post_creation_core", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/flutter/extract-blocks.py
+++ b/.docs-ops/integration-tests/flutter/extract-blocks.py
@@ -56,6 +56,7 @@ def resolve_pages(pages_data):
         + pages_data.get("audited_community_organization", [])
         + pages_data.get("audited_community_admin", [])
         + pages_data.get("audited_content_foundation", [])
+        + pages_data.get("audited_post_creation_core", [])
         + pages_data.get("chat_track", [])
         + pages_data.get("social_track", [])
         + pages_data.get("shared", [])

--- a/.docs-ops/integration-tests/flutter/pages.json
+++ b/.docs-ops/integration-tests/flutter/pages.json
@@ -51,6 +51,11 @@
     "social-plus-sdk/social/content-management/content-sharing.mdx",
     "social-plus-sdk/social/content-management/posts/overview.mdx"
   ],
+  "audited_post_creation_core": [
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/flutter/results/latest.json
+++ b/.docs-ops/integration-tests/flutter/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "run_at": "2026-06-20T09:54:40.897479+00:00",
+  "run_at": "2026-06-20T10:18:37.148099+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/Amity-Social-Cloud-SDK-Flutter-Internal",
   "preamble_version": "36859d1b",
   "stats": {
-    "pages_scanned": 55,
-    "blocks_extracted": 73,
+    "pages_scanned": 58,
+    "blocks_extracted": 76,
     "blocks_skipped": 0,
-    "blocks_passed": 73,
+    "blocks_passed": 76,
     "blocks_failed": 0,
     "total_warnings": 0,
     "pass_rate": 1.0,
@@ -176,6 +176,21 @@
     "social-plus-sdk/social/communities-spaces/organization/query-community-members.mdx": {
       "blocks": 2,
       "passed": 2,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx": {
+      "blocks": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx": {
+      "blocks": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx": {
+      "blocks": 1,
+      "passed": 1,
       "failed": 0
     },
     "social-plus-sdk/social/content-management/posts/moderation/delete-post.mdx": {

--- a/.docs-ops/integration-tests/ios/pages.json
+++ b/.docs-ops/integration-tests/ios/pages.json
@@ -52,6 +52,11 @@
     "social-plus-sdk/social/content-management/content-sharing.mdx",
     "social-plus-sdk/social/content-management/posts/overview.mdx"
   ],
+  "audited_post_creation_core": [
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/ios/results/latest.json
+++ b/.docs-ops/integration-tests/ios/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-06-20T09:58:15.605010+00:00",
+  "generated_at": "2026-06-20T10:22:24.983257+00:00",
   "toolchain": "swiftc -typecheck",
   "sdk_version": "AmitySDK 8.1.1 (xcframework binary)",
   "xcfw_url": "https://sdk.amity.co/sdk-release/ios-frameworks/8.1.1/AmitySDK.xcframework.zip",
   "stats": {
-    "blocks_extracted": 118,
-    "blocks_passed": 118,
-    "blocks_warned": 118,
+    "blocks_extracted": 122,
+    "blocks_passed": 122,
+    "blocks_warned": 122,
     "blocks_failed": 0,
     "blocks_skipped": 5
   },
@@ -999,6 +999,74 @@
     {
       "file": "content-sharing-block-1.swift",
       "source_page": "social-plus-sdk/social/content-management/content-sharing.mdx",
+      "block_index": 1,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 34,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        }
+      ]
+    },
+    {
+      "file": "text-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+      "block_index": 1,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 34,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        },
+        {
+          "line": 63,
+          "col": 9,
+          "severity": "warning",
+          "message": "initialization of immutable value 'post' was never used; consider replacing with assignment to '_' or removing it"
+        }
+      ]
+    },
+    {
+      "file": "text-post-block-2.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+      "block_index": 2,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 34,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        },
+        {
+          "line": 74,
+          "col": 9,
+          "severity": "warning",
+          "message": "initialization of immutable value 'post' was never used; consider replacing with assignment to '_' or removing it"
+        }
+      ]
+    },
+    {
+      "file": "image-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/image-post.mdx",
+      "block_index": 1,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 34,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        }
+      ]
+    },
+    {
+      "file": "video-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/video-post.mdx",
       "block_index": 1,
       "severity": "warning",
       "warnings": [
@@ -2371,6 +2439,22 @@
     {
       "file": "content-sharing-block-1.swift",
       "source_page": "social-plus-sdk/social/content-management/content-sharing.mdx"
+    },
+    {
+      "file": "text-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/text-post.mdx"
+    },
+    {
+      "file": "text-post-block-2.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/text-post.mdx"
+    },
+    {
+      "file": "image-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/image-post.mdx"
+    },
+    {
+      "file": "video-post-block-1.swift",
+      "source_page": "social-plus-sdk/social/content-management/posts/creation/video-post.mdx"
     },
     {
       "file": "authentication-block-1.swift",

--- a/.docs-ops/integration-tests/pages.json
+++ b/.docs-ops/integration-tests/pages.json
@@ -49,6 +49,11 @@
     "social-plus-sdk/social/content-management/content-sharing.mdx",
     "social-plus-sdk/social/content-management/posts/overview.mdx"
   ],
+  "audited_post_creation_core": [
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx",
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx"
+  ],
   "chat_track": [
     "social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx",
     "social-plus-sdk/getting-started/authentication.mdx",

--- a/.docs-ops/integration-tests/results/latest.json
+++ b/.docs-ops/integration-tests/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "run_at": "2026-06-20T09:53:36.299560+00:00",
+  "run_at": "2026-06-20T10:17:25.432388+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK",
   "preamble_version": "6e720279",
   "stats": {
-    "pages_scanned": 55,
-    "blocks_extracted": 130,
+    "pages_scanned": 58,
+    "blocks_extracted": 134,
     "blocks_skipped": 0,
-    "blocks_passed": 130,
+    "blocks_passed": 134,
     "blocks_failed": 0,
     "pass_rate": 1.0
   },
@@ -182,6 +182,21 @@
       "failed": 0
     },
     "social-plus-sdk/social/content-management/content-sharing.mdx": {
+      "blocks": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/image-post.mdx": {
+      "blocks": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/text-post.mdx": {
+      "blocks": 2,
+      "passed": 2,
+      "failed": 0
+    },
+    "social-plus-sdk/social/content-management/posts/creation/video-post.mdx": {
       "blocks": 1,
       "passed": 1,
       "failed": 0

--- a/.docs-ops/sdk-audit/tracker.csv
+++ b/.docs-ops/sdk-audit/tracker.csv
@@ -124,13 +124,13 @@ social-plus-sdk/social/content-management/posts/creation/audio-post.mdx,social,c
 social-plus-sdk/social/content-management/posts/creation/clip-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/custom-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/file-post.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/posts/creation/image-post.mdx,social,content-management,not_started,no,no,no,,,,
+social-plus-sdk/social/content-management/posts/creation/image-post.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source for image post creation across TS iOS Android Flutter. Proof: TS 134/134; Android 127/127 skipped 6; Flutter 76/76; iOS 122/122 skipped 5.","Replaced stale iOS client constructor and incorrect TS attachment product tag example with verified core image-post creation snippets."
 social-plus-sdk/social/content-management/posts/creation/live-stream-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/mixed-media-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/poll-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/creation/room-post.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/posts/creation/text-post.mdx,social,content-management,not_started,no,no,no,,,,
-social-plus-sdk/social/content-management/posts/creation/video-post.mdx,social,content-management,not_started,no,no,no,,,,
+social-plus-sdk/social/content-management/posts/creation/text-post.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source for text post creation and link preview metadata across TS iOS Android Flutter. Proof: TS 134/134; Android 127/127 skipped 6; Flutter 76/76; iOS 122/122 skipped 5.","Removed stale structureType and promise-query examples; documented Flutter structured-link limitation and verified TS Client.getLinkPreviewMetadata export path."
+social-plus-sdk/social/content-management/posts/creation/video-post.mdx,social,content-management,verified,yes,yes,yes,2026-06-20,codex,"Source: SDK source for video post creation across TS iOS Android Flutter. Proof: TS 134/134; Android 127/127 skipped 6; Flutter 76/76; iOS 122/122 skipped 5.","Replaced stale iOS client constructor and incorrect TS attachment product tag example with verified core video-post creation snippets."
 social-plus-sdk/social/content-management/posts/moderation/delete-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/moderation/edit-post.mdx,social,content-management,not_started,no,no,no,,,,
 social-plus-sdk/social/content-management/posts/moderation/pin-post.mdx,social,content-management,not_started,no,no,no,,,,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36029,820 +36029,341 @@ const postCommentTopic = getPostTopic(post, SubscriptionLevels.COMMENT);
 
 ### [Text Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/text-post)
 
-> Create simple text-based posts with mentions, hashtags, links, and rich formatting
+> Create text posts with the current Social+ SDKs, including optional structured links where supported.
 
-Create a text post (up to 20,000 characters) with mentions, hashtags, links, and custom metadata. Post to a user's feed, a community, or your own timeline.
+Text posts publish written content to a user feed, a community feed, or the current user's own feed. Use them for plain updates, status messages, and posts that attach structured link metadata.
 
-    Up to 20,000 characters with mentions, hashtags, and links
-    Post to user feeds, communities, or your own timeline
+    Publish to user feeds, community feeds, or the current user's feed depending on the SDK target API.
+    TypeScript, Android, and iOS can attach structured links during text post creation.
 
-## Overview
+## Create a Text Post
 
-Text posts provide a clean, straightforward way to share written content:
-
-- **Text Support**: Up to 20,000 characters per post
-- **Mentions**: Tag other users with @displayname syntax
-- **Hashtags**: Categorize content with #hashtag syntax
-- **Links**: Attach up to 100 structured links with optional preview metadata
-- **Custom Metadata**: Add additional structured data
-- **Flexible Targeting**: Post to user feeds or communities
-- **No Structure Type**: Text-only posts don't have a `structureType` field
-
-## Links and Preview Metadata
-
-Text post creation supports an optional `links` field in the request payload. Each post can contain up to **100 links**.
-
-When a link should show a preview card, set `renderPreview: true`. If preview metadata is missing, fetch it first with `getLinkPreviewMetadata(url)` and include the enriched data in your `links` array.
-
-### Link Models
-
-```ts
-AmityLink = {
-  index?: Int,
-  length?: Int,
-  url: String,
-  renderPreview: Bool,
-  domain?: String,
-  title?: String,
-  imageUrl?: String,
-}
-
-AmityLinkPreviewMetadata = {
-  title?: String,
-  description?: String,
-  domain?: String,
-  imageUrl?: String,
-}
-```
-
-## Understanding Post Structure Types
-
-**New Concept**: Posts now have a `structureType` field that describes their media composition. This enables precise content filtering and better content discovery.
-
-Text-only posts are unique in the post structure type system:
-
-    **Structure Type**: `null` or absent
-
-    When you create a text post without any attachments (images, videos, audio, or files), the post does not have a `structureType` value. This distinguishes pure text content from media-rich posts.
-
-```typescript
-// Text-only post example
-const textPost = {
-  data: { text: "Hello, world!" },
-  targetType: "user",
-  targetId: "user123"
-};
-// Result: structureType = null (no attachments)
-```
-
-    **Structure Types**: `image` | `video` | `audio` | `file` | `mixed`
-
-    When you add media attachments to a post, it automatically gets a `structureType` based on the media combination:
-
-    - **Single type**: `image`, `video`, `audio`, or `file` (when all attachments are the same type)
-    - **Multiple types**: `mixed` (when combining different media types)
-
-```typescript
-// Post with image attachments
-const imagePost = {
-  data: { text: "Check out these photos!" },
-  attachments: [
-    { type: "image", fileId: "img1" },
-    { type: "image", fileId: "img2" }
-  ],
-  targetType: "community",
-  targetId: "community123"
-};
-// Result: structureType = "image"
-
-// Post with mixed media
-const mixedPost = {
-  data: { text: "My multimedia post" },
-  attachments: [
-    { type: "image", fileId: "img1" },
-    { type: "audio", fileId: "aud1" }
-  ],
-  targetType: "community",
-  targetId: "community123"
-};
-// Result: structureType = "mixed"
-```
-
-### How Structure Types Affect Queries
-
-The `structureType` field enables powerful content filtering:
-
-```typescript
-// Query all posts (including text-only)
-const allPosts = await PostRepository.getPosts({
-  // No dataTypes filter = returns all posts
-});
-
-// Query posts with specific media types
-const imagePosts = await PostRepository.getPosts({
-  dataTypes: ['image']
-  // Returns only pure image posts (structureType = "image")
-  // Excludes mixed posts by default
-});
-
-// Query including mixed media posts
-const imageAndMixedPosts = await PostRepository.getPosts({
-  dataTypes: ['image'],
-  includeMixedStructure: true
-  // Returns both pure image posts AND mixed posts containing images
-});
-```
-
-For complete details on post structure types and filtering, see [Mixed Media Posts](./mixed-media-post).
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Text content (max 20,000 characters) |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ✅ | Target ID (`userId` or `communityId`) |
-| `metadata` | Object | ❌ | Custom metadata for the post |
-| `mentionUsers` | Array\<String\> | ❌ | User IDs to mention in the post |
-| `links` | Array\<AmityLink\> | ❌ | Structured links to attach to the post. Maximum **100 links** per post. |
-| `productTags` | Array\<AmityTextProductTag\> | ❌ | Product tags in text (max 20 per post) |
-
-### Create Text Post with Links
+The examples below create a text post in a community. Use the equivalent user target method or target type when posting to a user feed.
 
 ```swift iOS
-func createTextPostWithLinks() async throws {
-  let postRepository = AmityPostRepository(client: amityClient)
+let postRepository = AmityPostRepository()
+let builder = AmityTextPostBuilder()
+builder.setText("Hello community")
 
-  let builder = AmityTextPostBuilder()
-  builder.setText("Check this out https://www.amity.co")
-
-  let links = [
-    AmityLink(
-      url: "https://www.amity.co",
-      index: 15,
-      length: 20,
-      renderPreview: true,
-      domain: "www.amity.co"
-    )
-  ]
-
-  let post = try await postRepository.createTextPost(
+let post = try await postRepository.createTextPost(
     builder,
-    targetId: "userId1",
-    targetType: .user,
+    targetId: communityId,
+    targetType: .community,
     metadata: nil,
-    mentionees: nil,
-    hashtags: nil,
-    links: links,
-    productTags: nil
-  )
-}
+    mentionees: nil
+)
 ```
 
 ```kotlin Android
-fun createTextPostWithLinks(postRepository: AmityPostRepository) {
-  val links = listOf(
-    AmityLink(
-      index = 15,
-      length = 20,
-      url = "https://www.amity.co",
-      renderPreview = true,
-      domain = "www.amity.co",
-      title = null,
-      imageUrl = null
-    )
-  )
-
-  postRepository.createTextPost(
-    targetType = AmityPost.TargetType.USER,
-    targetId = "user1",
-    text = "Check this out https://www.amity.co",
-    links = links,
-  )
-    .doOnSuccess { post: AmityPost ->
-      // Success - text post with links created
-    }
-    .doOnError { error ->
-      // Handle error
-    }
-    .subscribe()
-}
+postRepository.createTextPost(
+    targetType = AmityPost.TargetType.COMMUNITY,
+    targetId = communityId,
+    text = "Hello community"
+)
+    .subscribe({ post ->
+        showSuccessMessage(post.getPostId())
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
 
-```typescript
-import { PostRepository } from '@amityco/ts-sdk';
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createTextPostWithLinks(): Promise<Amity.Post> {
-  const newPost = {
-  targetType: 'user',
-  targetId: 'userId1',
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
   data: {
-    text: 'Check this out https://www.amity.co',
+    text: "Hello community",
   },
-  links: [
-    {
-    index: 15,
-    length: 20,
-    url: 'https://www.amity.co',
-    renderPreview: true,
-    domain: 'www.amity.co',
-    },
-  ],
-  };
-
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
+});
 ```
 
-### Get Link Preview Metadata
+```dart Flutter
+final post = await AmitySocialClient.newPostRepository()
+    .createPost()
+    .targetCommunity(communityId)
+    .text('Hello community')
+    .createTextPost();
+```
+
+## Add Structured Links
+
+TypeScript, Android, and iOS expose a `links` field when creating a text post. Fetch preview metadata first if the post should render a preview card.
+
+Flutter's current public post creation builder supports text, metadata, and user mentions, but it does not expose a structured `links` payload on the text post builder.
 
 ```swift iOS
-let metadata = try await amityClient.getLinkPreviewMetadata(url: "https://www.amity.co")
+let postRepository = AmityPostRepository()
+let builder = AmityTextPostBuilder()
+builder.setText("Check this out https://www.amity.co")
+
+let preview = try await client.getLinkPreviewMetadata(url: "https://www.amity.co")
+let links = [
+    AmityLink(
+        url: "https://www.amity.co",
+        renderPreview: true,
+        domain: preview.domain,
+        title: preview.title,
+        imageUrl: preview.imageUrl
+    )
+]
+
+let post = try await postRepository.createTextPost(
+    builder,
+    targetId: communityId,
+    targetType: .community,
+    metadata: nil,
+    mentionees: nil,
+    links: links
+)
 ```
 
 ```kotlin Android
 AmityCoreClient.getLinkPreviewMetadata("https://www.amity.co")
-  .subscribe { metadata ->
-    // metadata.title, metadata.description, metadata.domain, metadata.imageUrl
-  }
+    .flatMap { preview ->
+        val links = listOf(
+            AmityLink(
+                index = null,
+                length = null,
+                url = "https://www.amity.co",
+                renderPreview = true,
+                domain = preview.getDomain(),
+                title = preview.getTitle(),
+                imageUrl = preview.getImageUrl()
+            )
+        )
+
+        postRepository.createTextPost(
+            targetType = AmityPost.TargetType.COMMUNITY,
+            targetId = communityId,
+            text = "Check this out https://www.amity.co",
+            links = links
+        )
+    }
+    .subscribe({ post ->
+        showSuccessMessage(post.getPostId())
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
 
-```typescript
-import { Client } from '@amityco/ts-sdk';
+```typescript TypeScript
+import { Client, PostRepository } from "@amityco/ts-sdk";
 
-const metadata = await Client.getLinkPreviewMetadata('https://www.amity.co');
+const preview = await Client.getLinkPreviewMetadata("https://www.amity.co");
+
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Check this out https://www.amity.co",
+  },
+  links: [
+    {
+      url: "https://www.amity.co",
+      renderPreview: true,
+      domain: preview.domain ?? undefined,
+      title: preview.title ?? undefined,
+      imageUrl: preview.imageUrl ?? undefined,
+    },
+  ],
+});
 ```
 
+## Querying Text Posts
 
-## Best Practices
+Post query APIs are SDK-specific. For TypeScript, `PostRepository.getPosts` returns a live collection through a callback instead of a promise, so do not call it with `await`.
 
-    - Keep text concise and engaging
-    - Use mentions sparingly to avoid spam
-    - Add relevant hashtags for discoverability
-    - Include context for better user engagement
-
-    - Validate text length before submission
-    - Handle network errors gracefully
-    - Provide user feedback during creation
-    - Cache drafts for better user experience
-
-    - Show character count indicators
-    - Provide auto-complete for mentions
-    - Suggest relevant hashtags
-    - Allow draft saving and editing
-
-## Troubleshooting
-
-    **Problem**: Post creation fails with text length error
-
-    **Solution**: Ensure text content is under 20,000 characters
-
-```typescript
-if (text.length > 20000) {
-  throw new Error('Text exceeds maximum length of 20,000 characters');
-}
-```
-
-    **Problem**: Mentions not working properly
-
-    **Solution**: Use correct format with @username (no spaces in username)
-
-```typescript
-// ✅ Correct
-"Hello @john-doe, how are you?"
-
-// ❌ Incorrect
-"Hello @john doe, how are you?"
-```
-
-    **Problem**: Post fails with invalid target error
-
-    **Solution**: Verify target exists and user has permission to post
-
-```typescript
-// Community membership is enforced server-side in v6.
-// The client-side membership check API was removed.
-// Simply attempt the operation — the server returns an error if unauthorized.
-```
-
-## Common Use Cases
-
-- **Status Updates**: Share personal thoughts and experiences
-- **Community Discussions**: Start conversations in community feeds
-- **Announcements**: Broadcast important information
-- **Questions**: Ask for advice or opinions from followers
-- **Storytelling**: Share experiences and narratives
-- **Links Sharing**: Share URLs with context and commentary
-
-## Related Topics
-
-    Create posts with photos and visual content
-    Share video content and multimedia experiences
-    Share audio content like podcasts and music
-    Share documents and file attachments
-    Combine multiple media types in one post
-    Edit, delete, and moderate your published posts
+For structure type values and filtering behavior, see [Posts Overview](../overview) and [Mixed Media Posts](./mixed-media-post).
 
 ---
 
 ### [Image Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/image-post)
 
-> Create posts with up to 10 images (JPEG, PNG, WebP, up to 100MB each). Images must be uploaded before post creation. Each image becomes a child post.
+> Create image posts with uploaded image files using the current Social+ SDKs.
 
-Use `PostRepository.createPost()` (TypeScript) or the platform post repository to publish image posts. Upload images first to get file IDs, then include them in the post. Each image becomes a child post that users can react to individually. Supports up to 10 images, 100MB each.
+Image posts combine one or more uploaded images with an optional text caption. Upload the images first, then pass the uploaded image objects or file IDs to the post creation API.
 
-    Upload up to 10 images per post with individual reactions
-    JPEG, PNG, WebP formats up to 100MB per image
+This page focuses on the SDK call that creates the post. See [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling) for upload steps, supported file inputs, and upload constraints.
 
-## Overview
+    Create posts from image objects or file IDs returned by the file upload flow.
+    Add text, metadata, mentions, or other SDK-supported post fields alongside the images.
 
-Image posts combine visual content with descriptive text:
+## Create an Image Post
 
-- **Multiple Images**: Up to 10 images per post
-- **Rich Captions**: Text descriptions with mentions and hashtags
-- **Parent-Child Structure**: Each image becomes a child post
-- **Interactive Features**: Users can react to individual images
-- **Structure Type**: Pure image posts have `structureType = "image"`
-
-| Requirement | Limit | Notes |
-|-------------|-------|-------|
-| **File Size** | Up to 100MB per image | Platform may have lower limits |
-| **Image Count** | Maximum 10 images | Per single post |
-| **File Formats** | JPEG, PNG, WebP, etc. | Platform dependent |
-
-**Want to mix media types?** Combine images with videos, audio, or files in a single post using [Mixed Media Posts](./mixed-media-post). Mixed posts allow up to 10 attachments of any combination.
-
-
-Images must be uploaded first before creating the post. See [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling) for upload instructions.
-
-    Use the File Repository to upload your images and get file IDs
-    Use the file IDs in your post creation request
-    The post will contain parent and child posts for each image
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Caption text (max 20,000 characters) |
-| `images/imageFiles` | Array | ✅ | Image files or uploaded image data |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ❌ | Target ID (`userId` or `communityId`) |
-| `tags` | Array\<String\> | ❌ | Tags for categorization |
-| `metadata` | Object | ❌ | Custom metadata |
-| `attachmentProductTags` | AmityAttachmentProductTags | ❌ | Product tags on images (max 20 per post) |
-
+The examples below create an image post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
 ```swift iOS
-func createImagePost(images: [AmityImageData]) async throws {
-    let postRepository = AmityPostRepository(client: amityClient)
-
+func createImagePost(
+    uploadedImages: [AmityImageData],
+    communityId: String
+) async throws -> AmityPost {
+    let postRepository = AmityPostRepository()
     let builder = AmityImagePostBuilder()
-    builder.setImages(images)
-    builder.setText("Check out these products!")
+    builder.setImages(uploadedImages)
+    builder.setText("Photos from today")
 
-    // Build attachment product tags: map fileId to media product tags
-    let attachmentProductTags = AmityAttachmentProductTags()
-    attachmentProductTags.add(
-        fileId: "image-file-id",
-        tag: AmityMediaProductTag(productId: "product-1")
-    )
-    attachmentProductTags.add(
-        fileId: "image-file-id-2",
-        tag: AmityMediaProductTag(productId: "product-2")
-    )
-
-    let post = try await postRepository.createImagePost(
+    return try await postRepository.createImagePost(
         builder,
-        targetId: "userId1",
-        targetType: .user,
+        targetId: communityId,
+        targetType: .community,
         metadata: nil,
-        mentionees: nil,
-        attachmentProductTags: attachmentProductTags
+        mentionees: nil
     )
 }
 ```
 
 ```kotlin Android
 fun createImagePost(
-    postRepository: AmityPostRepository,
-    images: Set<AmityImage>
+    uploadedImages: Set<AmityImage>,
+    communityId: String
 ) {
-    // Build attachment product tags: map each fileId to a list of product tags
-    val attachmentProductTags = AmityAttachmentProductTags.Builder()
-        .apply {
-            set(
-                "image-file-id-1",
-                listOf(AmityProductTag.Media(productId = "product-1"))
-            )
-            set(
-                "image-file-id-2",
-                listOf(AmityProductTag.Media(productId = "product-2"))
-            )
-        }
-        .build()
-
     postRepository.createImagePost(
-        targetType = AmityPost.TargetType.USER,
-        targetId = "user1",
-        images = images,
-        text = "Check out these products!",
-        attachmentProductTags = attachmentProductTags
+        targetType = AmityPost.TargetType.COMMUNITY,
+        targetId = communityId,
+        images = uploadedImages,
+        text = "Photos from today"
     )
-        .doOnSuccess { post: AmityPost ->
-            // Image post with product tags created successfully
-        }
-        .doOnError { error ->
-            // Handle error
-        }
-        .subscribe()
+        .subscribe({ post ->
+            showSuccessMessage(post.getPostId())
+        }, { error ->
+            handleGeneralError(error)
+        })
 }
 ```
 
 ```typescript TypeScript
-import { PostRepository, PostContentType } from '@amityco/ts-sdk';
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createImagePost(): Promise<Amity.Post> {
-  // Build attachment product tags
-  const attachmentTags = new AmityAttachmentProductTags();
-  attachmentTags.add("image-file-id-1", { productId: "product-1" });
-  attachmentTags.add("image-file-id-2", { productId: "product-2" });
-
-  const newPost = {
-    targetType: "user",
-    targetId: "userId1",
-    data: {
-      text: "Check out these products!",
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Photos from today",
+  },
+  attachments: [
+    {
+      type: "image",
+      fileId,
     },
-    attachments: [
-      {
-        fileId: "image-file-id-1",
-        type: PostContentType.IMAGE,
-      },
-      {
-        fileId: "image-file-id-2",
-        type: PostContentType.IMAGE,
-      },
-    ],
-    attachmentTags,
-  };
-
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
-```
-
-```dart Flutter
-late PagingController<AmityPost> _controller;
-
-void createImagePost(List<AmityImage> uploadedImages) {
-  AmitySocialClient.newPostRepository()
-      .createPost()
-      .targetUser('userId')
-      .image(uploadedImages)
-      .text('Check out these products!')
-      .post()
-      .then((AmityPost post) {
-        // Success - add to feed
-        _controller.add(post);
-        print('Image post created successfully');
-      })
-      .onError((error, stackTrace) {
-        print('Error creating image post: $error');
-      });
-}
-```
-
-
-## Best Practices
-
-    - Compress images before upload to reduce file size
-    - Resize images to appropriate dimensions (e.g., 1080x1080)
-    - Use appropriate file formats (JPEG for photos, PNG for graphics)
-    - Implement progress indicators for large uploads
-
-    - Show image previews before posting
-    - Allow users to reorder images
-    - Provide crop and edit functionality
-    - Handle upload failures gracefully with retry options
-
-    - Upload images in parallel when possible
-    - Cache uploaded images to avoid re-uploads
-    - Implement lazy loading for image previews
-    - Use appropriate image loading libraries
-
-## Troubleshooting
-
-    **Problem**: Images fail to upload or post creation fails
-
-    **Solutions**:
-    - Check file size (must be under 100MB per image)
-    - Verify supported format (JPEG, PNG, WebP)
-    - Ensure stable internet connection
-    - Implement retry logic with exponential backoff
-
-```typescript
-try {
-  const fileId = await FileRepository.uploadImage(imageFile);
-  // Proceed with post creation
-} catch (error) {
-  if (error.code === 'FILE_TOO_LARGE') {
-    // Compress image and retry
-  } else if (error.code === 'NETWORK_ERROR') {
-    // Implement retry logic
-  }
-}
-```
-
-    **Problem**: Images appear blurry or low quality
-
-    **Solutions**:
-    - Upload images at optimal resolution (1080x1080 or higher)
-    - Avoid excessive compression before upload
-    - Use appropriate file formats (JPEG for photos, PNG for graphics)
-
-```typescript
-// Recommended image dimensions
-const optimalDimensions = {
-  square: { width: 1080, height: 1080 },
-  landscape: { width: 1200, height: 630 },
-  portrait: { width: 1080, height: 1350 }
-};
-```
-
-    **Problem**: App crashes or becomes slow with large images
-
-    **Solutions**:
-    - Implement image compression before upload
-    - Use image loading libraries with memory management
-    - Resize images to appropriate dimensions
-    - Clear image cache periodically
-
-```typescript
-// Example: Compress image before upload
-const compressedImage = await compressImage(originalImage, {
-  maxWidth: 1200,
-  maxHeight: 1200,
-  quality: 0.8
+  ],
 });
 ```
 
+```dart Flutter
+Future<AmityPost> createImagePost(List<AmityImage> uploadedImages) {
+  return AmitySocialClient.newPostRepository()
+      .createPost()
+      .targetCommunity(communityId)
+      .image(uploadedImages)
+      .text('Photos from today')
+      .post();
+}
+```
 
-**Parent-Child Structure**: When you upload multiple images, the main post becomes the parent, and each image creates a child post that users can individually react to and comment on.
+## Notes
 
-## Common Use Cases
+- TypeScript accepts image attachments as `{ type: "image", fileId }`.
+- Android accepts a `Set<AmityImage>`.
+- iOS accepts `[AmityImageData]`.
+- Flutter accepts `List<AmityImage>`.
 
-- **Photo Sharing**: Share personal photos and memories
-- **Product Showcases**: Display products with multiple angles
-- **Event Documentation**: Share photos from events and gatherings
-- **Before/After Comparisons**: Show transformations or progress
-- **Step-by-Step Guides**: Visual tutorials and instructions
-- **Gallery Posts**: Curated collections of related images
-
-## Related Topics
-
-    Learn how to upload and manage images before creating posts
-    Create text-based posts with mentions and hashtags
-    Share video content and multimedia experiences
-    Create posts with audio attachments
-    Attach and share document files
-    Combine multiple media types in a single post
+For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
 ---
 
 ### [Video Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/video-post)
 
-> Create posts with up to 10 videos (up to 2GB and 2 hours each). Videos must be uploaded before post creation. HDR not supported on iOS.
+> Create video posts with uploaded video files using the current Social+ SDKs.
 
-Use `PostRepository.createPost()` (TypeScript) or the platform post repository to publish video posts. Upload videos first to get file IDs, then reference them in the post. Each video becomes a child post with automatic thumbnail generation. Supports up to 10 videos, 2GB and 2 hours each. HDR video is not supported on iOS.
+Video posts combine uploaded videos with an optional text caption. Upload the videos first, then pass the uploaded video objects or file IDs to the post creation API.
 
-    Upload up to 10 videos per post with automatic thumbnails
-    Support for videos up to 2GB and 2 hours duration each
+This page focuses on the SDK call that creates the post. See [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling) for upload steps, supported file inputs, processing behavior, and upload constraints.
 
-## Overview
+    Create posts from video objects or file IDs returned by the file upload flow.
+    Add text, metadata, mentions, or other SDK-supported post fields alongside the videos.
 
-Video posts combine visual storytelling with descriptive text:
+## Create a Video Post
 
-- **Multiple Videos**: Up to 10 videos per post
-- **Rich Captions**: Text descriptions with mentions and hashtags
-- **File Size Limit**: Up to 2GB per video
-- **Duration Limit**: Maximum 2 hours per video
-- **Format Support**: Wide range of video formats
-- **Parent-Child Structure**: Each video becomes a child post
-- **Structure Type**: Pure video posts have `structureType = 'video'`
-
-Want to combine videos with other media types (images, audio, or files)? Check out [Mixed Media Posts](./mixed-media-post) which support up to 10 mixed attachments of any type.
-
-
-| Requirement | Limit | Notes |
-|-------------|-------|-------|
-| **File Size** | Up to 2GB per video | Platform may have lower limits |
-| **Duration** | Maximum 2 hours | Per individual video |
-| **Video Count** | Maximum 10 videos | Per single post |
-| **File Formats** | `mp4`, `mov`, `avi`, `mkv`, `webm`, `flv`, `3gp`, `wmv`, `vob`, `ogv`, `3g2`, `f4v`, `m4v` | Platform dependent |
-
-HDR video format uploads are not supported on iOS platform.
-
-Videos must be uploaded first before creating the post. See [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling) for upload instructions.
-
-    Use the File Repository to upload your video files and get file IDs
-    Use the file IDs in your post creation request with captions
-    The post will contain parent and child posts for each video
-    Track video processing and thumbnail generation status
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Caption text (max 20,000 characters) |
-| `videos/videoFiles` | Array | ✅ | Video files or uploaded video data |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ✅ | Target ID (`userId` or `communityId`) |
-| `metadata` | Object | ❌ | Custom metadata |
-| `attachmentProductTags` | AmityAttachmentProductTags | ❌ | Product tags on videos (max 20 per post) |
-
+The examples below create a video post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
 ```swift iOS
-func createVideoPost(videos: [AmityVideoData]) async throws {
-    let postRepository = AmityPostRepository(client: amityClient)
-
+func createVideoPost(
+    uploadedVideos: [AmityVideoData],
+    communityId: String
+) async throws -> AmityPost {
+    let postRepository = AmityPostRepository()
     let builder = AmityVideoPostBuilder()
-    builder.setVideos(videos)
-    builder.setText("Check out this video!")
+    builder.setVideos(uploadedVideos)
+    builder.setText("Video from today")
 
-    // Build attachment product tags: map fileId to media product tags
-    let attachmentProductTags = AmityAttachmentProductTags()
-    attachmentProductTags.add(
-        fileId: "video-file-id",
-        tag: AmityMediaProductTag(productId: "product-1")
-    )
-
-    let post = try await postRepository.createVideoPost(
+    return try await postRepository.createVideoPost(
         builder,
-        targetId: "userId1",
-        targetType: .user,
+        targetId: communityId,
+        targetType: .community,
         metadata: nil,
-        mentionees: nil,
-        attachmentProductTags: attachmentProductTags
+        mentionees: nil
     )
 }
 ```
 
 ```kotlin Android
 fun createVideoPost(
-    postRepository: AmityPostRepository,
-    videos: Set<AmityVideo>
+    uploadedVideos: Set<AmityVideo>,
+    communityId: String
 ) {
-    // Build attachment product tags: map each fileId to a list of product tags
-    val attachmentProductTags = AmityAttachmentProductTags.Builder()
-        .apply {
-            set(
-                "video-file-id",
-                listOf(AmityProductTag.Media(productId = "product-1"))
-            )
-        }
-        .build()
-
     postRepository.createVideoPost(
-        targetType = AmityPost.TargetType.USER,
-        targetId = "user1",
-        videos = videos,
-        text = "Check out this video!",
-        attachmentProductTags = attachmentProductTags
+        targetType = AmityPost.TargetType.COMMUNITY,
+        targetId = communityId,
+        videos = uploadedVideos,
+        text = "Video from today"
     )
-        .doOnSuccess { post: AmityPost ->
-            // Video post with product tags created successfully
-        }
-        .doOnError { error ->
-            // Handle error
-        }
-        .subscribe()
+        .subscribe({ post ->
+            showSuccessMessage(post.getPostId())
+        }, { error ->
+            handleGeneralError(error)
+        })
 }
 ```
 
 ```typescript TypeScript
-import { PostRepository, PostContentType } from '@amityco/ts-sdk';
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createVideoPost(): Promise<Amity.Post> {
-  // Build attachment product tags
-  const attachmentTags = new AmityAttachmentProductTags();
-  attachmentTags.add("video-file-id", { productId: "product-1" });
-
-  const newPost = {
-    targetType: "user",
-    targetId: "userId1",
-    data: {
-      text: "Check out this video!",
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Video from today",
+  },
+  attachments: [
+    {
+      type: "video",
+      fileId,
     },
-    attachments: [
-      {
-        fileId: "video-file-id",
-        type: PostContentType.VIDEO,
-      },
-    ],
-    attachmentTags,
-  };
-
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
+  ],
+});
 ```
 
 ```dart Flutter
-late PagingController<AmityPost> _controller;
-
-void createVideoPost(List<AmityVideo> uploadedVideos) {
-  AmitySocialClient.newPostRepository()
+Future<AmityPost> createVideoPost(List<AmityVideo> uploadedVideos) {
+  return AmitySocialClient.newPostRepository()
       .createPost()
-      .targetUser('userId')
+      .targetCommunity(communityId)
       .video(uploadedVideos)
-      .text('Check out this video!')
-      .post()
-      .then((AmityPost post) {
-        // Success - add to feed
-        _controller.add(post);
-        print('Video post created successfully');
-      })
-      .onError((error, stackTrace) {
-        print('Error creating video post: $error');
-      });
+      .text('Video from today')
+      .post();
 }
 ```
 
+## Notes
 
-## Troubleshooting
+- TypeScript accepts video attachments as `{ type: "video", fileId }`.
+- Android accepts a `Set<AmityVideo>`.
+- iOS accepts `[AmityVideoData]`.
+- Flutter accepts `List<AmityVideo>`.
 
-    **Problem**: Video uploads fail or timeout during upload
-
-    **Solutions**:
-    - Check file size (must be under 2GB per video)
-    - Verify supported format (mp4, mov, avi, etc.)
-    - Ensure stable internet connection for large files
-
-
-    **Problem**: Videos appear low quality or take long to load
-
-    **Solutions**:
-    - Upload videos at optimal resolution (1080p recommended)
-    - Use appropriate bitrate (2-5 Mbps for 1080p)
-    - Choose efficient codecs (H.264 recommended)
-    - Consider adaptive bitrate streaming for large videos
-
-
-    **Problem**: HDR videos not uploading on iOS
-
-    **Solution**: HDR video formats are not supported on iOS platform. Please convert to standard format.
-
-```typescript
-// Check for HDR and convert if needed
-if (Platform.OS === 'ios' && videoInfo.isHDR) {
-   convertToStandardFormat(videoFile)
-     .then(convertedFile => {
-       // Proceed with converted file
-     })
-     .catch(error => {
-       console.error('HDR conversion failed:', error);
-     });
-}
-```
-
-    **Problem**: Video thumbnails not generating or appearing incorrect
-
-    **Solutions**:
-    - Wait for video processing to complete before displaying
-
-
-    **Problem**: Videos exceed 2-hour duration limit
-
-    **Solution**: Validate duration before upload and provide trimming options
-
-```typescript
-// Validate video duration
-const validateDuration = (duration) => {
-  const maxDuration = 2 * 60 * 60; // 2 hours in seconds
-  if (duration > maxDuration) {
-    throw new Error('Video duration exceeds 2-hour limit. Please trim the video.');
-  }
-};
-```
-
-## Common Use Cases
-
-- **Video Sharing**: Share personal videos and memories
-- **Tutorials**: Create step-by-step instructional content
-- **Live Updates**: Share real-time event footage
-- **Product Demos**: Showcase products in action
-- **Entertainment**: Share funny clips and entertainment content
-- **Educational Content**: Distribute learning materials and lectures
-
-## Related Topics
-
-    Learn how to upload and manage video files before creating posts
-    Create posts with photos and visual content
-    Create posts with audio attachments
-    Attach and share document files
-    Combine multiple media types in a single post
-    Create real-time video broadcasts and live content
+For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -163,9 +163,9 @@
 ## Social — Posts
 
 - [Posts Overview](https://learn.social.plus/social-plus-sdk/social/content-management/posts/overview): Understand post targets, content types, structure types, live comment counts, and the platform-specific post APIs
-- [Text Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/text-post): Create simple text-based posts with mentions, hashtags, links, and rich formatting
-- [Image Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/image-post): Create posts with up to 10 images (JPEG, PNG, WebP, up to 100MB each). Images must be uploaded before post creation. Each image becomes a child post.
-- [Video Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/video-post): Create posts with up to 10 videos (up to 2GB and 2 hours each). Videos must be uploaded before post creation. HDR not supported on iOS.
+- [Text Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/text-post): Create text posts with the current Social+ SDKs, including optional structured links where supported.
+- [Image Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/image-post): Create image posts with uploaded image files using the current Social+ SDKs.
+- [Video Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/video-post): Create video posts with uploaded video files using the current Social+ SDKs.
 - [Audio Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/audio-post): Create posts with audio files. Supports MP3, WAV, AAC, M4A, OGG, Opus, FLAC. Up to 10 files, 1GB each, 1 hour max duration.
 - [File Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/file-post): Create posts with file attachments like PDFs, documents, and other file formats
 - [Custom Posts](https://learn.social.plus/social-plus-sdk/social/content-management/posts/creation/custom-post): Create custom post types with a structured JSON payload up to 100KB. The dataType field must start with 'custom.' (e.g., 'custom.product').

--- a/social-plus-sdk/social/content-management/posts/creation/image-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/image-post.mdx
@@ -1,320 +1,102 @@
 ---
 title: "Image Posts"
-description: "Create posts with up to 10 images (JPEG, PNG, WebP, up to 100MB each). Images must be uploaded before post creation. Each image becomes a child post."
+description: "Create image posts with uploaded image files using the current Social+ SDKs."
 ---
 
-Use `PostRepository.createPost()` (TypeScript) or the platform post repository to publish image posts. Upload images first to get file IDs, then include them in the post. Each image becomes a child post that users can react to individually. Supports up to 10 images, 100MB each.
+Image posts combine one or more uploaded images with an optional text caption. Upload the images first, then pass the uploaded image objects or file IDs to the post creation API.
+
+<Info>
+This page focuses on the SDK call that creates the post. See [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling) for upload steps, supported file inputs, and upload constraints.
+</Info>
 
 <CardGroup cols={2}>
-  <Card title="Multiple Images" icon="images">
-    Upload up to 10 images per post with individual reactions
+  <Card title="Uploaded Images" icon="images">
+    Create posts from image objects or file IDs returned by the file upload flow.
   </Card>
-  <Card title="Rich Media Support" icon="image">
-    JPEG, PNG, WebP formats up to 100MB per image
+  <Card title="Caption Support" icon="text">
+    Add text, metadata, mentions, or other SDK-supported post fields alongside the images.
   </Card>
 </CardGroup>
 
-## Overview
+## Create an Image Post
 
-Image posts combine visual content with descriptive text:
-
-- **Multiple Images**: Up to 10 images per post
-- **Rich Captions**: Text descriptions with mentions and hashtags
-- **Parent-Child Structure**: Each image becomes a child post
-- **Interactive Features**: Users can react to individual images
-- **Structure Type**: Pure image posts have `structureType = "image"`
-
-| Requirement | Limit | Notes |
-|-------------|-------|-------|
-| **File Size** | Up to 100MB per image | Platform may have lower limits |
-| **Image Count** | Maximum 10 images | Per single post |
-| **File Formats** | JPEG, PNG, WebP, etc. | Platform dependent |
-
-<Info>
-**Want to mix media types?** Combine images with videos, audio, or files in a single post using [Mixed Media Posts](./mixed-media-post). Mixed posts allow up to 10 attachments of any combination.
-</Info>
-
-
-<Warning>
-Images must be uploaded first before creating the post. See [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling) for upload instructions.
-</Warning>
-
-<Steps>
-  <Step title="Upload Images">
-    Use the File Repository to upload your images and get file IDs
-  </Step>
-  <Step title="Create Post">
-    Use the file IDs in your post creation request
-  </Step>
-  <Step title="Handle Response">
-    The post will contain parent and child posts for each image
-  </Step>
-</Steps>
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Caption text (max 20,000 characters) |
-| `images/imageFiles` | Array | ✅ | Image files or uploaded image data |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ❌ | Target ID (`userId` or `communityId`) |
-| `tags` | Array\<String\> | ❌ | Tags for categorization |
-| `metadata` | Object | ❌ | Custom metadata |
-| `attachmentProductTags` | AmityAttachmentProductTags | ❌ | Product tags on images (max 20 per post) |
-
-
+The examples below create an image post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
 <CodeGroup>
 ```swift iOS
-func createImagePost(images: [AmityImageData]) async throws {
-    let postRepository = AmityPostRepository(client: amityClient)
-
+func createImagePost(
+    uploadedImages: [AmityImageData],
+    communityId: String
+) async throws -> AmityPost {
+    let postRepository = AmityPostRepository()
     let builder = AmityImagePostBuilder()
-    builder.setImages(images)
-    builder.setText("Check out these products!")
+    builder.setImages(uploadedImages)
+    builder.setText("Photos from today")
 
-    // Build attachment product tags: map fileId to media product tags
-    let attachmentProductTags = AmityAttachmentProductTags()
-    attachmentProductTags.add(
-        fileId: "image-file-id",
-        tag: AmityMediaProductTag(productId: "product-1")
-    )
-    attachmentProductTags.add(
-        fileId: "image-file-id-2",
-        tag: AmityMediaProductTag(productId: "product-2")
-    )
-
-    let post = try await postRepository.createImagePost(
+    return try await postRepository.createImagePost(
         builder,
-        targetId: "userId1",
-        targetType: .user,
+        targetId: communityId,
+        targetType: .community,
         metadata: nil,
-        mentionees: nil,
-        attachmentProductTags: attachmentProductTags
+        mentionees: nil
     )
 }
 ```
 
 ```kotlin Android
 fun createImagePost(
-    postRepository: AmityPostRepository,
-    images: Set<AmityImage>
+    uploadedImages: Set<AmityImage>,
+    communityId: String
 ) {
-    // Build attachment product tags: map each fileId to a list of product tags
-    val attachmentProductTags = AmityAttachmentProductTags.Builder()
-        .apply {
-            set(
-                "image-file-id-1",
-                listOf(AmityProductTag.Media(productId = "product-1"))
-            )
-            set(
-                "image-file-id-2",
-                listOf(AmityProductTag.Media(productId = "product-2"))
-            )
-        }
-        .build()
-
     postRepository.createImagePost(
-        targetType = AmityPost.TargetType.USER,
-        targetId = "user1",
-        images = images,
-        text = "Check out these products!",
-        attachmentProductTags = attachmentProductTags
+        targetType = AmityPost.TargetType.COMMUNITY,
+        targetId = communityId,
+        images = uploadedImages,
+        text = "Photos from today"
     )
-        .doOnSuccess { post: AmityPost ->
-            // Image post with product tags created successfully
-        }
-        .doOnError { error ->
-            // Handle error
-        }
-        .subscribe()
+        .subscribe({ post ->
+            showSuccessMessage(post.getPostId())
+        }, { error ->
+            handleGeneralError(error)
+        })
 }
 ```
 
 ```typescript TypeScript
-import { PostRepository, PostContentType } from '@amityco/ts-sdk';
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createImagePost(): Promise<Amity.Post> {
-  // Build attachment product tags
-  const attachmentTags = new AmityAttachmentProductTags();
-  attachmentTags.add("image-file-id-1", { productId: "product-1" });
-  attachmentTags.add("image-file-id-2", { productId: "product-2" });
-
-  const newPost = {
-    targetType: "user",
-    targetId: "userId1",
-    data: {
-      text: "Check out these products!",
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Photos from today",
+  },
+  attachments: [
+    {
+      type: "image",
+      fileId,
     },
-    attachments: [
-      {
-        fileId: "image-file-id-1",
-        type: PostContentType.IMAGE,
-      },
-      {
-        fileId: "image-file-id-2",
-        type: PostContentType.IMAGE,
-      },
-    ],
-    attachmentTags,
-  };
-
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
+  ],
+});
 ```
 
 ```dart Flutter
-late PagingController<AmityPost> _controller;
-
-void createImagePost(List<AmityImage> uploadedImages) {
-  AmitySocialClient.newPostRepository()
+Future<AmityPost> createImagePost(List<AmityImage> uploadedImages) {
+  return AmitySocialClient.newPostRepository()
       .createPost()
-      .targetUser('userId')
+      .targetCommunity(communityId)
       .image(uploadedImages)
-      .text('Check out these products!')
-      .post()
-      .then((AmityPost post) {
-        // Success - add to feed
-        _controller.add(post);
-        print('Image post created successfully');
-      })
-      .onError((error, stackTrace) {
-        print('Error creating image post: $error');
-      });
+      .text('Photos from today')
+      .post();
 }
 ```
-
-
 </CodeGroup>
 
-## Best Practices
+## Notes
 
-<AccordionGroup>
-  <Accordion title="Image Optimization">
-    - Compress images before upload to reduce file size
-    - Resize images to appropriate dimensions (e.g., 1080x1080)
-    - Use appropriate file formats (JPEG for photos, PNG for graphics)
-    - Implement progress indicators for large uploads
-  </Accordion>
-  
-  <Accordion title="User Experience">
-    - Show image previews before posting
-    - Allow users to reorder images
-    - Provide crop and edit functionality
-    - Handle upload failures gracefully with retry options
-  </Accordion>
-  
-  <Accordion title="Performance">
-    - Upload images in parallel when possible
-    - Cache uploaded images to avoid re-uploads
-    - Implement lazy loading for image previews
-    - Use appropriate image loading libraries
-  </Accordion>
-</AccordionGroup>
+- TypeScript accepts image attachments as `{ type: "image", fileId }`.
+- Android accepts a `Set<AmityImage>`.
+- iOS accepts `[AmityImageData]`.
+- Flutter accepts `List<AmityImage>`.
 
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="Image Upload Failures" icon="upload">
-    **Problem**: Images fail to upload or post creation fails
-    
-    **Solutions**:
-    - Check file size (must be under 100MB per image)
-    - Verify supported format (JPEG, PNG, WebP)
-    - Ensure stable internet connection
-    - Implement retry logic with exponential backoff
-    
-    ```typescript
-    try {
-      const fileId = await FileRepository.uploadImage(imageFile);
-      // Proceed with post creation
-    } catch (error) {
-      if (error.code === 'FILE_TOO_LARGE') {
-        // Compress image and retry
-      } else if (error.code === 'NETWORK_ERROR') {
-        // Implement retry logic
-      }
-    }
-    ```
-  </Accordion>
-  
-  <Accordion title="Image Quality Issues" icon="image">
-    **Problem**: Images appear blurry or low quality
-    
-    **Solutions**:
-    - Upload images at optimal resolution (1080x1080 or higher)
-    - Avoid excessive compression before upload
-    - Use appropriate file formats (JPEG for photos, PNG for graphics)
-    
-    ```typescript
-    // Recommended image dimensions
-    const optimalDimensions = {
-      square: { width: 1080, height: 1080 },
-      landscape: { width: 1200, height: 630 },
-      portrait: { width: 1080, height: 1350 }
-    };
-    ```
-  </Accordion>
-  
-  <Accordion title="Memory Issues" icon="memory">
-    **Problem**: App crashes or becomes slow with large images
-    
-    **Solutions**:
-    - Implement image compression before upload
-    - Use image loading libraries with memory management
-    - Resize images to appropriate dimensions
-    - Clear image cache periodically
-    
-    ```typescript
-    // Example: Compress image before upload
-    const compressedImage = await compressImage(originalImage, {
-      maxWidth: 1200,
-      maxHeight: 1200,
-      quality: 0.8
-    });
-    ```
-  </Accordion>
-</AccordionGroup>
-
-
-<Info>
-**Parent-Child Structure**: When you upload multiple images, the main post becomes the parent, and each image creates a child post that users can individually react to and comment on.
-</Info>
-
-## Common Use Cases
-
-- **Photo Sharing**: Share personal photos and memories
-- **Product Showcases**: Display products with multiple angles
-- **Event Documentation**: Share photos from events and gatherings
-- **Before/After Comparisons**: Show transformations or progress
-- **Step-by-Step Guides**: Visual tutorials and instructions
-- **Gallery Posts**: Curated collections of related images
-
-## Related Topics
-
-<CardGroup cols={3}>
-  <Card title="Image Upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling" icon="upload">
-    Learn how to upload and manage images before creating posts
-  </Card>
-  <Card title="Text Posts" href="./text-post" icon="text">
-    Create text-based posts with mentions and hashtags
-  </Card>
-  <Card title="Video Posts" href="./video-post" icon="video">
-    Share video content and multimedia experiences
-  </Card>
-  <Card title="Audio Posts" href="./audio-post" icon="file-audio">
-    Create posts with audio attachments
-  </Card>
-  <Card title="File Posts" href="./file-post" icon="file">
-    Attach and share document files
-  </Card>
-  <Card title="Mixed Media Posts" href="./mixed-media-post" icon="layer-group">
-    Combine multiple media types in a single post
-  </Card>
-</CardGroup>
-
-
-
-
+For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).

--- a/social-plus-sdk/social/content-management/posts/creation/text-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/text-post.mdx
@@ -1,376 +1,162 @@
 ---
 title: "Text Posts"
-description: "Create simple text-based posts with mentions, hashtags, links, and rich formatting"
+description: "Create text posts with the current Social+ SDKs, including optional structured links where supported."
 ---
 
-import CreateTextPost from '/snippets/social/posts/create-text-post.mdx';
-
-
-Create a text post (up to 20,000 characters) with mentions, hashtags, links, and custom metadata. Post to a user's feed, a community, or your own timeline.
+Text posts publish written content to a user feed, a community feed, or the current user's own feed. Use them for plain updates, status messages, and posts that attach structured link metadata.
 
 <CardGroup cols={2}>
-  <Card title="Rich Text Support" icon="text">
-    Up to 20,000 characters with mentions, hashtags, and links
+  <Card title="Flexible Targets" icon="users-viewfinder">
+    Publish to user feeds, community feeds, or the current user's feed depending on the SDK target API.
   </Card>
-  <Card title="Flexible Targeting" icon="users-viewfinder">
-    Post to user feeds, communities, or your own timeline
+  <Card title="Optional Enrichment" icon="link">
+    TypeScript, Android, and iOS can attach structured links during text post creation.
   </Card>
 </CardGroup>
 
-## Overview
+## Create a Text Post
 
-Text posts provide a clean, straightforward way to share written content:
-
-- **Text Support**: Up to 20,000 characters per post
-- **Mentions**: Tag other users with @displayname syntax
-- **Hashtags**: Categorize content with #hashtag syntax  
-- **Links**: Attach up to 100 structured links with optional preview metadata
-- **Custom Metadata**: Add additional structured data
-- **Flexible Targeting**: Post to user feeds or communities
-- **No Structure Type**: Text-only posts don't have a `structureType` field
-
-## Links and Preview Metadata
-
-Text post creation supports an optional `links` field in the request payload. Each post can contain up to **100 links**.
-
-<Info>
-When a link should show a preview card, set `renderPreview: true`. If preview metadata is missing, fetch it first with `getLinkPreviewMetadata(url)` and include the enriched data in your `links` array.
-</Info>
-
-### Link Models
-
-```ts
-AmityLink = {
-  index?: Int,
-  length?: Int,
-  url: String,
-  renderPreview: Bool,
-  domain?: String,
-  title?: String,
-  imageUrl?: String,
-}
-
-AmityLinkPreviewMetadata = {
-  title?: String,
-  description?: String,
-  domain?: String,
-  imageUrl?: String,
-}
-```
-
-## Understanding Post Structure Types
-
-<Info>
-**New Concept**: Posts now have a `structureType` field that describes their media composition. This enables precise content filtering and better content discovery.
-</Info>
-
-Text-only posts are unique in the post structure type system:
-
-<Tabs>
-  <Tab title="Text-Only Posts">
-    **Structure Type**: `null` or absent
-    
-    When you create a text post without any attachments (images, videos, audio, or files), the post does not have a `structureType` value. This distinguishes pure text content from media-rich posts.
-    
-    ```typescript
-    // Text-only post example
-    const textPost = {
-      data: { text: "Hello, world!" },
-      targetType: "user",
-      targetId: "user123"
-    };
-    // Result: structureType = null (no attachments)
-    ```
-  </Tab>
-  
-  <Tab title="Posts with Attachments">
-    **Structure Types**: `image` | `video` | `audio` | `file` | `mixed`
-    
-    When you add media attachments to a post, it automatically gets a `structureType` based on the media combination:
-    
-    - **Single type**: `image`, `video`, `audio`, or `file` (when all attachments are the same type)
-    - **Multiple types**: `mixed` (when combining different media types)
-    
-    ```typescript
-    // Post with image attachments
-    const imagePost = {
-      data: { text: "Check out these photos!" },
-      attachments: [
-        { type: "image", fileId: "img1" },
-        { type: "image", fileId: "img2" }
-      ],
-      targetType: "community",
-      targetId: "community123"
-    };
-    // Result: structureType = "image"
-    
-    // Post with mixed media
-    const mixedPost = {
-      data: { text: "My multimedia post" },
-      attachments: [
-        { type: "image", fileId: "img1" },
-        { type: "audio", fileId: "aud1" }
-      ],
-      targetType: "community",
-      targetId: "community123"
-    };
-    // Result: structureType = "mixed"
-    ```
-  </Tab>
-</Tabs>
-
-### How Structure Types Affect Queries
-
-The `structureType` field enables powerful content filtering:
-
-```typescript
-// Query all posts (including text-only)
-const allPosts = await PostRepository.getPosts({
-  // No dataTypes filter = returns all posts
-});
-
-// Query posts with specific media types
-const imagePosts = await PostRepository.getPosts({
-  dataTypes: ['image']
-  // Returns only pure image posts (structureType = "image")
-  // Excludes mixed posts by default
-});
-
-// Query including mixed media posts
-const imageAndMixedPosts = await PostRepository.getPosts({
-  dataTypes: ['image'],
-  includeMixedStructure: true
-  // Returns both pure image posts AND mixed posts containing images
-});
-```
-
-<Note>
-For complete details on post structure types and filtering, see [Mixed Media Posts](./mixed-media-post).
-</Note>
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Text content (max 20,000 characters) |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ✅ | Target ID (`userId` or `communityId`) |
-| `metadata` | Object | ❌ | Custom metadata for the post |
-| `mentionUsers` | Array\<String\> | ❌ | User IDs to mention in the post |
-| `links` | Array\<AmityLink\> | ❌ | Structured links to attach to the post. Maximum **100 links** per post. |
-| `productTags` | Array\<AmityTextProductTag\> | ❌ | Product tags in text (max 20 per post) |
-
-### Create Text Post with Links
+The examples below create a text post in a community. Use the equivalent user target method or target type when posting to a user feed.
 
 <CodeGroup>
 ```swift iOS
-func createTextPostWithLinks() async throws {
-  let postRepository = AmityPostRepository(client: amityClient)
+let postRepository = AmityPostRepository()
+let builder = AmityTextPostBuilder()
+builder.setText("Hello community")
 
-  let builder = AmityTextPostBuilder()
-  builder.setText("Check this out https://www.amity.co")
-
-  let links = [
-    AmityLink(
-      url: "https://www.amity.co",
-      index: 15,
-      length: 20,
-      renderPreview: true,
-      domain: "www.amity.co"
-    )
-  ]
-
-  let post = try await postRepository.createTextPost(
+let post = try await postRepository.createTextPost(
     builder,
-    targetId: "userId1",
-    targetType: .user,
+    targetId: communityId,
+    targetType: .community,
     metadata: nil,
-    mentionees: nil,
-    hashtags: nil,
-    links: links,
-    productTags: nil
-  )
-}
+    mentionees: nil
+)
 ```
 
 ```kotlin Android
-fun createTextPostWithLinks(postRepository: AmityPostRepository) {
-  val links = listOf(
-    AmityLink(
-      index = 15,
-      length = 20,
-      url = "https://www.amity.co",
-      renderPreview = true,
-      domain = "www.amity.co",
-      title = null,
-      imageUrl = null
-    )
-  )
-
-  postRepository.createTextPost(
-    targetType = AmityPost.TargetType.USER,
-    targetId = "user1",
-    text = "Check this out https://www.amity.co",
-    links = links,
-  )
-    .doOnSuccess { post: AmityPost ->
-      // Success - text post with links created
-    }
-    .doOnError { error ->
-      // Handle error
-    }
-    .subscribe()
-}
+postRepository.createTextPost(
+    targetType = AmityPost.TargetType.COMMUNITY,
+    targetId = communityId,
+    text = "Hello community"
+)
+    .subscribe({ post ->
+        showSuccessMessage(post.getPostId())
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
 
-```typescript
-import { PostRepository } from '@amityco/ts-sdk';
+```typescript TypeScript
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createTextPostWithLinks(): Promise<Amity.Post> {
-  const newPost = {
-  targetType: 'user',
-  targetId: 'userId1',
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
   data: {
-    text: 'Check this out https://www.amity.co',
+    text: "Hello community",
   },
-  links: [
-    {
-    index: 15,
-    length: 20,
-    url: 'https://www.amity.co',
-    renderPreview: true,
-    domain: 'www.amity.co',
-    },
-  ],
-  };
+});
+```
 
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
+```dart Flutter
+final post = await AmitySocialClient.newPostRepository()
+    .createPost()
+    .targetCommunity(communityId)
+    .text('Hello community')
+    .createTextPost();
 ```
 </CodeGroup>
 
-### Get Link Preview Metadata
+## Add Structured Links
+
+TypeScript, Android, and iOS expose a `links` field when creating a text post. Fetch preview metadata first if the post should render a preview card.
+
+<Note>
+Flutter's current public post creation builder supports text, metadata, and user mentions, but it does not expose a structured `links` payload on the text post builder.
+</Note>
 
 <CodeGroup>
 ```swift iOS
-let metadata = try await amityClient.getLinkPreviewMetadata(url: "https://www.amity.co")
+let postRepository = AmityPostRepository()
+let builder = AmityTextPostBuilder()
+builder.setText("Check this out https://www.amity.co")
+
+let preview = try await client.getLinkPreviewMetadata(url: "https://www.amity.co")
+let links = [
+    AmityLink(
+        url: "https://www.amity.co",
+        renderPreview: true,
+        domain: preview.domain,
+        title: preview.title,
+        imageUrl: preview.imageUrl
+    )
+]
+
+let post = try await postRepository.createTextPost(
+    builder,
+    targetId: communityId,
+    targetType: .community,
+    metadata: nil,
+    mentionees: nil,
+    links: links
+)
 ```
 
 ```kotlin Android
 AmityCoreClient.getLinkPreviewMetadata("https://www.amity.co")
-  .subscribe { metadata ->
-    // metadata.title, metadata.description, metadata.domain, metadata.imageUrl
-  }
+    .flatMap { preview ->
+        val links = listOf(
+            AmityLink(
+                index = null,
+                length = null,
+                url = "https://www.amity.co",
+                renderPreview = true,
+                domain = preview.getDomain(),
+                title = preview.getTitle(),
+                imageUrl = preview.getImageUrl()
+            )
+        )
+
+        postRepository.createTextPost(
+            targetType = AmityPost.TargetType.COMMUNITY,
+            targetId = communityId,
+            text = "Check this out https://www.amity.co",
+            links = links
+        )
+    }
+    .subscribe({ post ->
+        showSuccessMessage(post.getPostId())
+    }, { error ->
+        handleGeneralError(error)
+    })
 ```
 
-```typescript
-import { Client } from '@amityco/ts-sdk';
+```typescript TypeScript
+import { Client, PostRepository } from "@amityco/ts-sdk";
 
-const metadata = await Client.getLinkPreviewMetadata('https://www.amity.co');
+const preview = await Client.getLinkPreviewMetadata("https://www.amity.co");
+
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Check this out https://www.amity.co",
+  },
+  links: [
+    {
+      url: "https://www.amity.co",
+      renderPreview: true,
+      domain: preview.domain ?? undefined,
+      title: preview.title ?? undefined,
+      imageUrl: preview.imageUrl ?? undefined,
+    },
+  ],
+});
 ```
 </CodeGroup>
 
+## Querying Text Posts
 
-<CreateTextPost />
+Post query APIs are SDK-specific. For TypeScript, `PostRepository.getPosts` returns a live collection through a callback instead of a promise, so do not call it with `await`.
 
-
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Content Guidelines">
-    - Keep text concise and engaging
-    - Use mentions sparingly to avoid spam
-    - Add relevant hashtags for discoverability
-    - Include context for better user engagement
-  </Accordion>
-  
-  <Accordion title="Technical Implementation">
-    - Validate text length before submission
-    - Handle network errors gracefully
-    - Provide user feedback during creation
-    - Cache drafts for better user experience
-  </Accordion>
-  
-  <Accordion title="User Experience">
-    - Show character count indicators
-    - Provide auto-complete for mentions
-    - Suggest relevant hashtags
-    - Allow draft saving and editing
-  </Accordion>
-</AccordionGroup>
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="Text Length Validation" icon="ruler">
-    **Problem**: Post creation fails with text length error
-    
-    **Solution**: Ensure text content is under 20,000 characters
-    
-    ```typescript
-    if (text.length > 20000) {
-      throw new Error('Text exceeds maximum length of 20,000 characters');
-    }
-    ```
-  </Accordion>
-  
-  <Accordion title="Mention Format Issues" icon="at">
-    **Problem**: Mentions not working properly
-    
-    **Solution**: Use correct format with @username (no spaces in username)
-    
-    ```typescript
-    // ✅ Correct
-    "Hello @john-doe, how are you?"
-    
-    // ❌ Incorrect  
-    "Hello @john doe, how are you?"
-    ```
-  </Accordion>
-  
-  <Accordion title="Target Validation" icon="users-viewfinder">
-    **Problem**: Post fails with invalid target error
-    
-    **Solution**: Verify target exists and user has permission to post
-    
-    ```typescript
-    // Community membership is enforced server-side in v6.
-    // The client-side membership check API was removed.
-    // Simply attempt the operation — the server returns an error if unauthorized.
-    ```
-  </Accordion>
-</AccordionGroup>
-
-## Common Use Cases
-
-- **Status Updates**: Share personal thoughts and experiences
-- **Community Discussions**: Start conversations in community feeds
-- **Announcements**: Broadcast important information
-- **Questions**: Ask for advice or opinions from followers
-- **Storytelling**: Share experiences and narratives
-- **Links Sharing**: Share URLs with context and commentary
-
-## Related Topics
-
-<CardGroup cols={3}>
-  <Card title="Image Posts" href="./image-post" icon="image">
-    Create posts with photos and visual content
-  </Card>
-  <Card title="Video Posts" href="./video-post" icon="video">
-    Share video content and multimedia experiences
-  </Card>
-  <Card title="Audio Posts" href="./audio-post" icon="file-audio">
-    Share audio content like podcasts and music
-  </Card>
-  <Card title="File Posts" href="./file-post" icon="file">
-    Share documents and file attachments
-  </Card>
-  <Card title="Mixed Media Posts" href="./mixed-media-post" icon="layer-group">
-    Combine multiple media types in one post
-  </Card>
-  <Card title="Post Management" href="../moderation/edit-post" icon="gear">
-    Edit, delete, and moderate your published posts
-  </Card>
-</CardGroup>
+For structure type values and filtering behavior, see [Posts Overview](../overview) and [Mixed Media Posts](./mixed-media-post).

--- a/social-plus-sdk/social/content-management/posts/creation/video-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/video-post.mdx
@@ -1,284 +1,102 @@
 ---
 title: "Video Posts"
-description: "Create posts with up to 10 videos (up to 2GB and 2 hours each). Videos must be uploaded before post creation. HDR not supported on iOS."
+description: "Create video posts with uploaded video files using the current Social+ SDKs."
 ---
 
-Use `PostRepository.createPost()` (TypeScript) or the platform post repository to publish video posts. Upload videos first to get file IDs, then reference them in the post. Each video becomes a child post with automatic thumbnail generation. Supports up to 10 videos, 2GB and 2 hours each. HDR video is not supported on iOS.
+Video posts combine uploaded videos with an optional text caption. Upload the videos first, then pass the uploaded video objects or file IDs to the post creation API.
+
+<Info>
+This page focuses on the SDK call that creates the post. See [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling) for upload steps, supported file inputs, processing behavior, and upload constraints.
+</Info>
 
 <CardGroup cols={2}>
-  <Card title="Multi-Video Support" icon="video">
-    Upload up to 10 videos per post with automatic thumbnails
+  <Card title="Uploaded Videos" icon="video">
+    Create posts from video objects or file IDs returned by the file upload flow.
   </Card>
-  <Card title="Large File Support" icon="hard-drive">
-    Support for videos up to 2GB and 2 hours duration each
+  <Card title="Caption Support" icon="text">
+    Add text, metadata, mentions, or other SDK-supported post fields alongside the videos.
   </Card>
 </CardGroup>
 
-## Overview
+## Create a Video Post
 
-Video posts combine visual storytelling with descriptive text:
-
-- **Multiple Videos**: Up to 10 videos per post
-- **Rich Captions**: Text descriptions with mentions and hashtags
-- **File Size Limit**: Up to 2GB per video
-- **Duration Limit**: Maximum 2 hours per video
-- **Format Support**: Wide range of video formats
-- **Parent-Child Structure**: Each video becomes a child post
-- **Structure Type**: Pure video posts have `structureType = 'video'`
-
-<Info>
-Want to combine videos with other media types (images, audio, or files)? Check out [Mixed Media Posts](./mixed-media-post) which support up to 10 mixed attachments of any type.
-</Info>
-
-
-| Requirement | Limit | Notes |
-|-------------|-------|-------|
-| **File Size** | Up to 2GB per video | Platform may have lower limits |
-| **Duration** | Maximum 2 hours | Per individual video |
-| **Video Count** | Maximum 10 videos | Per single post |
-| **File Formats** | `mp4`, `mov`, `avi`, `mkv`, `webm`, `flv`, `3gp`, `wmv`, `vob`, `ogv`, `3g2`, `f4v`, `m4v` | Platform dependent |
-
-<Note>
-HDR video format uploads are not supported on iOS platform.
-</Note>
-
-<Warning>
-Videos must be uploaded first before creating the post. See [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling) for upload instructions.
-</Warning>
-
-<Steps>
-  <Step title="Upload Videos">
-    Use the File Repository to upload your video files and get file IDs
-  </Step>
-  <Step title="Create Post">
-    Use the file IDs in your post creation request with captions
-  </Step>
-  <Step title="Handle Response">
-    The post will contain parent and child posts for each video
-  </Step>
-  <Step title="Monitor Progress">
-    Track video processing and thumbnail generation status
-  </Step>
-</Steps>
-
-## Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | String | ✅ | Caption text (max 20,000 characters) |
-| `videos/videoFiles` | Array | ✅ | Video files or uploaded video data |
-| `targetType` | Enum | ✅ | Target type (`user` or `community`) |
-| `targetId` | String | ✅ | Target ID (`userId` or `communityId`) |
-| `metadata` | Object | ❌ | Custom metadata |
-| `attachmentProductTags` | AmityAttachmentProductTags | ❌ | Product tags on videos (max 20 per post) |
-
+The examples below create a video post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
 <CodeGroup>
 ```swift iOS
-func createVideoPost(videos: [AmityVideoData]) async throws {
-    let postRepository = AmityPostRepository(client: amityClient)
-
+func createVideoPost(
+    uploadedVideos: [AmityVideoData],
+    communityId: String
+) async throws -> AmityPost {
+    let postRepository = AmityPostRepository()
     let builder = AmityVideoPostBuilder()
-    builder.setVideos(videos)
-    builder.setText("Check out this video!")
+    builder.setVideos(uploadedVideos)
+    builder.setText("Video from today")
 
-    // Build attachment product tags: map fileId to media product tags
-    let attachmentProductTags = AmityAttachmentProductTags()
-    attachmentProductTags.add(
-        fileId: "video-file-id",
-        tag: AmityMediaProductTag(productId: "product-1")
-    )
-
-    let post = try await postRepository.createVideoPost(
+    return try await postRepository.createVideoPost(
         builder,
-        targetId: "userId1",
-        targetType: .user,
+        targetId: communityId,
+        targetType: .community,
         metadata: nil,
-        mentionees: nil,
-        attachmentProductTags: attachmentProductTags
+        mentionees: nil
     )
 }
 ```
 
 ```kotlin Android
 fun createVideoPost(
-    postRepository: AmityPostRepository,
-    videos: Set<AmityVideo>
+    uploadedVideos: Set<AmityVideo>,
+    communityId: String
 ) {
-    // Build attachment product tags: map each fileId to a list of product tags
-    val attachmentProductTags = AmityAttachmentProductTags.Builder()
-        .apply {
-            set(
-                "video-file-id",
-                listOf(AmityProductTag.Media(productId = "product-1"))
-            )
-        }
-        .build()
-
     postRepository.createVideoPost(
-        targetType = AmityPost.TargetType.USER,
-        targetId = "user1",
-        videos = videos,
-        text = "Check out this video!",
-        attachmentProductTags = attachmentProductTags
+        targetType = AmityPost.TargetType.COMMUNITY,
+        targetId = communityId,
+        videos = uploadedVideos,
+        text = "Video from today"
     )
-        .doOnSuccess { post: AmityPost ->
-            // Video post with product tags created successfully
-        }
-        .doOnError { error ->
-            // Handle error
-        }
-        .subscribe()
+        .subscribe({ post ->
+            showSuccessMessage(post.getPostId())
+        }, { error ->
+            handleGeneralError(error)
+        })
 }
 ```
 
 ```typescript TypeScript
-import { PostRepository, PostContentType } from '@amityco/ts-sdk';
+import { PostRepository } from "@amityco/ts-sdk";
 
-async function createVideoPost(): Promise<Amity.Post> {
-  // Build attachment product tags
-  const attachmentTags = new AmityAttachmentProductTags();
-  attachmentTags.add("video-file-id", { productId: "product-1" });
-
-  const newPost = {
-    targetType: "user",
-    targetId: "userId1",
-    data: {
-      text: "Check out this video!",
+const { data: post } = await PostRepository.createPost({
+  targetType: "community",
+  targetId: communityId,
+  data: {
+    text: "Video from today",
+  },
+  attachments: [
+    {
+      type: "video",
+      fileId,
     },
-    attachments: [
-      {
-        fileId: "video-file-id",
-        type: PostContentType.VIDEO,
-      },
-    ],
-    attachmentTags,
-  };
-
-  const { data: post } = await PostRepository.createPost(newPost);
-  return post;
-}
+  ],
+});
 ```
 
 ```dart Flutter
-late PagingController<AmityPost> _controller;
-
-void createVideoPost(List<AmityVideo> uploadedVideos) {
-  AmitySocialClient.newPostRepository()
+Future<AmityPost> createVideoPost(List<AmityVideo> uploadedVideos) {
+  return AmitySocialClient.newPostRepository()
       .createPost()
-      .targetUser('userId')
+      .targetCommunity(communityId)
       .video(uploadedVideos)
-      .text('Check out this video!')
-      .post()
-      .then((AmityPost post) {
-        // Success - add to feed
-        _controller.add(post);
-        print('Video post created successfully');
-      })
-      .onError((error, stackTrace) {
-        print('Error creating video post: $error');
-      });
+      .text('Video from today')
+      .post();
 }
 ```
-
 </CodeGroup>
 
-## Troubleshooting
+## Notes
 
-<AccordionGroup>
-  <Accordion title="Video Upload Failures" icon="upload">
-    **Problem**: Video uploads fail or timeout during upload
-    
-    **Solutions**:
-    - Check file size (must be under 2GB per video)
-    - Verify supported format (mp4, mov, avi, etc.)
-    - Ensure stable internet connection for large files
+- TypeScript accepts video attachments as `{ type: "video", fileId }`.
+- Android accepts a `Set<AmityVideo>`.
+- iOS accepts `[AmityVideoData]`.
+- Flutter accepts `List<AmityVideo>`.
 
-  </Accordion>
-  
-  <Accordion title="Video Quality Issues" icon="video">
-    **Problem**: Videos appear low quality or take long to load
-    
-    **Solutions**:
-    - Upload videos at optimal resolution (1080p recommended)
-    - Use appropriate bitrate (2-5 Mbps for 1080p)
-    - Choose efficient codecs (H.264 recommended)
-    - Consider adaptive bitrate streaming for large videos
-    
-  </Accordion>
-  
-  <Accordion title="HDR Video Support" icon="sun">
-    **Problem**: HDR videos not uploading on iOS
-
-    **Solution**: HDR video formats are not supported on iOS platform. Please convert to standard format.
-
-    ```typescript
-    // Check for HDR and convert if needed
-    if (Platform.OS === 'ios' && videoInfo.isHDR) {
-       convertToStandardFormat(videoFile)
-         .then(convertedFile => {
-           // Proceed with converted file
-         })
-         .catch(error => {
-           console.error('HDR conversion failed:', error);
-         });
-    }
-    ```
-  </Accordion>
-  
-  <Accordion title="Thumbnail Generation" icon="image">
-    **Problem**: Video thumbnails not generating or appearing incorrect
-    
-    **Solutions**:
-    - Wait for video processing to complete before displaying
-
-  </Accordion>
-  
-  <Accordion title="Duration Validation" icon="clock">
-    **Problem**: Videos exceed 2-hour duration limit
-    
-    **Solution**: Validate duration before upload and provide trimming options
-    
-    ```typescript
-    // Validate video duration
-    const validateDuration = (duration) => {
-      const maxDuration = 2 * 60 * 60; // 2 hours in seconds
-      if (duration > maxDuration) {
-        throw new Error('Video duration exceeds 2-hour limit. Please trim the video.');
-      }
-    };
-    ```
-  </Accordion>
-</AccordionGroup>
-
-## Common Use Cases
-
-- **Video Sharing**: Share personal videos and memories
-- **Tutorials**: Create step-by-step instructional content
-- **Live Updates**: Share real-time event footage
-- **Product Demos**: Showcase products in action
-- **Entertainment**: Share funny clips and entertainment content
-- **Educational Content**: Distribute learning materials and lectures
-
-## Related Topics
-
-<CardGroup cols={3}>
-  <Card title="Video Handling" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling" icon="upload">
-    Learn how to upload and manage video files before creating posts
-  </Card>
-  <Card title="Image Posts" href="./image-post" icon="image">
-    Create posts with photos and visual content
-  </Card>
-  <Card title="Audio Posts" href="./audio-post" icon="file-audio">
-    Create posts with audio attachments
-  </Card>
-  <Card title="File Posts" href="./file-post" icon="file">
-    Attach and share document files
-  </Card>
-  <Card title="Mixed Media Posts" href="./mixed-media-post" icon="layer-group">
-    Combine multiple media types in a single post
-  </Card>
-  <Card title="Live Streaming" href="/social-plus-sdk/video-new/broadcasting/overview" icon="circle-video">
-    Create real-time video broadcasts and live content
-  </Card>
-</CardGroup>
+For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).


### PR DESCRIPTION
## Summary
- Rewrite text, image, and video post creation docs around current SDK APIs
- Remove stale iOS repository constructors, invalid TypeScript query/product-tag examples, and unproven media limit/troubleshooting claims from the audited core pages
- Add the three pages to doc-as-test inventories and SDK audit tracker, then regenerate llms outputs

## Validation
- python3 .docs-ops/integration-tests/run-tests.py: 134/134 passed
- python3 .docs-ops/integration-tests/android/run-tests.py: 127/127 passed, 6 skipped, 4 warnings
- python3 .docs-ops/integration-tests/flutter/run-tests.py: 76/76 passed
- python3 .docs-ops/integration-tests/ios/run-tests.py: 122/122 passed, 5 skipped
- python3 tools/check_internal_links.py
- python3 .docs-ops/ci/check-mdx.py
- python3 .docs-ops/ci/check-drift.py --base HEAD --skip-fetch --require-doc-as-test all