### PR TITLE
Audit SDK video broadcasting room docs

### DIFF
--- a/.docs-ops/evals/ts-accuracy-drift.json
+++ b/.docs-ops/evals/ts-accuracy-drift.json
@@ -4,7 +4,7 @@
   "surface_used": ".docs-ops/sdk-surface/typescript.json",
   "stats": {
     "files_scanned": 482,
-    "ts_blocks_scanned": 1366,
+    "ts_blocks_scanned": 1346,
     "files_with_issues": 1,
     "total_issues": 1
   },

--- a/.docs-ops/integration-tests/android/pages.json
+++ b/.docs-ops/integration-tests/android/pages.json
@@ -214,6 +214,9 @@
   "shared": [
     "social-plus-sdk/core-concepts/foundation/logging.mdx",
     "social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx",
+    "social-plus-sdk/video-new/broadcasting/overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/rooms-overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx",
     "social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/realtime-events/",

--- a/.docs-ops/integration-tests/android/results/latest.json
+++ b/.docs-ops/integration-tests/android/results/latest.json
@@ -1,9 +1,9 @@
 {
-  "run_at": "2026-06-21T11:22:46.057427+00:00",
+  "run_at": "2026-06-21T11:55:30.290805+00:00",
   "stats": {
-    "blocks_extracted": 265,
+    "blocks_extracted": 268,
     "blocks_skipped": 3,
-    "blocks_passed": 265,
+    "blocks_passed": 268,
     "blocks_failed": 0,
     "total_warnings": 1,
     "pass_rate": 100.0,
@@ -738,6 +738,12 @@
     },
     "social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx": {
       "passed": 2,
+      "failed": 0,
+      "skipped": 0,
+      "warnings": 0
+    },
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx": {
+      "passed": 3,
       "failed": 0,
       "skipped": 0,
       "warnings": 0

--- a/.docs-ops/integration-tests/flutter/pages.json
+++ b/.docs-ops/integration-tests/flutter/pages.json
@@ -213,6 +213,9 @@
   "shared": [
     "social-plus-sdk/core-concepts/foundation/logging.mdx",
     "social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx",
+    "social-plus-sdk/video-new/broadcasting/overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/rooms-overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx",
     "social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/realtime-events/",

--- a/.docs-ops/integration-tests/flutter/results/latest.json
+++ b/.docs-ops/integration-tests/flutter/results/latest.json
@@ -1,9 +1,9 @@
 {
-  "run_at": "2026-06-21T11:15:40.542198+00:00",
+  "run_at": "2026-06-21T11:48:09.066252+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/Amity-Social-Cloud-SDK-Flutter-Internal",
   "preamble_version": "36859d1b",
   "stats": {
-    "pages_scanned": 155,
+    "pages_scanned": 158,
     "blocks_extracted": 191,
     "blocks_skipped": 0,
     "blocks_passed": 191,

--- a/.docs-ops/integration-tests/ios/pages.json
+++ b/.docs-ops/integration-tests/ios/pages.json
@@ -214,6 +214,9 @@
   "shared": [
     "social-plus-sdk/core-concepts/foundation/logging.mdx",
     "social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx",
+    "social-plus-sdk/video-new/broadcasting/overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/rooms-overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx",
     "social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/realtime-events/",

--- a/.docs-ops/integration-tests/ios/results/latest.json
+++ b/.docs-ops/integration-tests/ios/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-06-21T11:23:41.766399+00:00",
+  "generated_at": "2026-06-21T11:56:28.080389+00:00",
   "toolchain": "swiftc -typecheck",
   "sdk_version": "AmitySDK 8.1.1 (xcframework binary)",
   "xcfw_url": "https://sdk.amity.co/sdk-release/ios-frameworks/8.1.1/AmitySDK.xcframework.zip",
   "stats": {
-    "blocks_extracted": 291,
-    "blocks_passed": 291,
-    "blocks_warned": 291,
+    "blocks_extracted": 294,
+    "blocks_passed": 294,
+    "blocks_warned": 294,
     "blocks_failed": 0,
     "blocks_skipped": 1
   },
@@ -4179,6 +4179,48 @@
       ]
     },
     {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-1.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx",
+      "block_index": 1,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 44,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        }
+      ]
+    },
+    {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-2.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx",
+      "block_index": 2,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 44,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        }
+      ]
+    },
+    {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-3.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx",
+      "block_index": 3,
+      "severity": "warning",
+      "warnings": [
+        {
+          "line": 44,
+          "col": 1,
+          "severity": "warning",
+          "message": "@discardableResult declared on a function returning Void is unnecessary"
+        }
+      ]
+    },
+    {
       "file": "social-plus-sdk__core-concepts__user-management__user-operations__get-user-information-block-1.swift",
       "source_page": "social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx",
       "block_index": 1,
@@ -5753,6 +5795,18 @@
     {
       "file": "social-plus-sdk__core-concepts__safety-privacy__pii-detection-block-1.swift",
       "source_page": "social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx"
+    },
+    {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-1.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx"
+    },
+    {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-2.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx"
+    },
+    {
+      "file": "social-plus-sdk__video-new__broadcasting__create-room-block-3.swift",
+      "source_page": "social-plus-sdk/video-new/broadcasting/create-room.mdx"
     },
     {
       "file": "social-plus-sdk__core-concepts__user-management__user-operations__get-user-information-block-1.swift",

--- a/.docs-ops/integration-tests/pages.json
+++ b/.docs-ops/integration-tests/pages.json
@@ -211,6 +211,9 @@
   "shared": [
     "social-plus-sdk/core-concepts/foundation/logging.mdx",
     "social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx",
+    "social-plus-sdk/video-new/broadcasting/overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/rooms-overview.mdx",
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx",
     "social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/",
     "enumerate:social-plus-sdk/core-concepts/realtime-communication/realtime-events/",

--- a/.docs-ops/integration-tests/results/latest.json
+++ b/.docs-ops/integration-tests/results/latest.json
@@ -1,12 +1,12 @@
 {
-  "run_at": "2026-06-21T11:12:51.476400+00:00",
+  "run_at": "2026-06-21T11:45:16.289579+00:00",
   "sdk_root": "/Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK",
   "preamble_version": "0d813b14",
   "stats": {
-    "pages_scanned": 155,
-    "blocks_extracted": 265,
+    "pages_scanned": 158,
+    "blocks_extracted": 268,
     "blocks_skipped": 0,
-    "blocks_passed": 265,
+    "blocks_passed": 268,
     "blocks_failed": 0,
     "pass_rate": 1.0
   },
@@ -604,6 +604,11 @@
     "social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx": {
       "blocks": 2,
       "passed": 2,
+      "failed": 0
+    },
+    "social-plus-sdk/video-new/broadcasting/create-room.mdx": {
+      "blocks": 3,
+      "passed": 3,
       "failed": 0
     }
   },

--- a/.docs-ops/sdk-audit/tracker.csv
+++ b/.docs-ops/sdk-audit/tracker.csv
@@ -170,12 +170,12 @@ social-plus-sdk/social/user-relationship/overview.mdx,social,user-relationship,v
 social-plus-sdk/technical-faq.mdx,root,,not_started,no,no,no,,,,
 social-plus-sdk/video-new/analytics/overview.mdx,video-new,analytics,not_started,no,no,no,,,,
 social-plus-sdk/video-new/broadcasting/co-host-management.mdx,video-new,broadcasting,not_started,no,no,no,,,,
-social-plus-sdk/video-new/broadcasting/create-room.mdx,video-new,broadcasting,not_started,no,no,no,,,,
+social-plus-sdk/video-new/broadcasting/create-room.mdx,video-new,broadcasting,verified,yes,yes,yes,2026-06-21,codex,"Source: TS RoomRepository createRoom getBroadcasterData types; iOS AmityRoomRepository AmityRoomCreateOptions generateRoomToken; Android AmityVideoClient room repository createRoom getBroadcasterData; Flutter public-source search found no room repository. Proof: full drift gate TS 268/268; Android 268/268 skipped 3 warnings 1; Flutter 191/191; iOS 294/294 skipped 1 warnings 294.","Replaced stale universal RoomRepository examples with platform-specific CodeGroup snippets and parameter table; documented Flutter no public room creation surface."
 social-plus-sdk/video-new/broadcasting/live-viewing.mdx,video-new,broadcasting,not_started,no,no,no,,,,
 social-plus-sdk/video-new/broadcasting/manage-rooms.mdx,video-new,broadcasting,not_started,no,no,no,,,,
-social-plus-sdk/video-new/broadcasting/overview.mdx,video-new,broadcasting,not_started,no,no,no,,,,
+social-plus-sdk/video-new/broadcasting/overview.mdx,video-new,broadcasting,verified,yes,yes,yes,2026-06-21,codex,"Source: TS iOS Android room repository surfaces plus Flutter public-source search. Proof: full drift gate TS 268/268; Android 268/268 skipped 3 warnings 1; Flutter 191/191; iOS 294/294 skipped 1 warnings 294.","Reframed overview around SDK-owned room records broadcaster data and room posts; removed unsupported all-platform and automatic media-stack claims."
 social-plus-sdk/video-new/broadcasting/recorded-playback.mdx,video-new,broadcasting,not_started,no,no,no,,,,
-social-plus-sdk/video-new/broadcasting/rooms-overview.mdx,video-new,broadcasting,not_started,no,no,no,,,,
+social-plus-sdk/video-new/broadcasting/rooms-overview.mdx,video-new,broadcasting,verified,yes,yes,yes,2026-06-21,codex,"Source: TS Amity.Room type; iOS AmityRoom model enums options; Android AmityRoom model query builders; Flutter public-source search. Proof: full drift gate TS 268/268; Android 268/268 skipped 3 warnings 1; Flutter 191/191; iOS 294/294 skipped 1 warnings 294.","Replaced invented model snippets with source-backed platform field tables, room type notes, status model, participant fields, and playback metadata."
 social-plus-sdk/video-new/broadcasting/start-broadcasting.mdx,video-new,broadcasting,not_started,no,no,no,,,,
 social-plus-sdk/video-new/migration-guide.mdx,video-new,,not_started,no,no,no,,,,
 social-plus-sdk/video-new/playback/overview.mdx,video-new,playback,not_started,no,no,no,,,,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9293,1412 +9293,349 @@ The new analytics dashboard provides comprehensive insights into your livestream
 
 ### [Broadcasting Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/overview)
 
-> Introduction to room-based live broadcasting with co-hosting capabilities
+> SDK-backed overview of room-based live broadcasting and co-host rooms.
 
-# Broadcasting Overview
+Room broadcasting is the current SDK path for live rooms, including co-host rooms and direct-streaming room types where the platform exposes them. Treat rooms as the social.plus record for the live session: the SDK creates, observes, updates, stops, and publishes room objects, while your app's media stack connects to the streaming provider with credentials returned by the SDK.
 
-The social.plus Video SDK provides room-based broadcasting: interactive live streaming with co-hosting support across all platforms.
+  This page is about the SDK room APIs. The legacy stream APIs and UIKit-level video experiences are separate surfaces.
 
-## What is Room Broadcasting?
+## Platform Surface
 
-Room broadcasting enables collaborative live streaming where multiple hosts can broadcast together using LiveKit infrastructure. Unlike traditional single-host livestreams, rooms support real-time co-streaming, viewer interaction through live chat, and comprehensive moderation controls.
+| Platform | Current SDK surface | Notes |
+| --- | --- | --- |
+| TypeScript | `RoomRepository` and `PostRepository.createRoomPost()` | Supports room creation, live object/live collection observers, broadcaster data, stop/update/delete, recorded URL lookup, and room posts. |
+| iOS | `AmityRoomRepository`, `AmityRoomCreateOptions`, and `AmityPostRepository.createRoomPost()` | Supports room creation, `AmityObject<AmityRoom>`, `AmityCollection<AmityRoom>`, stop/update/delete, co-host events, room token generation, and room posts. |
+| Android | `AmityVideoClient.newRoomRepository()` and `AmitySocialClient.newPostRepository().createRoomPost()` | Supports room creation, `Flowable<AmityRoom>`, paging room queries, stop/update/delete, broadcaster data, recorded URLs, co-host events, and room posts. |
+| Flutter | No current public room broadcasting repository found in this audit | The Flutter source has older stream APIs such as `AmityStream`, but no public `AmityRoomRepository` or room post creation surface. |
 
-## Key Features
+## What the SDK Owns
 
-    **Multiple broadcasters in one stream**
-    - Invite co-hosts to join the broadcast
-    - Real-time audio/video synchronization
-    - Host and co-host role management
-    **Professional streaming infrastructure**
-    - Low-latency video transmission
-    - Adaptive bitrate streaming
-    - Automatic quality optimization
-    **Real-time viewer engagement**
-    - Integrated chat channels
-    - Host and co-host badges
-    - Moderation tools
-    **Complete content lifecycle**
-    - Automatic recording
-    - Post-broadcast playback
-    - Recording management
+| Concern | SDK-owned | App-owned |
+| --- | --- | --- |
+| Room record | Create, read, query, update, stop, delete where supported | Choose when to create or clean up rooms |
+| Feed distribution | Create a room post from an existing `roomId` where supported | Decide the target feed and product copy |
+| Broadcast credentials | Return broadcaster token or URL data where supported | Hand credentials to your media or LiveKit integration |
+| Live viewing | Expose room playback fields such as live playback URL and thumbnails | Build the player, controls, and viewer UX |
+| Room state | Expose statuses and realtime observers | React to state transitions in UI and operations |
 
-## Room Lifecycle
+## Room Workflow
 
-```mermaid
-graph LR
-    A[Create Room] --> B[Create Post]
-    B --> C[Get Broadcast Data]
-    C --> D[Connect to LiveKit]
-    D --> E[Go Live]
-    E --> F[End Broadcast]
-    F --> G[Recording Available]
+    Create the room with a title and optional room configuration. Use [Create Room](./create-room) for platform-specific examples.
+    Publish the room to a user or community feed with `createRoomPost()`. See [Room Posts](/social-plus-sdk/social/content-management/posts/creation/room-post).
+    Request broadcaster data for the room. TypeScript and Android expose typed broadcaster-data APIs; iOS exposes room token generation.
+    Connect your app's media stack, such as a LiveKit client, using the returned credentials. This connection is outside the social.plus SDK.
+    Observe the room object or room collection for lifecycle changes, then call the stop API when the broadcast ends.
 
-    style A fill:#e3f2fd
-    style E fill:#c8e6c9
-    style G fill:#e1bee7
-```
+## Room Statuses
 
-### Room States
+| Status | Meaning | Platform notes |
+| --- | --- | --- |
+| `idle` | Room exists but is not currently live | Available across TypeScript, iOS, and Android. |
+| `live` | Room is actively broadcasting | Available across TypeScript, iOS, and Android. |
+| `waitingReconnect` | Room is waiting for the broadcaster to reconnect | Available across TypeScript, iOS, and Android. |
+| `ended` | Live session has ended | Available across TypeScript, iOS, and Android. |
+| `recorded` | Recorded playback metadata is available | Available across TypeScript, iOS, and Android. |
+| `terminated` | Room was terminated | Exposed by TypeScript and iOS room status types. |
+| `error` | Room entered an error state | Available across TypeScript, iOS, and Android. |
 
-| Status | Description | Actions Available |
-|--------|-------------|-------------------|
-| **Idle** | Room created but not broadcasting | Start stream, invite co-hosts |
-| **Live** | Room is actively broadcasting | Manage broadcast, invite co-hosts |
-| **Waiting Reconnect** | Temporary disconnection | Auto-reconnect, manual stop |
-| **Ended** | Broadcast finished | Wait for recording |
-| **Recorded** | Recording available | Playback, download |
+## Related Topics
 
-## Broadcasting Workflow
-
-### 1. Create Room
-Set up a room with title, description, and optional configuration.
-
-### 2. Create Room Post
-Link the room to a post for social distribution in feeds or communities.
-
-### 3. Get Broadcaster Data
-Retrieve LiveKit credentials (`coHostToken`, `coHostUrl`) for streaming.
-
-### 4. Connect to LiveKit
-Use the LiveKit SDK to establish the streaming connection.
-
-### 5. Start Broadcasting
-Enable camera and microphone to begin the live broadcast.
-
-### 6. Manage Broadcast
-Invite co-hosts, monitor connection, interact with viewers.
-
-### 7. End Broadcast
-Disconnect from LiveKit and stop the room.
-
-## Platform Support
-
-| Platform | Status | Notes |
-|----------|--------|-------|
-| **iOS** | ✅ Full Support | AVFoundation + LiveKit SDK |
-| **Android** | ✅ Full Support | Camera2 API + LiveKit SDK |
-| **TypeScript/Web** | ✅ Full Support | WebRTC + LiveKit SDK |
-
-## Broadcasting Architecture
-
-The room broadcasting system uses LiveKit for real-time video streaming:
-
-- **Host** creates the room and gets broadcaster credentials
-- **Co-Hosts** are invited and receive their own credentials
-- **Viewers** watch via HLS playback URL (no LiveKit connection needed)
-- **Live Chat** runs through integrated chat channels
-
-## Quick Start
-
-    Use `RoomRepository.createRoom()` to create a new room
-    Create a post linked to the room for visibility
-    Call `getBroadcastData()` to get LiveKit credentials
-    Use LiveKit SDK to connect and publish video/audio tracks
-
-## Next Steps
-
-    Set up a room for broadcasting
-    Connect to LiveKit and go live
-    Invite and manage co-hosts
-    How viewers watch live broadcasts
-    Access recordings after broadcast ends
-    Query, update, and control rooms
+    Review the room model, statuses, participants, and playback fields.
+    Create a room and request broadcaster data with platform-specific SDK snippets.
+    Query, observe, update, stop, and delete room records.
+    Invite, remove, and observe co-host room participants.
+    Use room playback fields to power viewer playback.
+    Access recorded playback metadata after a room is recorded.
 
 ---
 
 ### [Rooms Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/rooms-overview)
 
-> Interactive live rooms with co-hosting, broadcasting, and playback capabilities
+> SDK-backed model overview for live rooms, co-host rooms, playback fields, and room state.
 
-# Rooms Overview
+Rooms are SDK records for live broadcasting sessions. A room can be observed as a single live object or queried as a live collection, then published into a feed by creating a room post from its `roomId`.
 
-Rooms provide an advanced broadcasting infrastructure that enables interactive live streaming with co-hosting capabilities. This page covers the core concepts, data models, and architecture of the room system.
+This page focuses on source-backed room concepts. Use [Create Room](./create-room) for runnable snippets.
 
-## Overview
+## Platform Availability
 
-The Room feature extends traditional livestreaming by supporting collaborative broadcasting where multiple users can participate as co-hosts. Rooms handle video/audio synchronization, participant management, and provide comprehensive moderation controls.
-
-## Key Features
-
-    **Multiple broadcasters in one stream**
-    - Invite co-hosts to join the broadcast
-    - Real-time audio/video synchronization
-    - Host and co-host role management
-    - Participant limit controls
-    **Flexible streaming architectures**
-    - Co-Hosts: Multiple broadcasters with LiveKit
-    - Parent-child room relationships
-    - Isolated or linked chat channels
-    **Complete room state handling**
-    - Idle → Live → Ended lifecycle
-    - Waiting for reconnection states
-    - Live viewing and recorded playback
-    - Automatic cleanup
-    **AI-powered content moderation**
-    - Real-time content flagging
-    - Automatic termination rules
-    - Moderation label tracking
-    - Stream safety controls
+| Platform | Room model | Single room observer | Room list/query | Room post |
+| --- | --- | --- | --- | --- |
+| TypeScript | `Amity.Room` | `RoomRepository.getRoom(roomId, callback)` | `RoomRepository.getRooms(params, callback)` | `PostRepository.createRoomPost()` |
+| iOS | `AmityRoom` | `AmityRoomRepository().getRoom(withId:)` | `AmityRoomRepository().getRooms(with:)` | `AmityPostRepository().createRoomPost()` |
+| Android | `AmityRoom` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `AmityVideoClient.newRoomRepository().getRooms().build().query()` | `AmitySocialClient.newPostRepository().createRoomPost()` |
+| Flutter | No current public `AmityRoom` model found | Not available | Not available | Not available |
 
 ## Room Types
 
-### Co-Hosts Room
-
-Multi-participant broadcasting using LiveKit infrastructure:
-
-```mermaid
-graph TB
-    A[Host Creates Room] --> B[Get Broadcaster Token]
-    B --> C[Host Goes Live]
-    C --> D[Invite Co-Hosts]
-    D --> E[Co-Hosts Join Stream]
-    E --> F[Collaborative Broadcasting]
-    F --> G[End Stream]
-
-    style A fill:#e3f2fd
-    style C fill:#c8e6c9
-    style F fill:#fff9c4
-    style G fill:#ffebee
-```
-
-**Characteristics:**
-- Multiple simultaneous broadcasters
-- Real-time audio/video mixing
-- Interactive participant management
-- Requires LiveKit tokens for each participant
-
-**Use Cases:**
-- Panel discussions
-- Interviews and Q&A sessions
-- Collaborative workshops
-- Multi-host shows
-
-## Room Lifecycle
-
-```mermaid
-graph LR
-    A[Idle] --> B[Live]
-    B --> C[Waiting Reconnect]
-    C --> B
-    B --> D[Ended]
-    D --> E[Recorded]
-
-    style A fill:#e3f2fd
-    style B fill:#c8e6c9
-    style C fill:#fff9c4
-    style D fill:#f5f5f5
-    style E fill:#e1bee7
-```
-
-| Status | Description | Actions Available |
-|--------|-------------|-------------------|
-| **Idle** | Room created but not broadcasting | Start stream, invite co-hosts, delete room |
-| **Live** | Room is actively broadcasting | Stop stream, invite/remove co-hosts, moderate content |
-| **Waiting Reconnect** | Temporary disconnection | Auto-reconnect, manual stop |
-| **Ended** | Broadcast finished | View recording, delete room |
-| **Recorded** | Recording available | Playback, download, delete |
-
-### Status Flow
-
-1. **Creation → Idle**: Room created, awaiting first broadcast
-2. **Idle → Live**: Broadcaster starts streaming
-3. **Live → Waiting Reconnect**: Temporary disconnection (automatic)
-4. **Waiting Reconnect → Live**: Reconnection successful
-5. **Live → Ended**: Broadcast stopped (manual or automatic)
-6. **Ended → Recorded**: Recording processing complete
-
-## Room Participants
-
-Participants represent users who can broadcast in the room:
-
-```swift iOS
-// AmityRoomParticipant structure
-struct AmityRoomParticipant {
-    let type: AmityRoomParticipantType  // .host, .coHost, .unknown
-    let userId: String
-    let userInternalId: String?
-    let user: AmityUser?  // Linked user object
-}
-
-enum AmityRoomParticipantType {
-    case host      // Creator of the room, full control
-    case coHost    // Invited broadcaster, limited controls
-    case unknown   // Unknown participant type
-}
-```
-
-```kotlin Android
-// AmityRoomParticipant structure
-data class AmityRoomParticipant(
-    val type: AmityRoomParticipantType,  // HOST, CO_HOST, UNKNOWN
-    val userId: String,
-    val userInternalId: String?,
-    val user: AmityUser?  // Linked user object
-)
-
-enum class AmityRoomParticipantType {
-    HOST,      // Creator of the room, full control
-    CO_HOST,   // Invited broadcaster, limited controls
-    UNKNOWN    // Unknown participant type
-}
-```
-
-```typescript TypeScript
-interface AmityRoomParticipant {
-  type: ParticipantType;
-  userId: string;
-  userInternalId?: string;
-  user?: AmityUser; // Linked user object
-}
-
-enum ParticipantType {
-  HOST = "host",      // Creator of the room, full control
-  CO_HOST = "coHost", // Invited broadcaster, limited controls
-  UNKNOWN = "unknown" // Unknown participant type
-}
-```
-
-**Participant Roles:**
-
-| Role | Description | Permissions |
-|------|-------------|-------------|
-| **Host** | Creator of the room | Full control, invite/remove co-hosts, end stream |
-| **Co-Host** | Invited broadcaster | Broadcast audio/video, leave stream |
-| **Viewer** | Watching the stream | View only (not a room participant) |
-
-For detailed co-host invitation and management workflows, see [Co-Host Management](./co-host-management).
-
-## Room Targets
-
-Rooms can be created for different contexts:
-
-### Community Room
-
-```swift iOS
-// Community target
-let target = AmityRoomTarget(
-    type: .community,
-    communityId: "community-123",
-    community: community  // Linked AmityCommunity object
-)
-```
-
-```kotlin Android
-// Community target
-val target = AmityRoomTarget(
-    type = AmityRoomTargetType.COMMUNITY,
-    communityId = "community-123",
-    community = community  // Linked AmityCommunity object
-)
-```
-
-```typescript TypeScript
-// Community target
-{
-  type: "community",
-  communityId: "community-123",
-  community: AmityCommunity // Linked object
-}
-```
-
-Broadcast to a specific community's audience.
-
-### User Room
-
-```swift iOS
-// User target
-let target = AmityRoomTarget(
-    type: .user,
-    userId: "user-123",
-    user: user  // Linked AmityUser object
-)
-```
-
-```kotlin Android
-// User target
-val target = AmityRoomTarget(
-    type = AmityRoomTargetType.USER,
-    userId = "user-123",
-    user = user  // Linked AmityUser object
-)
-```
-
-```typescript TypeScript
-// User target
-{
-  type: "user",
-  userId: "user-123",
-  user: AmityUser // Linked object
-}
-```
-
-Broadcast to user's timeline followers.
-
-## Room References
-
-Link rooms to other content types:
-
-**Supported References:**
-- **Community**: Room associated with community content
-- **User**: Room on user's timeline
-- **Event**: Room linked to a scheduled event
-
-```swift iOS
-struct AmityRoomReference {
-    let referenceType: AmityRoomReferenceType  // .community, .user, .event
-    let referenceId: String
-}
-```
-
-```kotlin Android
-data class AmityRoomReference(
-    val referenceType: AmityRoomReferenceType,  // COMMUNITY, USER, EVENT
-    val referenceId: String
-)
-```
-
-```typescript TypeScript
-interface AmityRoomReference {
-  referenceType: string; // "community" | "user" | "event"
-  referenceId: string;
-}
-```
-
-## Channel Integration
-
-Rooms can have integrated live chat channels for viewer interaction. Channels must be manually created after the livestream post is created.
-
-```swift iOS
-// Channel properties on AmityRoom
-let channelEnabled: Bool      // Indicates room supports live chat
-let channelId: String?        // Set after channel is created
-let channel: AmityChannel?    // Linked channel object
-```
-
-```kotlin Android
-// Channel properties on AmityRoom
-val channelEnabled: Boolean      // Indicates room supports live chat
-val channelId: String?           // Set after channel is created
-val channel: AmityChannel?       // Linked channel object
-```
-
-```typescript TypeScript
-// Channel properties on AmityRoom
-{
-  channelEnabled: boolean, // Indicates room supports live chat
-  channelId: string,       // Set after channel is created
-  channel: AmityChannel    // Linked channel object
-}
-```
-
-**Channel Features:**
-- Live chat during broadcast
-- Host/Co-host badges
-- Moderation tools
-- Message history
-
-**Manual Channel Creation Required**: Channels are **not** automatically created. You must create the channel after the post is created, passing both `postId` and `roomId`. See [Create Room - Room with Live Chat Channel](./create-room#room-with-live-chat-channel) for the complete workflow.
-
-## Moderation System
-
-AI-powered moderation monitors room content in real-time:
-
-```swift iOS
-struct AmityRoomModeration {
-    let moderationId: String
-    let roomId: String
-    let flagLabels: [AmityRoomModerationLabel]
-    let terminateLabels: [AmityRoomModerationLabel]
-    let createdAt: Date
-    let updatedAt: Date
-}
-
-struct AmityRoomModerationLabel {
-    let category: String  // e.g., "violence", "nudity", "hate_speech"
-    let detectedAt: Date
-}
-```
-
-```kotlin Android
-data class AmityRoomModeration(
-    val moderationId: String,
-    val roomId: String,
-    val flagLabels: List<AmityRoomModerationLabel>,
-    val terminateLabels: List<AmityRoomModerationLabel>,
-    val createdAt: DateTime,
-    val updatedAt: DateTime
-)
-
-data class AmityRoomModerationLabel(
-    val category: String,  // e.g., "violence", "nudity", "hate_speech"
-    val detectedAt: DateTime
-)
-```
-
-```typescript TypeScript
-interface AmityRoomModeration {
-  moderationId: string;
-  roomId: string;
-  flagLabels: AmityRoomModerationLabel[];
-  terminateLabels: AmityRoomModerationLabel[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface AmityRoomModerationLabel {
-  category: string; // e.g., "violence", "nudity", "hate_speech"
-  detectedAt: string;
-}
-```
-
-**Flag Labels**: Content detected but stream continues
-**Terminate Labels**: Content causes automatic stream termination
-
-**Automatic Termination**: When terminate-level content is detected, the room status changes to "ended" automatically and cannot be restarted.
-
-## Parent-Child Room Relationships
-
-Rooms can have hierarchical relationships for complex streaming scenarios:
-
-```swift iOS
-// Parent-child properties on AmityRoom
-let parentRoomId: String?
-let parentRoom: AmityRoom?       // Linked parent room
-let childRoomIds: [String]       // Array of child room IDs
-```
-
-```kotlin Android
-// Parent-child properties on AmityRoom
-val parentRoomId: String?
-val parentRoom: AmityRoom?           // Linked parent room
-val childRoomIds: List<String>       // Array of child room IDs
-```
-
-```typescript TypeScript
-// Parent-child properties on AmityRoom
-{
-  parentRoomId: string,
-  parentRoom: AmityRoom, // Linked parent room
-  childRoomIds: string[] // Array of child room IDs
-}
-```
-
-**Use Cases:**
-- Breakout sessions from main room
-- Multi-language streams
-- Regional broadcasts
-
-## Room Data Model
-
-Complete room object structure:
-
-```typescript
-interface AmityRoom {
-  roomId: string;
-  type: AmityRoomType; // "coHosts"
-
-  // Target
-  targetType: string;
-  targetId: string;
-  target: AmityRoomTarget;
-
-  // Reference
-  referenceType: string;
-  referenceId: string;
-  reference: AmityRoomReference;
-
-  // Content
-  title: string;
-  description?: string;
-  thumbnailFileId?: string;
-
-  // Status
-  status: AmityRoomStatus;
-
-  // Participants
-  participants: AmityRoomParticipant[];
-
-  // Channel
-  channelEnabled: boolean;
-  channelId?: string;
-  channel?: AmityChannel;
-
-  // Streaming
-  livePlaybackUrl?: string;
-  liveThumbnailUrl?: string;
-  liveResolution?: AmityRoomResolution;
-  durationSeconds?: number;
-
-  // Recorded playback
-  recordedPlaybackInfos?: AmityRoomRecordedPlaybackInfo[];
-  recordedResolution?: AmityRoomResolution;
-
-  // Relationships
-  parentRoomId?: string;
-  parentRoom?: AmityRoom;
-  childRoomIds: string[];
-
-  // Creator
-  creatorId: string;
-  creator?: AmityUser;
-
-  // Timestamps
-  createdAt: string;
-  updatedAt?: string;
-  liveAt?: string;
-  endedAt?: string;
-  recordedAt?: string;
-
-  // Deletion
-  isDeleted: boolean;
-  deletedAt?: string;
-  deletedById?: string;
-  deletedBy?: AmityUser;
-
-  // Moderation
-  moderation?: AmityRoomModeration;
-
-  // Custom data
-  metadata?: Record<string, any>;
-}
-
-interface AmityRoomResolution {
-  aspectRatio?: string;   // e.g. "16:9"
-  width?: number;         // e.g. 1920
-  height?: number;        // e.g. 1080
-}
-
-interface AmityRoomRecordedPlaybackInfo {
-  url: string;
-  thumbnailUrl: string;
-}
-```
-
-### Automatic Thumbnail Generation
-
-The backend automatically generates thumbnail images for live stream sessions. No manual action is required from the stream creator.
-
-| Field | Available When | Description |
-|-------|---------------|-------------|
-| `thumbnailFileId` | Any status | Creator-uploaded cover image |
-| `liveThumbnailUrl` | `live`, `waitingReconnect` | Auto-generated live thumbnail URL from the streaming backend. Available as soon as the room goes live. |
-| `recordedPlaybackInfos[].thumbnailUrl` | `recorded` | Auto-generated thumbnail for recorded playback. Available after recording processing completes. |
-
-The `liveThumbnailUrl` and recorded thumbnails are automatically populated by the backend during the live stream session. You do not need to upload or configure anything for these to be available.
-
-### Resolution Metadata
-
-Resolution metadata is automatically provided by the backend alongside thumbnails:
-
-| Field | Available When | Description |
-|-------|---------------|-------------|
-| `liveResolution` | `live`, `waitingReconnect` | Resolution and aspect ratio of the live stream (e.g., `{ aspectRatio: "16:9", width: 1920, height: 1080 }`) |
-| `recordedResolution` | `recorded` | Resolution and aspect ratio of the recorded stream |
-
-## Integration with Posts
-
-Rooms are linked to posts for social distribution. See [Room Posts](/social-plus-sdk/social/content-management/posts/creation/room-post) for detailed post creation.
-
-```typescript
-// Create room post
-const post = await postRepository.createPost({
-  dataType: PostContentType.ROOM,
-  targetType: 'community',
-  targetId: 'community-123',
-  data: {
-    text: 'Join us live!',
-    roomId: room.roomId,
-    title: room.title
-  }
-});
-
-// Access room from post
-console.log(post.data.room.status); // "live"
-console.log(post.data.room.livePlaybackUrl);
-```
-
-## Best Practices
-
-    Configure rooms appropriately for your use case:
-
-    - Use Co-Hosts type for interactive sessions
-    - Enable channels for viewer interaction
-    - Set clear titles and descriptions
-    - Upload thumbnails before going live
-    - Configure participant limits
-
-    Manage co-hosts effectively:
-
-    - Invite co-hosts before going live
-    - Set clear moderation rules
-    - Monitor participant count
-    - Have backup hosts ready
-    - Test audio/video before live
-
-    Implement safety measures:
-
-    - Review moderation labels regularly
-    - Have moderation guidelines
-    - Monitor flag labels proactively
-    - Respond to violations quickly
-    - Keep logs of moderation events
-
-    Optimize streaming performance:
-
-    - Test network bandwidth
-    - Use appropriate video quality
-    - Monitor connection stability
-    - Have reconnection strategies
-    - Clean up ended rooms
+| Type value | Meaning | Platform notes |
+| --- | --- | --- |
+| `coHosts` | Co-host live room type | TypeScript and iOS accept this value during creation. Android exposes it as `AmityRoomType.CO_HOSTS` for queries, but current `createRoom()` does not expose a room type argument. |
+| `directStreaming` | Direct streaming room type | TypeScript and iOS expose this value. Android exposes it as `AmityRoomType.DIRECT_STREAMING` for queries. |
+
+## Room Fields
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
+| Status | `room.status` | `room.status` | `room.getStatus()` |
+| Title and description | `title`, `description` | `title`, `description` | `getTitle()`, `getDescription()` |
+| Chat channel linkage | `liveChannelEnabled`, `liveChannelId`, `getLiveChat()` | `channelEnabled`, `channelId`, `channel` | `isChannelEnabled()`, `getChannelId()`, `getChannel()` |
+| Feed/post reference | `referenceType`, `referenceId`, `post` | `referenceType`, `referenceId`, `post` | `getReferenceType()`, `getReferenceId()`, `getPost()` |
+| Live playback | `livePlaybackUrl`, `liveThumbnailUrl`, `liveResolution` | `livePlaybackUrl`, `liveThumbnailUrl`, `liveResolution` | `getLivePlaybackUrl()`, `getLiveThumbnailUrl()`, `getLiveResolution()` |
+| Recorded playback | `recordedPlaybackInfos`, `recordedResolution` | `recordedData`, `recordedResolution` | `getRecordedPlaybackInfos()`, `getRecordedResolution()` |
+| Parent and child rooms | `parentRoomId`, `childRoomIds`, `childRooms` | `parentRoomId`, `childRoomIds`, `childRooms` | `getParentRoomId()`, `getChildRoomIds()`, `getChildRooms()` |
+| Creator and deletion | `createdBy`, `isDeleted`, `deletedBy` | `creatorId`, `creator`, `isDeleted`, `deletedById` | `getCreatorId()`, `getCreator()`, `isDeleted()` |
+| Custom metadata | `metadata` | `metadata` | `getMetadata()` |
+| Moderation | `moderation` | `moderation` | `getModeration()` |
+
+  Android's current public `AmityRoom` model does not expose a direct `getType()` accessor even though room type is available in query filters and internal model construction.
+
+## Participants
+
+Participants are users who can broadcast in the room. Viewers are not room participants.
+
+| Field | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Role/type | `type: "host" | "coHost"` | `type: String` | `ParticipantType.HOST`, `ParticipantType.CoHost`, or `ParticipantType.Unknown` |
+| User ID | `userId` | `userId` | `userId` |
+| Internal user ID | `userInternalId` | `userInternalId` | `userInternalId` |
+| Linked user | `user` | `user` | `user` |
+| Product-tag permission | `canManageProductTags` | `canManageProductTags` | `canManageProductTags` |
+
+## Status Model
+
+| Status | Meaning |
+| --- | --- |
+| `idle` | The room exists but is not broadcasting. |
+| `live` | The room is currently broadcasting. |
+| `waitingReconnect` | The live session is waiting for reconnection. |
+| `ended` | The live session has stopped. |
+| `recorded` | Recorded playback metadata is available. |
+| `terminated` | The room was terminated. TypeScript and iOS expose this status. |
+| `error` | The room is in an error state. |
+
+## Room Posts and Feed Distribution
+
+Creating a room does not by itself document a feed post in the SDK examples. To publish the room into a feed, create a room post with the room ID.
+
+    Create a user or community feed post that references an existing room.
+    Create a room before publishing it as a room post.
+
+## Media and Playback Fields
+
+The room model exposes media fields that your app can use for live or recorded playback. The SDK does not render the player for SDK integrations.
+
+| Field | Availability | Use |
+| --- | --- | --- |
+| `livePlaybackUrl` | While live when available | Viewer playback URL. |
+| `liveThumbnailUrl` | Live or reconnecting sessions when available | Live thumbnail generated by the streaming backend. |
+| `liveResolution` | Live or reconnecting sessions when available | Live stream aspect ratio, width, and height. |
+| `recordedPlaybackInfos` / `recordedData` | After recording is available | Recorded playback URL and thumbnail metadata. |
+| `recordedResolution` | After recording is available | Recorded stream aspect ratio, width, and height. |
 
 ## Next Steps
 
-    Set up new rooms for broadcasting
-    Connect to LiveKit and go live
-    Invite and manage co-hosts
-    Watch live streams in real-time
-    Play back recorded streams
-    Query, update, and control rooms
+    Create rooms and retrieve broadcaster data.
+    Observe, query, update, stop, and delete rooms.
+    Manage co-host invitations, removal, and permissions.
+    Read recorded playback fields after processing completes.
 
 ---
 
 ### [Create Room](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/create-room)
 
-> Set up rooms for co-hosting livestreams and collaborative broadcasting
+> Create live rooms and retrieve broadcaster data with the current SDK room APIs.
 
-# Create Room
+Create a room before you publish it to a feed or connect a broadcaster. Room creation stores the room record and initial configuration; creating the feed post and connecting the media layer are separate steps.
 
-Create rooms for interactive livestreaming with co-hosting capabilities, configure participants, and obtain broadcaster credentials for streaming.
-
-## Creating a Room
-
-### Basic Co-Hosts Room
-
-Create a room for collaborative broadcasting with multiple participants:
-
-```swift iOS
-Task { @MainActor in
-    do {
-        let room = try await AmityRoomRepository().createRoom(
-            title: "Product Launch Event",
-            description: "Join us for the unveiling of our latest features",
-            thumbnailFileId: nil,
-            metadata: nil,
-            channelEnabled: true,
-            parentRoomId: nil
-        )
-        print("Room created: \(room.roomId)")
-        print("Status: \(room.status)")
-    } catch {
-        print("Failed to create room: \(error)")
-    }
-}
-```
-
-```kotlin Android
-AmityRoomRepository.createRoom(
-    title = "Product Launch Event",
-    description = "Join us for the unveiling of our latest features",
-    thumbnailFileId = null,
-    metadata = null,
-    channelEnabled = true,
-    parentRoomId = null
-).subscribe(
-    onSuccess = { room ->
-        Log.d("Room", "Created: ${room.roomId}")
-        Log.d("Room", "Status: ${room.status}")
-    },
-    onError = { error ->
-        Log.e("Room", "Failed to create", error)
-    }
-)
-```
-
-```typescript TypeScript
-try {
-    const room = await roomRepository.createRoom({
-        title: "Product Launch Event",
-        description: "Join us for the unveiling of our latest features",
-        thumbnailFileId: null,
-        metadata: null,
-        channelEnabled: true,
-        parentRoomId: null
-    });
-    console.log("Room created:", room.roomId);
-    console.log("Status:", room.status);
-} catch (error) {
-    console.error("Failed to create room:", error);
-}
-```
-
-### Room with Live Chat Channel
-
-To enable live chat for viewer interaction, you must create a live channel **after** creating the room and livestream post. The channel requires both the `postId` and `roomId` to be properly linked.
-
-Channels are **not** automatically created. You must manually create the channel after the post is created, passing both the `postId` and `roomId`.
-
-```swift iOS
-// 1. First create the room
-let room = try await AmityRoomRepository().createRoom(
-    title: "Weekly Q&A Session",
-    description: "Ask us anything about our product",
-    thumbnailFileId: nil,
-    metadata: ["category": "education"],
-    channelEnabled: true,
-    parentRoomId: nil
-)
-
-// 2. Create the livestream post
-let post = try await AmityPostRepository().createLiveStreamPost(
-    targetType: .community,
-    targetId: communityId,
-    roomId: room.roomId,
-    text: "Join our Q&A session!",
-    title: room.title,
-    metadata: nil,
-    mentionUserIds: nil,
-    hashtags: nil
-)
-
-// 3. Create the live chat channel with postId and roomId
-let channelRepository = AmityChatClient.shared.channelRepository
-let channel = try await channelRepository.createChannel(room.title)
-    .live()
-    .postId(postId: post.postId)
-    .roomId(roomId: room.roomId)
-    .build()
-    .create()
-
-print("Live chat channel created: \(channel.channelId)")
-```
-
-```kotlin Android
-// Create room, post, and channel using reactive chain
-AmityRoomRepository.createRoom(
-    title = "Weekly Q&A Session",
-    description = "Ask us anything about our product",
-    thumbnailFileId = null,
-    metadata = mapOf("category" to "education"),
-    channelEnabled = true,
-    parentRoomId = null
-).flatMap { room ->
-    // 2. Create the livestream post
-    AmityPostRepository.createLiveStreamPost(
-        targetType = AmityPostTargetType.COMMUNITY,
-        targetId = communityId,
-        roomId = room.roomId,
-        text = "Join our Q&A session!",
-        title = room.title,
-        metadata = null,
-        mentionUserIds = null,
-        hashtags = null
-    ).map { post -> Pair(room, post) }
-}.flatMap { (room, post) ->
-    // 3. Create the live chat channel with postId and roomId
-    AmityChatClient.newChannelRepository()
-        .createChannel(room.title)
-        .live()
-        .postId(postId = post.postId)
-        .roomId(roomId = room.roomId)
-        .build()
-        .create()
-}.subscribe(
-    { channel ->
-        Log.d("Channel", "Live chat channel created: ${channel.getChannelId()}")
-    },
-    { error ->
-        Log.e("Channel", "Failed to create", error)
-    }
-)
-```
-
-```typescript TypeScript
-// 1. First create the room
-const room = await roomRepository.createRoom({
-    title: "Weekly Q&A Session",
-    description: "Ask us anything about our product",
-    thumbnailFileId: null,
-    metadata: { category: "education" },
-    channelEnabled: true,
-    parentRoomId: null
-});
-
-// 2. Create the livestream post
-const post = await postRepository.createLiveStreamPost({
-    targetType: AmityPostTargetType.COMMUNITY,
-    targetId: communityId,
-    roomId: room.roomId,
-    text: "Join our Q&A session!",
-    title: room.title
-});
-
-// 3. Create the live chat channel with postId and roomId
-const channel = await ChannelRepository.createChannel({
-    displayName: room.title,
-    type: 'live',
-    postId: post.postId,
-    roomId: room.roomId
-});
-
-console.log("Live chat channel created:", channel.channelId);
-```
-
-### Room with Thumbnail
-
-Upload and attach a thumbnail image:
-
-```swift iOS
-// First upload the thumbnail
-let thumbnailData = UIImage(named: "room-cover")?.jpegData(compressionQuality: 0.8)
-let thumbnailFile = try await AmityFileRepository().uploadImage(thumbnailData!)
-
-// Create room with thumbnail
-let room = try await AmityRoomRepository().createRoom(
-    title: "Community Livestream",
-    description: "Join our weekly community gathering",
-    thumbnailFileId: thumbnailFile.fileId,
-    metadata: nil,
-    channelEnabled: true,
-    parentRoomId: nil
-)
-```
-
-```kotlin Android
-// Upload thumbnail and create room using reactive chain
-AmityFileRepository.uploadImage(thumbnailUri)
-    .flatMap { thumbnailFile ->
-        AmityRoomRepository.createRoom(
-            title = "Community Livestream",
-            description = "Join our weekly community gathering",
-            thumbnailFileId = thumbnailFile.fileId,
-            metadata = null,
-            channelEnabled = true,
-            parentRoomId = null
-        )
-    }.subscribe(
-        { room ->
-            Log.d("Room", "Room created with thumbnail: ${room.roomId}")
-        },
-        { error ->
-            Log.e("Room", "Failed to create room", error)
-        }
-    )
-```
-
-```typescript TypeScript
-// First upload the thumbnail
-const thumbnailFile = await fileRepository.uploadImage(thumbnailBlob);
-
-// Create room with thumbnail
-const room = await roomRepository.createRoom({
-    title: "Community Livestream",
-    description: "Join our weekly community gathering",
-    thumbnailFileId: thumbnailFile.fileId,
-    metadata: null,
-    channelEnabled: true,
-    parentRoomId: null
-});
-```
+  Flutter does not currently expose a public room broadcasting repository in the audited SDK source. Use TypeScript, iOS, Android, or a backend-supported flow when your product needs to create rooms.
 
 ## Parameters
 
-    **Type:** `string`
-    **Required:** Yes
-    **Description:** Room title/name
+| Parameter | Required | Platform support | Description |
+| --- | --- | --- | --- |
+| `title` | TypeScript and Android: yes. iOS initializer accepts `nil`; send a title for usable rooms. | TypeScript, iOS, Android | Room title shown in your product experience. |
+| `description` | No | TypeScript, iOS, Android | Optional room description. |
+| `thumbnailFileId` | No | TypeScript, iOS, Android | File ID for an uploaded thumbnail image. |
+| `metadata` | No | TypeScript, iOS, Android | Custom key-value data stored with the room. |
+| `liveChatEnabled` | No | TypeScript, iOS, Android | Whether the room should support live chat linkage. iOS defaults this to `true`. |
+| `parentRoomId` | No | TypeScript, iOS, Android | Parent room ID for room hierarchy scenarios. |
+| `participants` | No | iOS, Android | Initial participant user IDs. TypeScript room creation does not expose this field. |
+| `type` | No | TypeScript, iOS | Room type such as `coHosts` / `.coHosts` or `directStreaming` / `.directStreaming`. Android creation does not expose a type argument. |
 
-    **Guidelines:**
-    - Clear and descriptive
-    - Indicates content or purpose
-    - Recommended max: 100 characters
+## Create a Room
 
-    **Example:**
-```typescript
-title: "Product Roadmap Discussion"
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const { data: room } = await RoomRepository.createRoom({
+  title: "Product Launch Event",
+  description: "Join us for the unveiling of our latest features",
+  liveChatEnabled: true,
+  type: "coHosts",
+  metadata: {
+    category: "education",
+  },
+});
+
+showSuccessMessage(room.roomId);
 ```
 
-    **Type:** `string`
-    **Required:** No
-    **Description:** Detailed room description
+```kotlin Android
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+import com.google.gson.JsonObject
 
-    **Guidelines:**
-    - Provide context about the stream
-    - Mention topics to be covered
-    - Include any prerequisites
-
-    **Example:**
-```typescript
-description: "Join us as we discuss upcoming features and answer your questions"
-```
-
-    **Type:** `string`
-    **Required:** No
-    **Description:** File ID of uploaded thumbnail (cover image)
-
-    **Usage:**
-    1. Upload image using FileRepository
-    2. Use returned fileId in room creation
-
-    **Example:**
-```typescript
-thumbnailFileId: "file-abc123"
-```
-
-    **Automatic Thumbnails**: Even if you don't provide a `thumbnailFileId`, the backend automatically generates a live thumbnail (`liveThumbnailUrl`) once the room goes live, and a recorded thumbnail (`recordedPlaybackInfos[].thumbnailUrl`) after the stream ends. The creator-uploaded thumbnail always takes priority over auto-generated ones. See [Rooms Overview - Automatic Thumbnail Generation](./rooms-overview#automatic-thumbnail-generation) for the full fallback chain.
-
-    **Type:** `object`
-    **Required:** No
-    **Description:** Custom metadata for the room
-
-    **Use Cases:**
-    - Store custom properties
-    - Link to external systems
-    - Track categories or tags
-
-    **Example:**
-```typescript
-metadata: {
-  category: "education",
-  language: "en",
-  eventId: "event-123"
+val metadata = JsonObject().apply {
+    addProperty("category", "education")
 }
+
+AmityVideoClient.newRoomRepository()
+    .createRoom(
+        title = "Product Launch Event",
+        description = "Join us for the unveiling of our latest features",
+        metadata = metadata,
+        liveChatEnabled = true,
+        participants = listOf(userId)
+    )
+    .subscribe(
+        { room -> showSuccessMessage(room.getRoomId()) },
+        { error -> handleGeneralError(error) }
+    )
 ```
-
-    **Type:** `boolean`
-    **Required:** No
-    **Default:** `false`
-    **Description:** Indicates the room supports integrated chat
-
-    **Behavior:**
-    - When `true`, signals that the room supports live chat
-    - You must **manually create** the live channel after creating the post
-    - Use `postId` and `roomId` when creating the channel
-    - See [Room with Live Chat Channel](#room-with-live-chat-channel) for full workflow
-
-    **Example:**
-```typescript
-channelEnabled: true
-```
-
-    **Type:** `string`
-    **Required:** No
-    **Description:** ID of parent room for hierarchical relationships
-
-    **Use Cases:**
-    - Breakout sessions
-    - Multi-language streams
-    - Regional broadcasts
-
-    **Example:**
-```typescript
-parentRoomId: "room-main-session"
-```
-
-## Getting Broadcaster Data
-
-After creating a room, obtain streaming credentials:
 
 ```swift iOS
-Task { @MainActor in
-    do {
-        let broadcasterData = try await AmityRoomRepository().getBroadcastData(
-            roomId: room.roomId
-        )
+let options = AmityRoomCreateOptions(
+    title: "Product Launch Event",
+    description: "Join us for the unveiling of our latest features",
+    metadata: ["category": "education"],
+    liveChatEnabled: true,
+    participants: [userId],
+    type: .coHosts
+)
 
-        // Handle broadcaster data
-        if case .coHosts(let token, let url) = broadcasterData {
-            print("Co-host token: \(token)")
-            print("Co-host URL: \(url)")
-            // Use LiveKit SDK with these credentials
-        }
-    } catch {
-        print("Failed to get broadcaster data: \(error)")
-    }
+let room = try await AmityRoomRepository().createRoom(with: options)
+showSuccessMessage(room.roomId)
+```
+
+
+## Create With Thumbnail or Parent Room
+
+Use `thumbnailFileId` after uploading an image through the file APIs. Use `parentRoomId` only when your product intentionally creates a room hierarchy.
+
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const { data: childRoom } = await RoomRepository.createRoom({
+  title: "Regional Breakout",
+  thumbnailFileId: imageFileId,
+  parentRoomId: roomId,
+  liveChatEnabled: true,
+});
+
+showSuccessMessage(childRoom.roomId);
+```
+
+```kotlin Android
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+
+AmityVideoClient.newRoomRepository()
+    .createRoom(
+        title = "Regional Breakout",
+        thumbnailFileId = imageFileId,
+        parentRoomId = roomId,
+        liveChatEnabled = true
+    )
+    .subscribe(
+        { room -> showSuccessMessage(room.getRoomId()) },
+        { error -> handleGeneralError(error) }
+    )
+```
+
+```swift iOS
+let options = AmityRoomCreateOptions(
+    title: "Regional Breakout",
+    thumbnailFileId: imageFileId,
+    liveChatEnabled: true,
+    parentRoomId: roomId
+)
+
+let childRoom = try await AmityRoomRepository().createRoom(with: options)
+showSuccessMessage(childRoom.roomId)
+```
+
+
+## Get Broadcaster Data
+
+After creating the room, request broadcaster credentials before connecting the media layer. TypeScript and Android expose broadcaster-data APIs. iOS exposes room token generation.
+
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const broadcasterData = await RoomRepository.getBroadcasterData(roomId);
+
+if (broadcasterData.coHostUrl && broadcasterData.coHostToken) {
+  showSuccessMessage(broadcasterData.coHostUrl);
 }
 ```
 
 ```kotlin Android
-AmityRoomRepository.getBroadcasterData(roomId = room.roomId)
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+import com.amity.socialcloud.sdk.model.video.room.AmityRoomBroadcastData
+
+AmityVideoClient.newRoomRepository()
+    .getBroadcasterData(roomId)
     .subscribe(
-        onSuccess = { broadcasterData ->
-            if (broadcasterData is AmityRoomBroadcastData.CoHosts) {
-                Log.d("Broadcast", "Token: ${broadcasterData.coHostToken}")
-                Log.d("Broadcast", "URL: ${broadcasterData.coHostUrl}")
-                // Use LiveKit SDK with these credentials
+        { broadcasterData ->
+            when (broadcasterData) {
+                is AmityRoomBroadcastData.CoHosts -> {
+                    showSuccessMessage(broadcasterData.getCoHostUrl())
+                }
+                is AmityRoomBroadcastData.DirectStreaming -> {
+                    showSuccessMessage(broadcasterData.getDirectStreamUrl())
+                }
             }
         },
-        onError = { error ->
-            Log.e("Broadcast", "Failed to get data", error)
-        }
+        { error -> handleGeneralError(error) }
     )
 ```
-
-```typescript TypeScript
-try {
-    const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-
-    console.log("Co-host token:", broadcasterData.coHostToken);
-    console.log("Co-host URL:", broadcasterData.coHostUrl);
-    // Use LiveKit SDK with these credentials
-} catch (error) {
-    console.error("Failed to get broadcaster data:", error);
-}
-```
-
-**Broadcaster Credentials**: The broadcast data contains credentials needed to start streaming. Use LiveKit SDK with the `coHostToken` and `coHostUrl` to connect to the streaming server.
-
-## Creating Livestream Post
-
-Link the room to a post for social distribution:
 
 ```swift iOS
-Task { @MainActor in
-    do {
-        let post = try await AmityPostRepository().createLiveStreamPost(
-            targetType: .community,
-            targetId: "community-123",
-            roomId: room.roomId,
-            text: "Join us for today's live session!",
-            title: room.title,
-            metadata: nil,
-            mentionUserIds: nil,
-            hashtags: nil
-        )
-        print("Livestream post created: \(post.postId)")
-    } catch {
-        print("Failed to create post: \(error)")
-    }
-}
-```
+let broadcasterData = try await AmityRoomRepository()
+    .generateRoomToken(withId: roomId)
 
-```kotlin Android
-AmityPostRepository.createLiveStreamPost(
-    targetType = AmityPostTargetType.COMMUNITY,
-    targetId = "community-123",
-    roomId = room.roomId,
-    text = "Join us for today's live session!",
-    title = room.title,
-    metadata = null,
-    mentionUserIds = null,
-    hashtags = null
-).subscribe(
-    onSuccess = { post ->
-        Log.d("Post", "Livestream post created: ${post.postId}")
-    },
-    onError = { error ->
-        Log.e("Post", "Failed to create", error)
-    }
-)
-```
+let coHostUrl = broadcasterData?["coHostUrl"] as? String
+let coHostToken = broadcasterData?["coHostToken"] as? String
 
-```typescript TypeScript
-try {
-    const post = await postRepository.createLiveStreamPost({
-        targetType: AmityPostTargetType.COMMUNITY,
-        targetId: "community-123",
-        roomId: room.roomId,
-        text: "Join us for today's live session!",
-        title: room.title,
-        metadata: null,
-        mentionUserIds: null,
-        hashtags: null
-    });
-    console.log("Livestream post created:", post.postId);
-} catch (error) {
-    console.error("Failed to create post:", error);
-}
-```
-
-## Complete Workflow Example
-
-Full room creation, post, channel, and streaming setup:
-
-
-```swift iOS
-Task { @MainActor in
-    do {
-        // 1. Create room
-        let room = try await AmityRoomRepository().createRoom(
-            title: "Product Demo",
-            description: "Live demo of our new features",
-            thumbnailFileId: nil,
-            metadata: nil,
-            channelEnabled: true,
-            parentRoomId: nil
-        )
-
-        // 2. Create livestream post
-        let post = try await AmityPostRepository().createLiveStreamPost(
-            targetType: .community,
-            targetId: communityId,
-            roomId: room.roomId,
-            text: "Going live now! Join us for a product demo.",
-            title: room.title,
-            metadata: nil,
-            mentionUserIds: nil,
-            hashtags: nil
-        )
-
-        // 3. Create live chat channel (must be after post creation)
-        let channelRepository = AmityChatClient.shared.channelRepository
-        let channel = try await channelRepository.createChannel(room.title)
-            .live()
-            .postId(postId: post.postId)
-            .roomId(roomId: room.roomId)
-            .build()
-            .create()
-
-        // 4. Get broadcaster credentials
-        let broadcasterData = try await AmityRoomRepository().getBroadcastData(
-            roomId: room.roomId
-        )
-
-        // 5. Initialize broadcaster (LiveKit example)
-        if case .coHosts(let token, let url) = broadcasterData {
-            try await initializeLiveKitBroadcaster(url: url, token: token)
-        }
-
-        // 6. Start broadcasting
-        try await startStreaming()
-
-        print("Room created and streaming started!")
-        print("Room ID: \(room.roomId)")
-        print("Post ID: \(post.postId)")
-        print("Channel ID: \(channel.channelId)")
-    } catch {
-        print("Failed to create room and start streaming: \(error)")
-    }
-}
-```
-
-```kotlin Android
-fun createRoomAndStartStreaming(
-    communityId: String,
-) {
-    // 1. Create room
-    AmityRoomRepository.createRoom(
-        title = "Product Demo",
-        description = "Live demo of our new features",
-        thumbnailFileId = null,
-        metadata = null,
-        channelEnabled = true,
-        parentRoomId = null
-    ).flatMap { room ->
-        // 2. Create livestream post
-        AmityPostRepository.createLiveStreamPost(
-            targetType = AmityPostTargetType.COMMUNITY,
-            targetId = communityId,
-            roomId = room.roomId,
-            text = "Going live now! Join us for a product demo.",
-            title = room.title,
-            metadata = null,
-            mentionUserIds = null,
-            hashtags = null
-        ).map { post -> Pair(room, post) }
-    }.flatMap { (room, post) ->
-        // 3. Create live chat channel (must be after post creation)
-        AmityChatClient.newChannelRepository()
-            .createChannel(room.title)
-            .live()
-            .postId(postId = post.postId)
-            .roomId(roomId = room.roomId)
-            .build()
-            .create()
-            .map { channel -> Triple(room, post, channel) }
-    }.flatMap { (room, post, channel) ->
-        // 4. Get broadcaster credentials
-        AmityRoomRepository.getBroadcasterData(roomId = room.roomId)
-            .doOnSuccess { broadcasterData ->
-                // 5. Initialize broadcaster (LiveKit example)
-                if (broadcasterData is AmityRoomBroadcastData.CoHosts) {
-                    initializeLiveKitBroadcaster(
-                        url = broadcasterData.coHostUrl,
-                        token = broadcasterData.coHostToken
-                    )
-                }
-
-                // 6. Start broadcasting
-                startStreaming()
-
-                Log.d("Room", "Room created and streaming started!")
-                Log.d("Room", "Room ID: ${room.roomId}")
-                Log.d("Room", "Post ID: ${post.postId}")
-                Log.d("Room", "Channel ID: ${channel.getChannelId()}")
-            }
-    }.subscribe(
-        { },
-        { error ->
-            Log.e("Room", "Failed to create room and start streaming", error)
-        }
-    )
-}
-```
-
-```typescript TypeScript
-async function createRoomAndStartStreaming(
-    communityId: string,
-) {
-    try {
-        // 1. Create room
-        const room = await roomRepository.createRoom({
-            title: "Product Demo",
-            description: "Live demo of our new features",
-            channelEnabled: true
-        });
-
-        // 2. Create livestream post
-        const post = await postRepository.createLiveStreamPost({
-            targetType: AmityPostTargetType.COMMUNITY,
-            targetId: communityId,
-            roomId: room.roomId,
-            text: "Going live now! Join us for a product demo.",
-            title: room.title
-        });
-
-        // 3. Create live chat channel (must be after post creation)
-        const channel = await ChannelRepository.createChannel({
-            displayName: room.title,
-            type: 'live',
-            postId: post.postId,
-            roomId: room.roomId
-        });
-
-        // 4. Get broadcaster credentials
-        const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-
-        // 5. Initialize broadcaster (LiveKit example)
-        if (broadcasterData.type === "coHosts") {
-            await initializeLiveKitBroadcaster(
-                broadcasterData.coHostUrl,
-                broadcasterData.coHostToken
-            );
-        }
-
-        // 6. Start broadcasting
-        await startStreaming();
-
-        console.log("Room created and streaming started!");
-        console.log("Room ID:", room.roomId);
-        console.log("Post ID:", post.postId);
-        console.log("Channel ID:", channel.channelId);
-    } catch (error) {
-        console.error("Failed to create room and start streaming:", error);
-    }
+if let coHostUrl, let coHostToken {
+    showSuccessMessage("\(coHostUrl):\(coHostToken)")
 }
 ```
 
 
-**Important:** The live chat channel must be created **after** the post is created, as it requires the `postId`. The order is: Room → Post → Channel.
+  Use the returned broadcaster data with your media stack, such as a LiveKit client. The social.plus SDK returns room and credential data; it does not publish camera or microphone tracks for your SDK integration.
 
-## Best Practices
+## Publish the Room
 
-    Configure rooms appropriately:
+To show the room in a user or community feed, create a room post from the room ID.
 
-    - Always enable channels for viewer interaction
-    - Upload thumbnails before creating posts
-    - Set clear, descriptive titles
-    - Include relevant metadata for filtering
-    - Validate participant list before creation
+    Create a feed post that references an existing room.
+    Review room fields, statuses, participants, and playback metadata.
 
-    Handle participants effectively:
+## Platform Notes
 
-    - Include all co-hosts in initial creation
-    - Limit participants to reasonable number (3-5)
-    - Verify user IDs exist before adding
-    - Update participant list as needed
-
-    Implement robust error handling:
-
-```typescript
-try {
-    const room = await roomRepository.createRoom(options);
-    const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-    // Proceed with streaming
-} catch (error) {
-    if (error.code === 'INVALID_PARTICIPANTS') {
-        showError("One or more participants are invalid");
-    } else if (error.code === 'QUOTA_EXCEEDED') {
-        showError("Room creation limit reached");
-    } else {
-        showError("Failed to create room");
-    }
-    // Clean up if needed
-}
-```
-
-    Clean up resources appropriately:
-
-    - Delete rooms after streaming ends
-    - Stop streaming before deleting
-    - Handle interrupted streams
-    - Check room status before operations
-
-## Error Handling
-
-```swift iOS
-do {
-    let room = try await AmityRoomRepository().createRoom(
-        title: title,
-        description: description,
-        thumbnailFileId: thumbnailId,
-        metadata: metadata,
-        channelEnabled: true,
-        parentRoomId: nil
-    )
-    // Success
-} catch AmityError.invalidParameter(let message) {
-    showError("Invalid room data: \(message)")
-} catch AmityError.quotaExceeded {
-    showError("Room creation limit reached")
-} catch AmityError.permissionDenied {
-    showError("You don't have permission to create rooms")
-} catch {
-    showError("Failed to create room: \(error.localizedDescription)")
-}
-```
-
-
-```kotlin Android
-AmityRoomRepository.createRoom(/* parameters */)
-    .subscribe(
-        onSuccess = { room -> /* Success */ },
-        onError = { error ->
-            when {
-                error is AmityException && error.code == AmityError.INVALID_PARAMETER.code -> {
-                    showError("Invalid room data: ${error.message}")
-                }
-                error is AmityException && error.code == AmityError.PERMISSION_DENIED.code -> {
-                    showError("You don't have permission to create rooms")
-                }
-                else -> {
-                    showError("Failed to create room: ${error.message}")
-                }
-            }
-        }
-    )
-```
-
-```typescript TypeScript
-try {
-    const room = await roomRepository.createRoom(options);
-    // Success
-} catch (error) {
-    if (error.code === 'INVALID_PARAMETER') {
-        showError(`Invalid room data: ${error.message}`);
-    } else if (error.code === 'QUOTA_EXCEEDED') {
-        showError("Room creation limit reached");
-    } else if (error.code === 'PERMISSION_DENIED') {
-        showError("You don't have permission to create rooms");
-    } else {
-        showError(`Failed to create room: ${error.message}`);
-    }
-}
-```
+- TypeScript exposes `RoomRepository.createRoom()` and returns `Amity.Cached<Amity.Room>`.
+- iOS creates rooms with `AmityRoomCreateOptions` and `AmityRoomRepository().createRoom(with:)`.
+- Android creates rooms with `AmityVideoClient.newRoomRepository().createRoom(...)`.
+- Flutter does not currently expose a public room creation API in the audited SDK source.
 
 ## Related Topics
 
-    Connect to LiveKit and go live
-    Invite and manage co-hosts
-    Update and control rooms
+    Observe, query, update, stop, and delete rooms after creation.
+    Connect the broadcaster after retrieving credentials.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -71,9 +71,9 @@
 
 ## Video — Broadcasting
 
-- [Broadcasting Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/overview): Introduction to room-based live broadcasting with co-hosting capabilities
-- [Rooms Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/rooms-overview): Interactive live rooms with co-hosting, broadcasting, and playback capabilities
-- [Create Room](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/create-room): Set up rooms for co-hosting livestreams and collaborative broadcasting
+- [Broadcasting Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/overview): SDK-backed overview of room-based live broadcasting and co-host rooms.
+- [Rooms Overview](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/rooms-overview): SDK-backed model overview for live rooms, co-host rooms, playback fields, and room state.
+- [Create Room](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/create-room): Create live rooms and retrieve broadcaster data with the current SDK room APIs.
 - [Start Broadcasting](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/start-broadcasting): Connect to LiveKit and start co-streaming with multiple hosts in a room
 - [Live Room Viewing](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/live-viewing): Watch live rooms and handle real-time playback across all platforms
 - [Manage Rooms](https://learn.social.plus/social-plus-sdk/video-new/broadcasting/manage-rooms): Query, update, stop, and delete rooms with comprehensive lifecycle management

--- a/social-plus-sdk/video-new/broadcasting/create-room.mdx
+++ b/social-plus-sdk/video-new/broadcasting/create-room.mdx
@@ -1,792 +1,216 @@
 ---
 title: "Create Room"
-description: "Set up rooms for co-hosting livestreams and collaborative broadcasting"
+description: "Create live rooms and retrieve broadcaster data with the current SDK room APIs."
 ---
 
-# Create Room
-
-Create rooms for interactive livestreaming with co-hosting capabilities, configure participants, and obtain broadcaster credentials for streaming.
-
-## Creating a Room
-
-### Basic Co-Hosts Room
-
-Create a room for collaborative broadcasting with multiple participants:
-
-<CodeGroup>
-```swift iOS
-Task { @MainActor in
-    do {
-        let room = try await AmityRoomRepository().createRoom(
-            title: "Product Launch Event",
-            description: "Join us for the unveiling of our latest features",
-            thumbnailFileId: nil,
-            metadata: nil,
-            channelEnabled: true,
-            parentRoomId: nil
-        )
-        print("Room created: \(room.roomId)")
-        print("Status: \(room.status)")
-    } catch {
-        print("Failed to create room: \(error)")
-    }
-}
-```
-
-```kotlin Android
-AmityRoomRepository.createRoom(
-    title = "Product Launch Event",
-    description = "Join us for the unveiling of our latest features",
-    thumbnailFileId = null,
-    metadata = null,
-    channelEnabled = true,
-    parentRoomId = null
-).subscribe(
-    onSuccess = { room ->
-        Log.d("Room", "Created: ${room.roomId}")
-        Log.d("Room", "Status: ${room.status}")
-    },
-    onError = { error ->
-        Log.e("Room", "Failed to create", error)
-    }
-)
-```
-
-```typescript TypeScript
-try {
-    const room = await roomRepository.createRoom({
-        title: "Product Launch Event",
-        description: "Join us for the unveiling of our latest features",
-        thumbnailFileId: null,
-        metadata: null,
-        channelEnabled: true,
-        parentRoomId: null
-    });
-    console.log("Room created:", room.roomId);
-    console.log("Status:", room.status);
-} catch (error) {
-    console.error("Failed to create room:", error);
-}
-```
-</CodeGroup>
-
-### Room with Live Chat Channel
-
-To enable live chat for viewer interaction, you must create a live channel **after** creating the room and livestream post. The channel requires both the `postId` and `roomId` to be properly linked.
+Create a room before you publish it to a feed or connect a broadcaster. Room creation stores the room record and initial configuration; creating the feed post and connecting the media layer are separate steps.
 
 <Note>
-Channels are **not** automatically created. You must manually create the channel after the post is created, passing both the `postId` and `roomId`.
+  Flutter does not currently expose a public room broadcasting repository in the audited SDK source. Use TypeScript, iOS, Android, or a backend-supported flow when your product needs to create rooms.
 </Note>
-
-<CodeGroup>
-```swift iOS
-// 1. First create the room
-let room = try await AmityRoomRepository().createRoom(
-    title: "Weekly Q&A Session",
-    description: "Ask us anything about our product",
-    thumbnailFileId: nil,
-    metadata: ["category": "education"],
-    channelEnabled: true,
-    parentRoomId: nil
-)
-
-// 2. Create the livestream post
-let post = try await AmityPostRepository().createLiveStreamPost(
-    targetType: .community,
-    targetId: communityId,
-    roomId: room.roomId,
-    text: "Join our Q&A session!",
-    title: room.title,
-    metadata: nil,
-    mentionUserIds: nil,
-    hashtags: nil
-)
-
-// 3. Create the live chat channel with postId and roomId
-let channelRepository = AmityChatClient.shared.channelRepository
-let channel = try await channelRepository.createChannel(room.title)
-    .live()
-    .postId(postId: post.postId)
-    .roomId(roomId: room.roomId)
-    .build()
-    .create()
-
-print("Live chat channel created: \(channel.channelId)")
-```
-
-```kotlin Android
-// Create room, post, and channel using reactive chain
-AmityRoomRepository.createRoom(
-    title = "Weekly Q&A Session",
-    description = "Ask us anything about our product",
-    thumbnailFileId = null,
-    metadata = mapOf("category" to "education"),
-    channelEnabled = true,
-    parentRoomId = null
-).flatMap { room ->
-    // 2. Create the livestream post
-    AmityPostRepository.createLiveStreamPost(
-        targetType = AmityPostTargetType.COMMUNITY,
-        targetId = communityId,
-        roomId = room.roomId,
-        text = "Join our Q&A session!",
-        title = room.title,
-        metadata = null,
-        mentionUserIds = null,
-        hashtags = null
-    ).map { post -> Pair(room, post) }
-}.flatMap { (room, post) ->
-    // 3. Create the live chat channel with postId and roomId
-    AmityChatClient.newChannelRepository()
-        .createChannel(room.title)
-        .live()
-        .postId(postId = post.postId)
-        .roomId(roomId = room.roomId)
-        .build()
-        .create()
-}.subscribe(
-    { channel ->
-        Log.d("Channel", "Live chat channel created: ${channel.getChannelId()}")
-    },
-    { error ->
-        Log.e("Channel", "Failed to create", error)
-    }
-)
-```
-
-```typescript TypeScript
-// 1. First create the room
-const room = await roomRepository.createRoom({
-    title: "Weekly Q&A Session",
-    description: "Ask us anything about our product",
-    thumbnailFileId: null,
-    metadata: { category: "education" },
-    channelEnabled: true,
-    parentRoomId: null
-});
-
-// 2. Create the livestream post
-const post = await postRepository.createLiveStreamPost({
-    targetType: AmityPostTargetType.COMMUNITY,
-    targetId: communityId,
-    roomId: room.roomId,
-    text: "Join our Q&A session!",
-    title: room.title
-});
-
-// 3. Create the live chat channel with postId and roomId
-const channel = await ChannelRepository.createChannel({
-    displayName: room.title,
-    type: 'live',
-    postId: post.postId,
-    roomId: room.roomId
-});
-
-console.log("Live chat channel created:", channel.channelId);
-```
-</CodeGroup>
-
-### Room with Thumbnail
-
-Upload and attach a thumbnail image:
-
-<CodeGroup>
-```swift iOS
-// First upload the thumbnail
-let thumbnailData = UIImage(named: "room-cover")?.jpegData(compressionQuality: 0.8)
-let thumbnailFile = try await AmityFileRepository().uploadImage(thumbnailData!)
-
-// Create room with thumbnail
-let room = try await AmityRoomRepository().createRoom(
-    title: "Community Livestream",
-    description: "Join our weekly community gathering",
-    thumbnailFileId: thumbnailFile.fileId,
-    metadata: nil,
-    channelEnabled: true,
-    parentRoomId: nil
-)
-```
-
-```kotlin Android
-// Upload thumbnail and create room using reactive chain
-AmityFileRepository.uploadImage(thumbnailUri)
-    .flatMap { thumbnailFile ->
-        AmityRoomRepository.createRoom(
-            title = "Community Livestream",
-            description = "Join our weekly community gathering",
-            thumbnailFileId = thumbnailFile.fileId,
-            metadata = null,
-            channelEnabled = true,
-            parentRoomId = null
-        )
-    }.subscribe(
-        { room ->
-            Log.d("Room", "Room created with thumbnail: ${room.roomId}")
-        },
-        { error ->
-            Log.e("Room", "Failed to create room", error)
-        }
-    )
-```
-
-```typescript TypeScript
-// First upload the thumbnail
-const thumbnailFile = await fileRepository.uploadImage(thumbnailBlob);
-
-// Create room with thumbnail
-const room = await roomRepository.createRoom({
-    title: "Community Livestream",
-    description: "Join our weekly community gathering",
-    thumbnailFileId: thumbnailFile.fileId,
-    metadata: null,
-    channelEnabled: true,
-    parentRoomId: null
-});
-```
-</CodeGroup>
 
 ## Parameters
 
-<AccordionGroup>
-  <Accordion title="title" icon="heading">
-    **Type:** `string`  
-    **Required:** Yes  
-    **Description:** Room title/name
-    
-    **Guidelines:**
-    - Clear and descriptive
-    - Indicates content or purpose
-    - Recommended max: 100 characters
-    
-    **Example:**
-    ```typescript
-    title: "Product Roadmap Discussion"
-    ```
-  </Accordion>
-  
-  <Accordion title="description" icon="text">
-    **Type:** `string`  
-    **Required:** No  
-    **Description:** Detailed room description
-    
-    **Guidelines:**
-    - Provide context about the stream
-    - Mention topics to be covered
-    - Include any prerequisites
-    
-    **Example:**
-    ```typescript
-    description: "Join us as we discuss upcoming features and answer your questions"
-    ```
-  </Accordion>
-  
-  <Accordion title="thumbnailFileId" icon="image">
-    **Type:** `string`  
-    **Required:** No  
-    **Description:** File ID of uploaded thumbnail (cover image)
-    
-    **Usage:**
-    1. Upload image using FileRepository
-    2. Use returned fileId in room creation
-    
-    **Example:**
-    ```typescript
-    thumbnailFileId: "file-abc123"
-    ```
+| Parameter | Required | Platform support | Description |
+| --- | --- | --- | --- |
+| `title` | TypeScript and Android: yes. iOS initializer accepts `nil`; send a title for usable rooms. | TypeScript, iOS, Android | Room title shown in your product experience. |
+| `description` | No | TypeScript, iOS, Android | Optional room description. |
+| `thumbnailFileId` | No | TypeScript, iOS, Android | File ID for an uploaded thumbnail image. |
+| `metadata` | No | TypeScript, iOS, Android | Custom key-value data stored with the room. |
+| `liveChatEnabled` | No | TypeScript, iOS, Android | Whether the room should support live chat linkage. iOS defaults this to `true`. |
+| `parentRoomId` | No | TypeScript, iOS, Android | Parent room ID for room hierarchy scenarios. |
+| `participants` | No | iOS, Android | Initial participant user IDs. TypeScript room creation does not expose this field. |
+| `type` | No | TypeScript, iOS | Room type such as `coHosts` / `.coHosts` or `directStreaming` / `.directStreaming`. Android creation does not expose a type argument. |
 
-    <Info>
-    **Automatic Thumbnails**: Even if you don't provide a `thumbnailFileId`, the backend automatically generates a live thumbnail (`liveThumbnailUrl`) once the room goes live, and a recorded thumbnail (`recordedPlaybackInfos[].thumbnailUrl`) after the stream ends. The creator-uploaded thumbnail always takes priority over auto-generated ones. See [Rooms Overview - Automatic Thumbnail Generation](./rooms-overview#automatic-thumbnail-generation) for the full fallback chain.
-    </Info>
-  </Accordion>
-  
-  <Accordion title="metadata" icon="database">
-    **Type:** `object`  
-    **Required:** No  
-    **Description:** Custom metadata for the room
-    
-    **Use Cases:**
-    - Store custom properties
-    - Link to external systems
-    - Track categories or tags
-    
-    **Example:**
-    ```typescript
-    metadata: {
-      category: "education",
-      language: "en",
-      eventId: "event-123"
-    }
-    ```
-  </Accordion>
-  
-  <Accordion title="channelEnabled" icon="comment">
-    **Type:** `boolean`  
-    **Required:** No  
-    **Default:** `false`  
-    **Description:** Indicates the room supports integrated chat
-    
-    **Behavior:**
-    - When `true`, signals that the room supports live chat
-    - You must **manually create** the live channel after creating the post
-    - Use `postId` and `roomId` when creating the channel
-    - See [Room with Live Chat Channel](#room-with-live-chat-channel) for full workflow
-    
-    **Example:**
-    ```typescript
-    channelEnabled: true
-    ```
-  </Accordion>
-  
-  <Accordion title="parentRoomId" icon="diagram-project">
-    **Type:** `string`  
-    **Required:** No  
-    **Description:** ID of parent room for hierarchical relationships
-    
-    **Use Cases:**
-    - Breakout sessions
-    - Multi-language streams
-    - Regional broadcasts
-    
-    **Example:**
-    ```typescript
-    parentRoomId: "room-main-session"
-    ```
-  </Accordion>
-</AccordionGroup>
-
-## Getting Broadcaster Data
-
-After creating a room, obtain streaming credentials:
+## Create a Room
 
 <CodeGroup>
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const { data: room } = await RoomRepository.createRoom({
+  title: "Product Launch Event",
+  description: "Join us for the unveiling of our latest features",
+  liveChatEnabled: true,
+  type: "coHosts",
+  metadata: {
+    category: "education",
+  },
+});
+
+showSuccessMessage(room.roomId);
+```
+
+```kotlin Android
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+import com.google.gson.JsonObject
+
+val metadata = JsonObject().apply {
+    addProperty("category", "education")
+}
+
+AmityVideoClient.newRoomRepository()
+    .createRoom(
+        title = "Product Launch Event",
+        description = "Join us for the unveiling of our latest features",
+        metadata = metadata,
+        liveChatEnabled = true,
+        participants = listOf(userId)
+    )
+    .subscribe(
+        { room -> showSuccessMessage(room.getRoomId()) },
+        { error -> handleGeneralError(error) }
+    )
+```
+
 ```swift iOS
-Task { @MainActor in
-    do {
-        let broadcasterData = try await AmityRoomRepository().getBroadcastData(
-            roomId: room.roomId
-        )
-        
-        // Handle broadcaster data
-        if case .coHosts(let token, let url) = broadcasterData {
-            print("Co-host token: \(token)")
-            print("Co-host URL: \(url)")
-            // Use LiveKit SDK with these credentials
-        }
-    } catch {
-        print("Failed to get broadcaster data: \(error)")
-    }
+let options = AmityRoomCreateOptions(
+    title: "Product Launch Event",
+    description: "Join us for the unveiling of our latest features",
+    metadata: ["category": "education"],
+    liveChatEnabled: true,
+    participants: [userId],
+    type: .coHosts
+)
+
+let room = try await AmityRoomRepository().createRoom(with: options)
+showSuccessMessage(room.roomId)
+```
+
+</CodeGroup>
+
+## Create With Thumbnail or Parent Room
+
+Use `thumbnailFileId` after uploading an image through the file APIs. Use `parentRoomId` only when your product intentionally creates a room hierarchy.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const { data: childRoom } = await RoomRepository.createRoom({
+  title: "Regional Breakout",
+  thumbnailFileId: imageFileId,
+  parentRoomId: roomId,
+  liveChatEnabled: true,
+});
+
+showSuccessMessage(childRoom.roomId);
+```
+
+```kotlin Android
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+
+AmityVideoClient.newRoomRepository()
+    .createRoom(
+        title = "Regional Breakout",
+        thumbnailFileId = imageFileId,
+        parentRoomId = roomId,
+        liveChatEnabled = true
+    )
+    .subscribe(
+        { room -> showSuccessMessage(room.getRoomId()) },
+        { error -> handleGeneralError(error) }
+    )
+```
+
+```swift iOS
+let options = AmityRoomCreateOptions(
+    title: "Regional Breakout",
+    thumbnailFileId: imageFileId,
+    liveChatEnabled: true,
+    parentRoomId: roomId
+)
+
+let childRoom = try await AmityRoomRepository().createRoom(with: options)
+showSuccessMessage(childRoom.roomId)
+```
+
+</CodeGroup>
+
+## Get Broadcaster Data
+
+After creating the room, request broadcaster credentials before connecting the media layer. TypeScript and Android expose broadcaster-data APIs. iOS exposes room token generation.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { RoomRepository } from "@amityco/ts-sdk";
+
+const broadcasterData = await RoomRepository.getBroadcasterData(roomId);
+
+if (broadcasterData.coHostUrl && broadcasterData.coHostToken) {
+  showSuccessMessage(broadcasterData.coHostUrl);
 }
 ```
 
 ```kotlin Android
-AmityRoomRepository.getBroadcasterData(roomId = room.roomId)
+import com.amity.socialcloud.sdk.api.video.AmityVideoClient
+import com.amity.socialcloud.sdk.model.video.room.AmityRoomBroadcastData
+
+AmityVideoClient.newRoomRepository()
+    .getBroadcasterData(roomId)
     .subscribe(
-        onSuccess = { broadcasterData ->
-            if (broadcasterData is AmityRoomBroadcastData.CoHosts) {
-                Log.d("Broadcast", "Token: ${broadcasterData.coHostToken}")
-                Log.d("Broadcast", "URL: ${broadcasterData.coHostUrl}")
-                // Use LiveKit SDK with these credentials
+        { broadcasterData ->
+            when (broadcasterData) {
+                is AmityRoomBroadcastData.CoHosts -> {
+                    showSuccessMessage(broadcasterData.getCoHostUrl())
+                }
+                is AmityRoomBroadcastData.DirectStreaming -> {
+                    showSuccessMessage(broadcasterData.getDirectStreamUrl())
+                }
             }
         },
-        onError = { error ->
-            Log.e("Broadcast", "Failed to get data", error)
-        }
+        { error -> handleGeneralError(error) }
     )
 ```
 
-```typescript TypeScript
-try {
-    const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-    
-    console.log("Co-host token:", broadcasterData.coHostToken);
-    console.log("Co-host URL:", broadcasterData.coHostUrl);
-    // Use LiveKit SDK with these credentials
-} catch (error) {
-    console.error("Failed to get broadcaster data:", error);
+```swift iOS
+let broadcasterData = try await AmityRoomRepository()
+    .generateRoomToken(withId: roomId)
+
+let coHostUrl = broadcasterData?["coHostUrl"] as? String
+let coHostToken = broadcasterData?["coHostToken"] as? String
+
+if let coHostUrl, let coHostToken {
+    showSuccessMessage("\(coHostUrl):\(coHostToken)")
 }
 ```
+
 </CodeGroup>
 
 <Info>
-**Broadcaster Credentials**: The broadcast data contains credentials needed to start streaming. Use LiveKit SDK with the `coHostToken` and `coHostUrl` to connect to the streaming server.
+  Use the returned broadcaster data with your media stack, such as a LiveKit client. The social.plus SDK returns room and credential data; it does not publish camera or microphone tracks for your SDK integration.
 </Info>
 
-## Creating Livestream Post
+## Publish the Room
 
-Link the room to a post for social distribution:
+To show the room in a user or community feed, create a room post from the room ID.
 
-<CodeGroup>
-```swift iOS
-Task { @MainActor in
-    do {
-        let post = try await AmityPostRepository().createLiveStreamPost(
-            targetType: .community,
-            targetId: "community-123",
-            roomId: room.roomId,
-            text: "Join us for today's live session!",
-            title: room.title,
-            metadata: nil,
-            mentionUserIds: nil,
-            hashtags: nil
-        )
-        print("Livestream post created: \(post.postId)")
-    } catch {
-        print("Failed to create post: \(error)")
-    }
-}
-```
+<CardGroup cols={2}>
+  <Card title="Room Posts" icon="newspaper" href="/social-plus-sdk/social/content-management/posts/creation/room-post">
+    Create a feed post that references an existing room.
+  </Card>
+  <Card title="Rooms Overview" icon="circle-info" href="./rooms-overview">
+    Review room fields, statuses, participants, and playback metadata.
+  </Card>
+</CardGroup>
 
-```kotlin Android
-AmityPostRepository.createLiveStreamPost(
-    targetType = AmityPostTargetType.COMMUNITY,
-    targetId = "community-123",
-    roomId = room.roomId,
-    text = "Join us for today's live session!",
-    title = room.title,
-    metadata = null,
-    mentionUserIds = null,
-    hashtags = null
-).subscribe(
-    onSuccess = { post ->
-        Log.d("Post", "Livestream post created: ${post.postId}")
-    },
-    onError = { error ->
-        Log.e("Post", "Failed to create", error)
-    }
-)
-```
+## Platform Notes
 
-```typescript TypeScript
-try {
-    const post = await postRepository.createLiveStreamPost({
-        targetType: AmityPostTargetType.COMMUNITY,
-        targetId: "community-123",
-        roomId: room.roomId,
-        text: "Join us for today's live session!",
-        title: room.title,
-        metadata: null,
-        mentionUserIds: null,
-        hashtags: null
-    });
-    console.log("Livestream post created:", post.postId);
-} catch (error) {
-    console.error("Failed to create post:", error);
-}
-```
-</CodeGroup>
-
-## Complete Workflow Example
-
-Full room creation, post, channel, and streaming setup:
-
-<CodeGroup>
-
-```swift iOS
-Task { @MainActor in
-    do {
-        // 1. Create room
-        let room = try await AmityRoomRepository().createRoom(
-            title: "Product Demo",
-            description: "Live demo of our new features",
-            thumbnailFileId: nil,
-            metadata: nil,
-            channelEnabled: true,
-            parentRoomId: nil
-        )
-        
-        // 2. Create livestream post
-        let post = try await AmityPostRepository().createLiveStreamPost(
-            targetType: .community,
-            targetId: communityId,
-            roomId: room.roomId,
-            text: "Going live now! Join us for a product demo.",
-            title: room.title,
-            metadata: nil,
-            mentionUserIds: nil,
-            hashtags: nil
-        )
-        
-        // 3. Create live chat channel (must be after post creation)
-        let channelRepository = AmityChatClient.shared.channelRepository
-        let channel = try await channelRepository.createChannel(room.title)
-            .live()
-            .postId(postId: post.postId)
-            .roomId(roomId: room.roomId)
-            .build()
-            .create()
-        
-        // 4. Get broadcaster credentials
-        let broadcasterData = try await AmityRoomRepository().getBroadcastData(
-            roomId: room.roomId
-        )
-        
-        // 5. Initialize broadcaster (LiveKit example)
-        if case .coHosts(let token, let url) = broadcasterData {
-            try await initializeLiveKitBroadcaster(url: url, token: token)
-        }
-        
-        // 6. Start broadcasting
-        try await startStreaming()
-        
-        print("Room created and streaming started!")
-        print("Room ID: \(room.roomId)")
-        print("Post ID: \(post.postId)")
-        print("Channel ID: \(channel.channelId)")
-    } catch {
-        print("Failed to create room and start streaming: \(error)")
-    }
-}
-```
-
-```kotlin Android
-fun createRoomAndStartStreaming(
-    communityId: String,
-) {
-    // 1. Create room
-    AmityRoomRepository.createRoom(
-        title = "Product Demo",
-        description = "Live demo of our new features",
-        thumbnailFileId = null,
-        metadata = null,
-        channelEnabled = true,
-        parentRoomId = null
-    ).flatMap { room ->
-        // 2. Create livestream post
-        AmityPostRepository.createLiveStreamPost(
-            targetType = AmityPostTargetType.COMMUNITY,
-            targetId = communityId,
-            roomId = room.roomId,
-            text = "Going live now! Join us for a product demo.",
-            title = room.title,
-            metadata = null,
-            mentionUserIds = null,
-            hashtags = null
-        ).map { post -> Pair(room, post) }
-    }.flatMap { (room, post) ->
-        // 3. Create live chat channel (must be after post creation)
-        AmityChatClient.newChannelRepository()
-            .createChannel(room.title)
-            .live()
-            .postId(postId = post.postId)
-            .roomId(roomId = room.roomId)
-            .build()
-            .create()
-            .map { channel -> Triple(room, post, channel) }
-    }.flatMap { (room, post, channel) ->
-        // 4. Get broadcaster credentials
-        AmityRoomRepository.getBroadcasterData(roomId = room.roomId)
-            .doOnSuccess { broadcasterData ->
-                // 5. Initialize broadcaster (LiveKit example)
-                if (broadcasterData is AmityRoomBroadcastData.CoHosts) {
-                    initializeLiveKitBroadcaster(
-                        url = broadcasterData.coHostUrl,
-                        token = broadcasterData.coHostToken
-                    )
-                }
-                
-                // 6. Start broadcasting
-                startStreaming()
-                
-                Log.d("Room", "Room created and streaming started!")
-                Log.d("Room", "Room ID: ${room.roomId}")
-                Log.d("Room", "Post ID: ${post.postId}")
-                Log.d("Room", "Channel ID: ${channel.getChannelId()}")
-            }
-    }.subscribe(
-        { },
-        { error ->
-            Log.e("Room", "Failed to create room and start streaming", error)
-        }
-    )
-}
-```
-
-```typescript TypeScript
-async function createRoomAndStartStreaming(
-    communityId: string,
-) {
-    try {
-        // 1. Create room
-        const room = await roomRepository.createRoom({
-            title: "Product Demo",
-            description: "Live demo of our new features",
-            channelEnabled: true
-        });
-
-        // 2. Create livestream post
-        const post = await postRepository.createLiveStreamPost({
-            targetType: AmityPostTargetType.COMMUNITY,
-            targetId: communityId,
-            roomId: room.roomId,
-            text: "Going live now! Join us for a product demo.",
-            title: room.title
-        });
-
-        // 3. Create live chat channel (must be after post creation)
-        const channel = await ChannelRepository.createChannel({
-            displayName: room.title,
-            type: 'live',
-            postId: post.postId,
-            roomId: room.roomId
-        });
-
-        // 4. Get broadcaster credentials
-        const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-
-        // 5. Initialize broadcaster (LiveKit example)
-        if (broadcasterData.type === "coHosts") {
-            await initializeLiveKitBroadcaster(
-                broadcasterData.coHostUrl,
-                broadcasterData.coHostToken
-            );
-        }
-
-        // 6. Start broadcasting
-        await startStreaming();
-
-        console.log("Room created and streaming started!");
-        console.log("Room ID:", room.roomId);
-        console.log("Post ID:", post.postId);
-        console.log("Channel ID:", channel.channelId);
-    } catch (error) {
-        console.error("Failed to create room and start streaming:", error);
-    }
-}
-```
-
-</CodeGroup>
-
-<Warning>
-**Important:** The live chat channel must be created **after** the post is created, as it requires the `postId`. The order is: Room → Post → Channel.
-</Warning>
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Room Configuration" icon="sliders">
-    Configure rooms appropriately:
-    
-    - Always enable channels for viewer interaction
-    - Upload thumbnails before creating posts
-    - Set clear, descriptive titles
-    - Include relevant metadata for filtering
-    - Validate participant list before creation
-  </Accordion>
-  
-  <Accordion title="Participant Management" icon="user-plus">
-    Handle participants effectively:
-    
-    - Include all co-hosts in initial creation
-    - Limit participants to reasonable number (3-5)
-    - Verify user IDs exist before adding
-    - Update participant list as needed
-  </Accordion>
-  
-  <Accordion title="Error Handling" icon="triangle-exclamation">
-    Implement robust error handling:
-    
-    ```typescript
-    try {
-        const room = await roomRepository.createRoom(options);
-        const broadcasterData = await roomRepository.getBroadcastData(room.roomId);
-        // Proceed with streaming
-    } catch (error) {
-        if (error.code === 'INVALID_PARTICIPANTS') {
-            showError("One or more participants are invalid");
-        } else if (error.code === 'QUOTA_EXCEEDED') {
-            showError("Room creation limit reached");
-        } else {
-            showError("Failed to create room");
-        }
-        // Clean up if needed
-    }
-    ```
-  </Accordion>
-  
-  <Accordion title="Resource Cleanup" icon="broom">
-    Clean up resources appropriately:
-    
-    - Delete rooms after streaming ends
-    - Stop streaming before deleting
-    - Handle interrupted streams
-    - Check room status before operations
-  </Accordion>
-</AccordionGroup>
-
-## Error Handling
-
-<CodeGroup>
-```swift iOS
-do {
-    let room = try await AmityRoomRepository().createRoom(
-        title: title,
-        description: description,
-        thumbnailFileId: thumbnailId,
-        metadata: metadata,
-        channelEnabled: true,
-        parentRoomId: nil
-    )
-    // Success
-} catch AmityError.invalidParameter(let message) {
-    showError("Invalid room data: \(message)")
-} catch AmityError.quotaExceeded {
-    showError("Room creation limit reached")
-} catch AmityError.permissionDenied {
-    showError("You don't have permission to create rooms")
-} catch {
-    showError("Failed to create room: \(error.localizedDescription)")
-}
-```
-
-
-```kotlin Android
-AmityRoomRepository.createRoom(/* parameters */)
-    .subscribe(
-        onSuccess = { room -> /* Success */ },
-        onError = { error ->
-            when {
-                error is AmityException && error.code == AmityError.INVALID_PARAMETER.code -> {
-                    showError("Invalid room data: ${error.message}")
-                }
-                error is AmityException && error.code == AmityError.PERMISSION_DENIED.code -> {
-                    showError("You don't have permission to create rooms")
-                }
-                else -> {
-                    showError("Failed to create room: ${error.message}")
-                }
-            }
-        }
-    )
-```
-
-```typescript TypeScript
-try {
-    const room = await roomRepository.createRoom(options);
-    // Success
-} catch (error) {
-    if (error.code === 'INVALID_PARAMETER') {
-        showError(`Invalid room data: ${error.message}`);
-    } else if (error.code === 'QUOTA_EXCEEDED') {
-        showError("Room creation limit reached");
-    } else if (error.code === 'PERMISSION_DENIED') {
-        showError("You don't have permission to create rooms");
-    } else {
-        showError(`Failed to create room: ${error.message}`);
-    }
-}
-```
-</CodeGroup>
+- TypeScript exposes `RoomRepository.createRoom()` and returns `Amity.Cached<Amity.Room>`.
+- iOS creates rooms with `AmityRoomCreateOptions` and `AmityRoomRepository().createRoom(with:)`.
+- Android creates rooms with `AmityVideoClient.newRoomRepository().createRoom(...)`.
+- Flutter does not currently expose a public room creation API in the audited SDK source.
 
 ## Related Topics
 
-<CardGroup cols={3}>
-  <Card title="Start Broadcasting" href="./start-broadcasting" icon="play">
-    Connect to LiveKit and go live
+<CardGroup cols={2}>
+  <Card title="Manage Rooms" icon="gear" href="./manage-rooms">
+    Observe, query, update, stop, and delete rooms after creation.
   </Card>
-  <Card title="Co-Host Management" href="./co-host-management" icon="users">
-    Invite and manage co-hosts
-  </Card>
-  <Card title="Manage Rooms" href="./manage-rooms" icon="gear">
-    Update and control rooms
+  <Card title="Start Broadcasting" icon="play" href="./start-broadcasting">
+    Connect the broadcaster after retrieving credentials.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/video-new/broadcasting/overview.mdx
+++ b/social-plus-sdk/video-new/broadcasting/overview.mdx
@@ -1,147 +1,84 @@
 ---
 title: "Broadcasting Overview"
-description: "Introduction to room-based live broadcasting with co-hosting capabilities"
+description: "SDK-backed overview of room-based live broadcasting and co-host rooms."
 ---
 
-# Broadcasting Overview
+Room broadcasting is the current SDK path for live rooms, including co-host rooms and direct-streaming room types where the platform exposes them. Treat rooms as the social.plus record for the live session: the SDK creates, observes, updates, stops, and publishes room objects, while your app's media stack connects to the streaming provider with credentials returned by the SDK.
 
-The social.plus Video SDK provides room-based broadcasting: interactive live streaming with co-hosting support across all platforms.
+<Note>
+  This page is about the SDK room APIs. The legacy stream APIs and UIKit-level video experiences are separate surfaces.
+</Note>
 
-## What is Room Broadcasting?
+## Platform Surface
 
-Room broadcasting enables collaborative live streaming where multiple hosts can broadcast together using LiveKit infrastructure. Unlike traditional single-host livestreams, rooms support real-time co-streaming, viewer interaction through live chat, and comprehensive moderation controls.
+| Platform | Current SDK surface | Notes |
+| --- | --- | --- |
+| TypeScript | `RoomRepository` and `PostRepository.createRoomPost()` | Supports room creation, live object/live collection observers, broadcaster data, stop/update/delete, recorded URL lookup, and room posts. |
+| iOS | `AmityRoomRepository`, `AmityRoomCreateOptions`, and `AmityPostRepository.createRoomPost()` | Supports room creation, `AmityObject<AmityRoom>`, `AmityCollection<AmityRoom>`, stop/update/delete, co-host events, room token generation, and room posts. |
+| Android | `AmityVideoClient.newRoomRepository()` and `AmitySocialClient.newPostRepository().createRoomPost()` | Supports room creation, `Flowable<AmityRoom>`, paging room queries, stop/update/delete, broadcaster data, recorded URLs, co-host events, and room posts. |
+| Flutter | No current public room broadcasting repository found in this audit | The Flutter source has older stream APIs such as `AmityStream`, but no public `AmityRoomRepository` or room post creation surface. |
 
-## Key Features
+## What the SDK Owns
 
-<CardGroup cols={2}>
-  <Card title="Co-Hosting" icon="users">
-    **Multiple broadcasters in one stream**
-    - Invite co-hosts to join the broadcast
-    - Real-time audio/video synchronization
-    - Host and co-host role management
-  </Card>
-  <Card title="LiveKit Integration" icon="signal-stream">
-    **Professional streaming infrastructure**
-    - Low-latency video transmission
-    - Adaptive bitrate streaming
-    - Automatic quality optimization
-  </Card>
-  <Card title="Live Chat" icon="comments">
-    **Real-time viewer engagement**
-    - Integrated chat channels
-    - Host and co-host badges
-    - Moderation tools
-  </Card>
-  <Card title="Recording & Playback" icon="video">
-    **Complete content lifecycle**
-    - Automatic recording
-    - Post-broadcast playback
-    - Recording management
-  </Card>
-</CardGroup>
+| Concern | SDK-owned | App-owned |
+| --- | --- | --- |
+| Room record | Create, read, query, update, stop, delete where supported | Choose when to create or clean up rooms |
+| Feed distribution | Create a room post from an existing `roomId` where supported | Decide the target feed and product copy |
+| Broadcast credentials | Return broadcaster token or URL data where supported | Hand credentials to your media or LiveKit integration |
+| Live viewing | Expose room playback fields such as live playback URL and thumbnails | Build the player, controls, and viewer UX |
+| Room state | Expose statuses and realtime observers | React to state transitions in UI and operations |
 
-## Room Lifecycle
-
-```mermaid
-graph LR
-    A[Create Room] --> B[Create Post]
-    B --> C[Get Broadcast Data]
-    C --> D[Connect to LiveKit]
-    D --> E[Go Live]
-    E --> F[End Broadcast]
-    F --> G[Recording Available]
-    
-    style A fill:#e3f2fd
-    style E fill:#c8e6c9
-    style G fill:#e1bee7
-```
-
-### Room States
-
-| Status | Description | Actions Available |
-|--------|-------------|-------------------|
-| **Idle** | Room created but not broadcasting | Start stream, invite co-hosts |
-| **Live** | Room is actively broadcasting | Manage broadcast, invite co-hosts |
-| **Waiting Reconnect** | Temporary disconnection | Auto-reconnect, manual stop |
-| **Ended** | Broadcast finished | Wait for recording |
-| **Recorded** | Recording available | Playback, download |
-
-## Broadcasting Workflow
-
-### 1. Create Room
-Set up a room with title, description, and optional configuration.
-
-### 2. Create Room Post
-Link the room to a post for social distribution in feeds or communities.
-
-### 3. Get Broadcaster Data
-Retrieve LiveKit credentials (`coHostToken`, `coHostUrl`) for streaming.
-
-### 4. Connect to LiveKit
-Use the LiveKit SDK to establish the streaming connection.
-
-### 5. Start Broadcasting
-Enable camera and microphone to begin the live broadcast.
-
-### 6. Manage Broadcast
-Invite co-hosts, monitor connection, interact with viewers.
-
-### 7. End Broadcast
-Disconnect from LiveKit and stop the room.
-
-## Platform Support
-
-| Platform | Status | Notes |
-|----------|--------|-------|
-| **iOS** | ✅ Full Support | AVFoundation + LiveKit SDK |
-| **Android** | ✅ Full Support | Camera2 API + LiveKit SDK |
-| **TypeScript/Web** | ✅ Full Support | WebRTC + LiveKit SDK |
-
-## Broadcasting Architecture
-
-The room broadcasting system uses LiveKit for real-time video streaming:
-
-- **Host** creates the room and gets broadcaster credentials
-- **Co-Hosts** are invited and receive their own credentials
-- **Viewers** watch via HLS playback URL (no LiveKit connection needed)
-- **Live Chat** runs through integrated chat channels
-
-## Quick Start
+## Room Workflow
 
 <Steps>
-  <Step title="Create a Room">
-    Use `RoomRepository.createRoom()` to create a new room
+  <Step title="Create a room">
+    Create the room with a title and optional room configuration. Use [Create Room](./create-room) for platform-specific examples.
   </Step>
-  <Step title="Create a Room Post">
-    Create a post linked to the room for visibility
+  <Step title="Publish a room post">
+    Publish the room to a user or community feed with `createRoomPost()`. See [Room Posts](/social-plus-sdk/social/content-management/posts/creation/room-post).
   </Step>
-  <Step title="Get Broadcaster Data">
-    Call `getBroadcastData()` to get LiveKit credentials
+  <Step title="Get broadcaster data">
+    Request broadcaster data for the room. TypeScript and Android expose typed broadcaster-data APIs; iOS exposes room token generation.
   </Step>
-  <Step title="Connect & Broadcast">
-    Use LiveKit SDK to connect and publish video/audio tracks
+  <Step title="Connect the media layer">
+    Connect your app's media stack, such as a LiveKit client, using the returned credentials. This connection is outside the social.plus SDK.
+  </Step>
+  <Step title="Observe and stop the room">
+    Observe the room object or room collection for lifecycle changes, then call the stop API when the broadcast ends.
   </Step>
 </Steps>
 
-## Next Steps
+## Room Statuses
+
+| Status | Meaning | Platform notes |
+| --- | --- | --- |
+| `idle` | Room exists but is not currently live | Available across TypeScript, iOS, and Android. |
+| `live` | Room is actively broadcasting | Available across TypeScript, iOS, and Android. |
+| `waitingReconnect` | Room is waiting for the broadcaster to reconnect | Available across TypeScript, iOS, and Android. |
+| `ended` | Live session has ended | Available across TypeScript, iOS, and Android. |
+| `recorded` | Recorded playback metadata is available | Available across TypeScript, iOS, and Android. |
+| `terminated` | Room was terminated | Exposed by TypeScript and iOS room status types. |
+| `error` | Room entered an error state | Available across TypeScript, iOS, and Android. |
+
+## Related Topics
 
 <CardGroup cols={2}>
-  <Card title="Create Room" href="./create-room" icon="plus">
-    Set up a room for broadcasting
+  <Card title="Rooms Overview" icon="circle-info" href="./rooms-overview">
+    Review the room model, statuses, participants, and playback fields.
   </Card>
-  <Card title="Start Broadcasting" href="./start-broadcasting" icon="play">
-    Connect to LiveKit and go live
+  <Card title="Create Room" icon="plus" href="./create-room">
+    Create a room and request broadcaster data with platform-specific SDK snippets.
   </Card>
-  <Card title="Co-Host Management" href="./co-host-management" icon="users">
-    Invite and manage co-hosts
+  <Card title="Manage Rooms" icon="gear" href="./manage-rooms">
+    Query, observe, update, stop, and delete room records.
   </Card>
-  <Card title="Live Viewing" href="./live-viewing" icon="eye">
-    How viewers watch live broadcasts
+  <Card title="Co-Host Management" icon="users" href="./co-host-management">
+    Invite, remove, and observe co-host room participants.
   </Card>
-  <Card title="Recorded Playback" href="./recorded-playback" icon="video">
-    Access recordings after broadcast ends
+  <Card title="Live Viewing" icon="eye" href="./live-viewing">
+    Use room playback fields to power viewer playback.
   </Card>
-  <Card title="Manage Rooms" href="./manage-rooms" icon="gear">
-    Query, update, and control rooms
+  <Card title="Recorded Playback" icon="video" href="./recorded-playback">
+    Access recorded playback metadata after a room is recorded.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/video-new/broadcasting/rooms-overview.mdx
+++ b/social-plus-sdk/video-new/broadcasting/rooms-overview.mdx
@@ -1,610 +1,110 @@
 ---
 title: "Rooms Overview"
-description: "Interactive live rooms with co-hosting, broadcasting, and playback capabilities"
+description: "SDK-backed model overview for live rooms, co-host rooms, playback fields, and room state."
 ---
 
-# Rooms Overview
+Rooms are SDK records for live broadcasting sessions. A room can be observed as a single live object or queried as a live collection, then published into a feed by creating a room post from its `roomId`.
 
-Rooms provide an advanced broadcasting infrastructure that enables interactive live streaming with co-hosting capabilities. This page covers the core concepts, data models, and architecture of the room system.
+This page focuses on source-backed room concepts. Use [Create Room](./create-room) for runnable snippets.
 
-## Overview
+## Platform Availability
 
-The Room feature extends traditional livestreaming by supporting collaborative broadcasting where multiple users can participate as co-hosts. Rooms handle video/audio synchronization, participant management, and provide comprehensive moderation controls.
-
-## Key Features
-
-<CardGroup cols={2}>
-  <Card title="Co-Hosting" icon="users">
-    **Multiple broadcasters in one stream**
-    - Invite co-hosts to join the broadcast
-    - Real-time audio/video synchronization
-    - Host and co-host role management
-    - Participant limit controls
-  </Card>
-  <Card title="Room Types" icon="diagram-project">
-    **Flexible streaming architectures**
-    - Co-Hosts: Multiple broadcasters with LiveKit
-    - Parent-child room relationships
-    - Isolated or linked chat channels
-  </Card>
-  <Card title="Lifecycle Management" icon="rotate">
-    **Complete room state handling**
-    - Idle → Live → Ended lifecycle
-    - Waiting for reconnection states
-    - Live viewing and recorded playback
-    - Automatic cleanup
-  </Card>
-  <Card title="Moderation & Safety" icon="shield-halved">
-    **AI-powered content moderation**
-    - Real-time content flagging
-    - Automatic termination rules
-    - Moderation label tracking
-    - Stream safety controls
-  </Card>
-</CardGroup>
+| Platform | Room model | Single room observer | Room list/query | Room post |
+| --- | --- | --- | --- | --- |
+| TypeScript | `Amity.Room` | `RoomRepository.getRoom(roomId, callback)` | `RoomRepository.getRooms(params, callback)` | `PostRepository.createRoomPost()` |
+| iOS | `AmityRoom` | `AmityRoomRepository().getRoom(withId:)` | `AmityRoomRepository().getRooms(with:)` | `AmityPostRepository().createRoomPost()` |
+| Android | `AmityRoom` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `AmityVideoClient.newRoomRepository().getRooms().build().query()` | `AmitySocialClient.newPostRepository().createRoomPost()` |
+| Flutter | No current public `AmityRoom` model found | Not available | Not available | Not available |
 
 ## Room Types
 
-### Co-Hosts Room
+| Type value | Meaning | Platform notes |
+| --- | --- | --- |
+| `coHosts` | Co-host live room type | TypeScript and iOS accept this value during creation. Android exposes it as `AmityRoomType.CO_HOSTS` for queries, but current `createRoom()` does not expose a room type argument. |
+| `directStreaming` | Direct streaming room type | TypeScript and iOS expose this value. Android exposes it as `AmityRoomType.DIRECT_STREAMING` for queries. |
 
-Multi-participant broadcasting using LiveKit infrastructure:
+## Room Fields
 
-```mermaid
-graph TB
-    A[Host Creates Room] --> B[Get Broadcaster Token]
-    B --> C[Host Goes Live]
-    C --> D[Invite Co-Hosts]
-    D --> E[Co-Hosts Join Stream]
-    E --> F[Collaborative Broadcasting]
-    F --> G[End Stream]
-    
-    style A fill:#e3f2fd
-    style C fill:#c8e6c9
-    style F fill:#fff9c4
-    style G fill:#ffebee
-```
-
-**Characteristics:**
-- Multiple simultaneous broadcasters
-- Real-time audio/video mixing
-- Interactive participant management
-- Requires LiveKit tokens for each participant
-
-**Use Cases:**
-- Panel discussions
-- Interviews and Q&A sessions
-- Collaborative workshops
-- Multi-host shows
-
-## Room Lifecycle
-
-```mermaid
-graph LR
-    A[Idle] --> B[Live]
-    B --> C[Waiting Reconnect]
-    C --> B
-    B --> D[Ended]
-    D --> E[Recorded]
-    
-    style A fill:#e3f2fd
-    style B fill:#c8e6c9
-    style C fill:#fff9c4
-    style D fill:#f5f5f5
-    style E fill:#e1bee7
-```
-
-| Status | Description | Actions Available |
-|--------|-------------|-------------------|
-| **Idle** | Room created but not broadcasting | Start stream, invite co-hosts, delete room |
-| **Live** | Room is actively broadcasting | Stop stream, invite/remove co-hosts, moderate content |
-| **Waiting Reconnect** | Temporary disconnection | Auto-reconnect, manual stop |
-| **Ended** | Broadcast finished | View recording, delete room |
-| **Recorded** | Recording available | Playback, download, delete |
-
-### Status Flow
-
-1. **Creation → Idle**: Room created, awaiting first broadcast
-2. **Idle → Live**: Broadcaster starts streaming
-3. **Live → Waiting Reconnect**: Temporary disconnection (automatic)
-4. **Waiting Reconnect → Live**: Reconnection successful
-5. **Live → Ended**: Broadcast stopped (manual or automatic)
-6. **Ended → Recorded**: Recording processing complete
-
-## Room Participants
-
-Participants represent users who can broadcast in the room:
-
-<CodeGroup>
-```swift iOS
-// AmityRoomParticipant structure
-struct AmityRoomParticipant {
-    let type: AmityRoomParticipantType  // .host, .coHost, .unknown
-    let userId: String
-    let userInternalId: String?
-    let user: AmityUser?  // Linked user object
-}
-
-enum AmityRoomParticipantType {
-    case host      // Creator of the room, full control
-    case coHost    // Invited broadcaster, limited controls
-    case unknown   // Unknown participant type
-}
-```
-
-```kotlin Android
-// AmityRoomParticipant structure
-data class AmityRoomParticipant(
-    val type: AmityRoomParticipantType,  // HOST, CO_HOST, UNKNOWN
-    val userId: String,
-    val userInternalId: String?,
-    val user: AmityUser?  // Linked user object
-)
-
-enum class AmityRoomParticipantType {
-    HOST,      // Creator of the room, full control
-    CO_HOST,   // Invited broadcaster, limited controls
-    UNKNOWN    // Unknown participant type
-}
-```
-
-```typescript TypeScript
-interface AmityRoomParticipant {
-  type: ParticipantType;
-  userId: string;
-  userInternalId?: string;
-  user?: AmityUser; // Linked user object
-}
-
-enum ParticipantType {
-  HOST = "host",      // Creator of the room, full control
-  CO_HOST = "coHost", // Invited broadcaster, limited controls
-  UNKNOWN = "unknown" // Unknown participant type
-}
-```
-</CodeGroup>
-
-**Participant Roles:**
-
-| Role | Description | Permissions |
-|------|-------------|-------------|
-| **Host** | Creator of the room | Full control, invite/remove co-hosts, end stream |
-| **Co-Host** | Invited broadcaster | Broadcast audio/video, leave stream |
-| **Viewer** | Watching the stream | View only (not a room participant) |
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
+| Status | `room.status` | `room.status` | `room.getStatus()` |
+| Title and description | `title`, `description` | `title`, `description` | `getTitle()`, `getDescription()` |
+| Chat channel linkage | `liveChannelEnabled`, `liveChannelId`, `getLiveChat()` | `channelEnabled`, `channelId`, `channel` | `isChannelEnabled()`, `getChannelId()`, `getChannel()` |
+| Feed/post reference | `referenceType`, `referenceId`, `post` | `referenceType`, `referenceId`, `post` | `getReferenceType()`, `getReferenceId()`, `getPost()` |
+| Live playback | `livePlaybackUrl`, `liveThumbnailUrl`, `liveResolution` | `livePlaybackUrl`, `liveThumbnailUrl`, `liveResolution` | `getLivePlaybackUrl()`, `getLiveThumbnailUrl()`, `getLiveResolution()` |
+| Recorded playback | `recordedPlaybackInfos`, `recordedResolution` | `recordedData`, `recordedResolution` | `getRecordedPlaybackInfos()`, `getRecordedResolution()` |
+| Parent and child rooms | `parentRoomId`, `childRoomIds`, `childRooms` | `parentRoomId`, `childRoomIds`, `childRooms` | `getParentRoomId()`, `getChildRoomIds()`, `getChildRooms()` |
+| Creator and deletion | `createdBy`, `isDeleted`, `deletedBy` | `creatorId`, `creator`, `isDeleted`, `deletedById` | `getCreatorId()`, `getCreator()`, `isDeleted()` |
+| Custom metadata | `metadata` | `metadata` | `getMetadata()` |
+| Moderation | `moderation` | `moderation` | `getModeration()` |
 
 <Info>
-For detailed co-host invitation and management workflows, see [Co-Host Management](./co-host-management).
+  Android's current public `AmityRoom` model does not expose a direct `getType()` accessor even though room type is available in query filters and internal model construction.
 </Info>
 
-## Room Targets
+## Participants
 
-Rooms can be created for different contexts:
+Participants are users who can broadcast in the room. Viewers are not room participants.
 
-### Community Room
+| Field | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Role/type | `type: "host" | "coHost"` | `type: String` | `ParticipantType.HOST`, `ParticipantType.CoHost`, or `ParticipantType.Unknown` |
+| User ID | `userId` | `userId` | `userId` |
+| Internal user ID | `userInternalId` | `userInternalId` | `userInternalId` |
+| Linked user | `user` | `user` | `user` |
+| Product-tag permission | `canManageProductTags` | `canManageProductTags` | `canManageProductTags` |
 
-<CodeGroup>
-```swift iOS
-// Community target
-let target = AmityRoomTarget(
-    type: .community,
-    communityId: "community-123",
-    community: community  // Linked AmityCommunity object
-)
-```
+## Status Model
 
-```kotlin Android
-// Community target
-val target = AmityRoomTarget(
-    type = AmityRoomTargetType.COMMUNITY,
-    communityId = "community-123",
-    community = community  // Linked AmityCommunity object
-)
-```
+| Status | Meaning |
+| --- | --- |
+| `idle` | The room exists but is not broadcasting. |
+| `live` | The room is currently broadcasting. |
+| `waitingReconnect` | The live session is waiting for reconnection. |
+| `ended` | The live session has stopped. |
+| `recorded` | Recorded playback metadata is available. |
+| `terminated` | The room was terminated. TypeScript and iOS expose this status. |
+| `error` | The room is in an error state. |
 
-```typescript TypeScript
-// Community target
-{
-  type: "community",
-  communityId: "community-123",
-  community: AmityCommunity // Linked object
-}
-```
-</CodeGroup>
+## Room Posts and Feed Distribution
 
-Broadcast to a specific community's audience.
+Creating a room does not by itself document a feed post in the SDK examples. To publish the room into a feed, create a room post with the room ID.
 
-### User Room
+<CardGroup cols={2}>
+  <Card title="Room Posts" icon="newspaper" href="/social-plus-sdk/social/content-management/posts/creation/room-post">
+    Create a user or community feed post that references an existing room.
+  </Card>
+  <Card title="Create Room" icon="plus" href="./create-room">
+    Create a room before publishing it as a room post.
+  </Card>
+</CardGroup>
 
-<CodeGroup>
-```swift iOS
-// User target
-let target = AmityRoomTarget(
-    type: .user,
-    userId: "user-123",
-    user: user  // Linked AmityUser object
-)
-```
+## Media and Playback Fields
 
-```kotlin Android
-// User target
-val target = AmityRoomTarget(
-    type = AmityRoomTargetType.USER,
-    userId = "user-123",
-    user = user  // Linked AmityUser object
-)
-```
+The room model exposes media fields that your app can use for live or recorded playback. The SDK does not render the player for SDK integrations.
 
-```typescript TypeScript
-// User target
-{
-  type: "user",
-  userId: "user-123",
-  user: AmityUser // Linked object
-}
-```
-</CodeGroup>
-
-Broadcast to user's timeline followers.
-
-## Room References
-
-Link rooms to other content types:
-
-**Supported References:**
-- **Community**: Room associated with community content
-- **User**: Room on user's timeline
-- **Event**: Room linked to a scheduled event
-
-<CodeGroup>
-```swift iOS
-struct AmityRoomReference {
-    let referenceType: AmityRoomReferenceType  // .community, .user, .event
-    let referenceId: String
-}
-```
-
-```kotlin Android
-data class AmityRoomReference(
-    val referenceType: AmityRoomReferenceType,  // COMMUNITY, USER, EVENT
-    val referenceId: String
-)
-```
-
-```typescript TypeScript
-interface AmityRoomReference {
-  referenceType: string; // "community" | "user" | "event"
-  referenceId: string;
-}
-```
-</CodeGroup>
-
-## Channel Integration
-
-Rooms can have integrated live chat channels for viewer interaction. Channels must be manually created after the livestream post is created.
-
-<CodeGroup>
-```swift iOS
-// Channel properties on AmityRoom
-let channelEnabled: Bool      // Indicates room supports live chat
-let channelId: String?        // Set after channel is created
-let channel: AmityChannel?    // Linked channel object
-```
-
-```kotlin Android
-// Channel properties on AmityRoom
-val channelEnabled: Boolean      // Indicates room supports live chat
-val channelId: String?           // Set after channel is created
-val channel: AmityChannel?       // Linked channel object
-```
-
-```typescript TypeScript
-// Channel properties on AmityRoom
-{
-  channelEnabled: boolean, // Indicates room supports live chat
-  channelId: string,       // Set after channel is created
-  channel: AmityChannel    // Linked channel object
-}
-```
-</CodeGroup>
-
-**Channel Features:**
-- Live chat during broadcast
-- Host/Co-host badges
-- Moderation tools
-- Message history
-
-<Warning>
-**Manual Channel Creation Required**: Channels are **not** automatically created. You must create the channel after the post is created, passing both `postId` and `roomId`. See [Create Room - Room with Live Chat Channel](./create-room#room-with-live-chat-channel) for the complete workflow.
-</Warning>
-
-## Moderation System
-
-AI-powered moderation monitors room content in real-time:
-
-<CodeGroup>
-```swift iOS
-struct AmityRoomModeration {
-    let moderationId: String
-    let roomId: String
-    let flagLabels: [AmityRoomModerationLabel]
-    let terminateLabels: [AmityRoomModerationLabel]
-    let createdAt: Date
-    let updatedAt: Date
-}
-
-struct AmityRoomModerationLabel {
-    let category: String  // e.g., "violence", "nudity", "hate_speech"
-    let detectedAt: Date
-}
-```
-
-```kotlin Android
-data class AmityRoomModeration(
-    val moderationId: String,
-    val roomId: String,
-    val flagLabels: List<AmityRoomModerationLabel>,
-    val terminateLabels: List<AmityRoomModerationLabel>,
-    val createdAt: DateTime,
-    val updatedAt: DateTime
-)
-
-data class AmityRoomModerationLabel(
-    val category: String,  // e.g., "violence", "nudity", "hate_speech"
-    val detectedAt: DateTime
-)
-```
-
-```typescript TypeScript
-interface AmityRoomModeration {
-  moderationId: string;
-  roomId: string;
-  flagLabels: AmityRoomModerationLabel[];
-  terminateLabels: AmityRoomModerationLabel[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface AmityRoomModerationLabel {
-  category: string; // e.g., "violence", "nudity", "hate_speech"
-  detectedAt: string;
-}
-```
-</CodeGroup>
-
-**Flag Labels**: Content detected but stream continues
-**Terminate Labels**: Content causes automatic stream termination
-
-<Warning>
-**Automatic Termination**: When terminate-level content is detected, the room status changes to "ended" automatically and cannot be restarted.
-</Warning>
-
-## Parent-Child Room Relationships
-
-Rooms can have hierarchical relationships for complex streaming scenarios:
-
-<CodeGroup>
-```swift iOS
-// Parent-child properties on AmityRoom
-let parentRoomId: String?
-let parentRoom: AmityRoom?       // Linked parent room
-let childRoomIds: [String]       // Array of child room IDs
-```
-
-```kotlin Android
-// Parent-child properties on AmityRoom
-val parentRoomId: String?
-val parentRoom: AmityRoom?           // Linked parent room
-val childRoomIds: List<String>       // Array of child room IDs
-```
-
-```typescript TypeScript
-// Parent-child properties on AmityRoom
-{
-  parentRoomId: string,
-  parentRoom: AmityRoom, // Linked parent room
-  childRoomIds: string[] // Array of child room IDs
-}
-```
-</CodeGroup>
-
-**Use Cases:**
-- Breakout sessions from main room
-- Multi-language streams
-- Regional broadcasts
-
-## Room Data Model
-
-Complete room object structure:
-
-```typescript
-interface AmityRoom {
-  roomId: string;
-  type: AmityRoomType; // "coHosts"
-  
-  // Target
-  targetType: string;
-  targetId: string;
-  target: AmityRoomTarget;
-  
-  // Reference
-  referenceType: string;
-  referenceId: string;
-  reference: AmityRoomReference;
-  
-  // Content
-  title: string;
-  description?: string;
-  thumbnailFileId?: string;
-  
-  // Status
-  status: AmityRoomStatus;
-  
-  // Participants
-  participants: AmityRoomParticipant[];
-  
-  // Channel
-  channelEnabled: boolean;
-  channelId?: string;
-  channel?: AmityChannel;
-  
-  // Streaming
-  livePlaybackUrl?: string;
-  liveThumbnailUrl?: string;
-  liveResolution?: AmityRoomResolution;
-  durationSeconds?: number;
-  
-  // Recorded playback
-  recordedPlaybackInfos?: AmityRoomRecordedPlaybackInfo[];
-  recordedResolution?: AmityRoomResolution;
-  
-  // Relationships
-  parentRoomId?: string;
-  parentRoom?: AmityRoom;
-  childRoomIds: string[];
-  
-  // Creator
-  creatorId: string;
-  creator?: AmityUser;
-  
-  // Timestamps
-  createdAt: string;
-  updatedAt?: string;
-  liveAt?: string;
-  endedAt?: string;
-  recordedAt?: string;
-  
-  // Deletion
-  isDeleted: boolean;
-  deletedAt?: string;
-  deletedById?: string;
-  deletedBy?: AmityUser;
-  
-  // Moderation
-  moderation?: AmityRoomModeration;
-  
-  // Custom data
-  metadata?: Record<string, any>;
-}
-
-interface AmityRoomResolution {
-  aspectRatio?: string;   // e.g. "16:9"
-  width?: number;         // e.g. 1920
-  height?: number;        // e.g. 1080
-}
-
-interface AmityRoomRecordedPlaybackInfo {
-  url: string;
-  thumbnailUrl: string;
-}
-```
-
-### Automatic Thumbnail Generation
-
-The backend automatically generates thumbnail images for live stream sessions. No manual action is required from the stream creator.
-
-| Field | Available When | Description |
-|-------|---------------|-------------|
-| `thumbnailFileId` | Any status | Creator-uploaded cover image |
-| `liveThumbnailUrl` | `live`, `waitingReconnect` | Auto-generated live thumbnail URL from the streaming backend. Available as soon as the room goes live. |
-| `recordedPlaybackInfos[].thumbnailUrl` | `recorded` | Auto-generated thumbnail for recorded playback. Available after recording processing completes. |
-
-<Info>
-The `liveThumbnailUrl` and recorded thumbnails are automatically populated by the backend during the live stream session. You do not need to upload or configure anything for these to be available.
-</Info>
-
-### Resolution Metadata
-
-Resolution metadata is automatically provided by the backend alongside thumbnails:
-
-| Field | Available When | Description |
-|-------|---------------|-------------|
-| `liveResolution` | `live`, `waitingReconnect` | Resolution and aspect ratio of the live stream (e.g., `{ aspectRatio: "16:9", width: 1920, height: 1080 }`) |
-| `recordedResolution` | `recorded` | Resolution and aspect ratio of the recorded stream |
-
-## Integration with Posts
-
-Rooms are linked to posts for social distribution. See [Room Posts](/social-plus-sdk/social/content-management/posts/creation/room-post) for detailed post creation.
-
-```typescript
-// Create room post
-const post = await postRepository.createPost({
-  dataType: PostContentType.ROOM,
-  targetType: 'community',
-  targetId: 'community-123',
-  data: {
-    text: 'Join us live!',
-    roomId: room.roomId,
-    title: room.title
-  }
-});
-
-// Access room from post
-console.log(post.data.room.status); // "live"
-console.log(post.data.room.livePlaybackUrl);
-```
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Room Setup" icon="gear">
-    Configure rooms appropriately for your use case:
-    
-    - Use Co-Hosts type for interactive sessions
-    - Enable channels for viewer interaction
-    - Set clear titles and descriptions
-    - Upload thumbnails before going live
-    - Configure participant limits
-  </Accordion>
-  
-  <Accordion title="Co-Host Coordination" icon="users-gear">
-    Manage co-hosts effectively:
-    
-    - Invite co-hosts before going live
-    - Set clear moderation rules
-    - Monitor participant count
-    - Have backup hosts ready
-    - Test audio/video before live
-  </Accordion>
-  
-  <Accordion title="Moderation" icon="shield">
-    Implement safety measures:
-    
-    - Review moderation labels regularly
-    - Have moderation guidelines
-    - Monitor flag labels proactively
-    - Respond to violations quickly
-    - Keep logs of moderation events
-  </Accordion>
-  
-  <Accordion title="Performance" icon="gauge-high">
-    Optimize streaming performance:
-    
-    - Test network bandwidth
-    - Use appropriate video quality
-    - Monitor connection stability
-    - Have reconnection strategies
-    - Clean up ended rooms
-  </Accordion>
-</AccordionGroup>
+| Field | Availability | Use |
+| --- | --- | --- |
+| `livePlaybackUrl` | While live when available | Viewer playback URL. |
+| `liveThumbnailUrl` | Live or reconnecting sessions when available | Live thumbnail generated by the streaming backend. |
+| `liveResolution` | Live or reconnecting sessions when available | Live stream aspect ratio, width, and height. |
+| `recordedPlaybackInfos` / `recordedData` | After recording is available | Recorded playback URL and thumbnail metadata. |
+| `recordedResolution` | After recording is available | Recorded stream aspect ratio, width, and height. |
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Create Room" href="./create-room" icon="plus">
-    Set up new rooms for broadcasting
+  <Card title="Create Room" icon="plus" href="./create-room">
+    Create rooms and retrieve broadcaster data.
   </Card>
-  <Card title="Start Broadcasting" href="./start-broadcasting" icon="play">
-    Connect to LiveKit and go live
+  <Card title="Manage Rooms" icon="gear" href="./manage-rooms">
+    Observe, query, update, stop, and delete rooms.
   </Card>
-  <Card title="Co-Host Management" href="./co-host-management" icon="users">
-    Invite and manage co-hosts
+  <Card title="Co-Host Management" icon="users" href="./co-host-management">
+    Manage co-host invitations, removal, and permissions.
   </Card>
-  <Card title="Live Viewing" href="./live-viewing" icon="eye">
-    Watch live streams in real-time
-  </Card>
-  <Card title="Recorded Playback" href="./recorded-playback" icon="video">
-    Play back recorded streams
-  </Card>
-  <Card title="Manage Rooms" href="./manage-rooms" icon="gear">
-    Query, update, and control rooms
+  <Card title="Recorded Playback" icon="video" href="./recorded-playback">
+    Read recorded playback fields after processing completes.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- rewrite the SDK video broadcasting overview, rooms overview, and create-room pages around source-backed room APIs
- replace stale universal room snippets with tested TypeScript, Android, and iOS CodeGroup examples
- document Flutter room-broadcasting absence, platform differences, room fields, statuses, participant fields, and room-post boundaries
- add the audited pages to doc-as-test manifests, update the SDK audit tracker, and regenerate llms.txt / llms-full.txt

## Validation
- python3 .docs-ops/ci/check-mdx.py
- python3 .docs-ops/integration-tests/run-tests.py
- python3 .docs-ops/integration-tests/android/run-tests.py
- python3 .docs-ops/integration-tests/flutter/run-tests.py
- python3 .docs-ops/integration-tests/ios/run-tests.py
- go run ./cmd/main.go (llmstxt)
- go test ./... (llmstxt)
- python3 .docs-ops/ci/check-drift.py --base origin/main --skip-fetch --require-doc-as-test all

Full drift gate summary: TS 268/268, Android 268/268 with 3 skipped and 1 warning, Flutter 191/191, iOS 294/294 with 1 skipped and warnings only; MDX clean; regex drift delta 0.