### PR TITLE
docs: align community discovery SDK support

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17245,7 +17245,7 @@ Implement multiple confirmation steps and consider a cooling-off period for comm
 
 > Query and search communities by membership, category, tags, keyword, and sort order.
 
-Use community query APIs to browse communities by membership, category, tags, and sort order. Use the platform's search API or keyword option when you need name-based search.
+Use community query APIs to browse communities by membership, category, tag filters where supported, and sort order. Use the platform's search API or keyword option when you need name-based search.
 
     Query communities with filtering and sorting options
     Find specific communities using keyword-based search
@@ -17280,7 +17280,7 @@ Communities can be organized by categories to help users find relevant content f
 
 ### Tag filtering
 
-Communities can be tagged to describe their topics or purpose. Pass a `tags` array to filter communities by tag. Tags are available in TypeScript, Android, and Flutter query/search APIs, and in current iOS source for `AmityCommunityQueryOptions`.
+Communities can be tagged to describe their topics or purpose. TypeScript, Android, and Flutter expose a `tags` filter on the query/search builders shown below. The published iOS SDK used for this page does not expose a tag parameter on `AmityCommunityQueryOptions` or `AmityCommunitySearchOptions`.
 
 Combine tag filtering with category and membership filters for precise discovery experiences.
 
@@ -17297,7 +17297,7 @@ TypeScript, iOS, and Flutter expose Live Collection style APIs. Android returns 
 | Membership filter | TypeScript, iOS, Android, Flutter | Filter by all, joined, or not-joined communities |
 | Sort order | TypeScript, iOS, Android, Flutter | Sort by display name, newest first, or oldest first |
 | `categoryId` | TypeScript, iOS, Android, Flutter | Filter by category ID |
-| `tags` | TypeScript, Android, Flutter, iOS query source | Filter by community tags |
+| `tags` | TypeScript, Android, Flutter | Filter by community tags |
 | `includeDeleted` | TypeScript, iOS, Android, Flutter | Include or exclude deleted communities |
 | `includeDiscoverablePrivateCommunity` | TypeScript, iOS, Android | Include discoverable private communities where supported |
 
@@ -17424,6 +17424,7 @@ Use search for name-based discovery. The parameter name differs by platform: Typ
 | Membership filter | Enum/string | Filter by membership status |
 | Sort order | Enum/string | Sort by display name, newest first, or oldest first |
 | `categoryId` | String | Filter search results by category ID |
+| `tags` | String[] | TypeScript, Android, and Flutter only. Filter search results by community tags |
 | `includeDeleted` | Boolean | Include deleted communities |
 | `includeDiscoverablePrivateCommunity` | Boolean | Include discoverable private communities where supported |
 
@@ -17507,6 +17508,7 @@ void searchCommunities() {
       .withKeyword('gaming')
       .filter(AmityCommunityFilter.NOT_MEMBER)
       .sortBy(AmityCommunitySortOption.DISPLAY_NAME)
+      .tags(['gaming'])
       .includeDeleted(false)
       .getLiveCollection(pageSize: 20);
 
@@ -26828,11 +26830,11 @@ Use follower and following list APIs when you need to show people lists, pending
 | Followers | Users who follow the target user |
 | Following | Users the target user follows |
 
-Status filters use `accepted`, `pending`, or `all` where the platform exposes them. Android supports status filters on the current user's follower/following builders. TypeScript, iOS, and Flutter expose status filters for the list APIs shown below.
+Status filters use `accepted`, `pending`, or `all` where the platform exposes them. TypeScript and Flutter support status filters on target-user follower/following builders. iOS and Android support status filters on the current user's follower/following builders; use their target-user builders when you need another user's accepted social graph without a status filter.
 
 ## Get followers
 
-Query followers when your UI needs a paginated people list for a user.
+Query followers when your UI needs a paginated people list for a user. The iOS and Android snippets use the current-user builders because those SDKs expose status filters there.
 
 
 ```swift iOS
@@ -26904,7 +26906,7 @@ final relationships = page.data;
 
 ## Get following
 
-Query following relationships when your UI needs the users a profile follows.
+Query following relationships when your UI needs the users a profile follows. The iOS snippet uses the current-user builder to show status filtering; the Android snippet uses the target-user builder for another user's following list.
 
 
 ```swift iOS

--- a/social-plus-sdk/social/communities-spaces/discovery/query-communities.mdx
+++ b/social-plus-sdk/social/communities-spaces/discovery/query-communities.mdx
@@ -3,7 +3,7 @@ title: "Query Communities"
 description: "Query and search communities by membership, category, tags, keyword, and sort order."
 ---
 
-Use community query APIs to browse communities by membership, category, tags, and sort order. Use the platform's search API or keyword option when you need name-based search.
+Use community query APIs to browse communities by membership, category, tag filters where supported, and sort order. Use the platform's search API or keyword option when you need name-based search.
 
 <CardGroup cols={2}>
   <Card title="Browse All Communities" icon="list">
@@ -48,7 +48,7 @@ Communities can be organized by categories to help users find relevant content f
 
 ### Tag filtering
 
-Communities can be tagged to describe their topics or purpose. Pass a `tags` array to filter communities by tag. Tags are available in TypeScript, Android, and Flutter query/search APIs, and in current iOS source for `AmityCommunityQueryOptions`.
+Communities can be tagged to describe their topics or purpose. TypeScript, Android, and Flutter expose a `tags` filter on the query/search builders shown below. The published iOS SDK used for this page does not expose a tag parameter on `AmityCommunityQueryOptions` or `AmityCommunitySearchOptions`.
 
 <Tip>
 Combine tag filtering with category and membership filters for precise discovery experiences.
@@ -69,7 +69,7 @@ TypeScript, iOS, and Flutter expose Live Collection style APIs. Android returns 
 | Membership filter | TypeScript, iOS, Android, Flutter | Filter by all, joined, or not-joined communities |
 | Sort order | TypeScript, iOS, Android, Flutter | Sort by display name, newest first, or oldest first |
 | `categoryId` | TypeScript, iOS, Android, Flutter | Filter by category ID |
-| `tags` | TypeScript, Android, Flutter, iOS query source | Filter by community tags |
+| `tags` | TypeScript, Android, Flutter | Filter by community tags |
 | `includeDeleted` | TypeScript, iOS, Android, Flutter | Include or exclude deleted communities |
 | `includeDiscoverablePrivateCommunity` | TypeScript, iOS, Android | Include discoverable private communities where supported |
 
@@ -200,6 +200,7 @@ Use search for name-based discovery. The parameter name differs by platform: Typ
 | Membership filter | Enum/string | Filter by membership status |
 | Sort order | Enum/string | Sort by display name, newest first, or oldest first |
 | `categoryId` | String | Filter search results by category ID |
+| `tags` | String[] | TypeScript, Android, and Flutter only. Filter search results by community tags |
 | `includeDeleted` | Boolean | Include deleted communities |
 | `includeDiscoverablePrivateCommunity` | Boolean | Include discoverable private communities where supported |
 
@@ -284,6 +285,7 @@ void searchCommunities() {
       .withKeyword('gaming')
       .filter(AmityCommunityFilter.NOT_MEMBER)
       .sortBy(AmityCommunitySortOption.DISPLAY_NAME)
+      .tags(['gaming'])
       .includeDeleted(false)
       .getLiveCollection(pageSize: 20);
 

--- a/social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx
+++ b/social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx
@@ -11,12 +11,12 @@ Use follower and following list APIs when you need to show people lists, pending
 | Following | Users the target user follows |
 
 <Info>
-Status filters use `accepted`, `pending`, or `all` where the platform exposes them. Android supports status filters on the current user's follower/following builders. TypeScript, iOS, and Flutter expose status filters for the list APIs shown below.
+Status filters use `accepted`, `pending`, or `all` where the platform exposes them. TypeScript and Flutter support status filters on target-user follower/following builders. iOS and Android support status filters on the current user's follower/following builders; use their target-user builders when you need another user's accepted social graph without a status filter.
 </Info>
 
 ## Get followers
 
-Query followers when your UI needs a paginated people list for a user.
+Query followers when your UI needs a paginated people list for a user. The iOS and Android snippets use the current-user builders because those SDKs expose status filters there.
 
 <CodeGroup>
 
@@ -90,7 +90,7 @@ final relationships = page.data;
 
 ## Get following
 
-Query following relationships when your UI needs the users a profile follows.
+Query following relationships when your UI needs the users a profile follows. The iOS snippet uses the current-user builder to show status filtering; the Android snippet uses the target-user builder for another user's following list.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Summary
- Align community tag-filter support with the published SDK surface: TypeScript, Android, and Flutter only for query/search tags on this page
- Add the Flutter search `.tags(...)` example and parameter row so the snippet and prose match
- Clarify follower/following status-filter support by platform
- Regenerate `llms-full.txt` for the AI-facing docs mirror

## Validation
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/social/communities-spaces social-plus-sdk/social/user-relationship`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/social/communities-spaces social-plus-sdk/social/user-relationship`
- `python3 .docs-ops/integration-tests/extract-blocks.py && python3 .docs-ops/integration-tests/run-tests.py`
- `python3 .docs-ops/integration-tests/ios/run-tests.py --extract --no-download`
- `python3 .docs-ops/integration-tests/flutter/extract-blocks.py && python3 .docs-ops/integration-tests/flutter/run-tests.py`
- `python3 .docs-ops/integration-tests/android/extract-blocks.py && python3 .docs-ops/integration-tests/android/run-tests.py`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `python3 tools/check_internal_links.py social-plus-sdk`
- `cd llmstxt && go test ./... && go run ./cmd/main.go`
- `python3 .docs-ops/ci/check-drift.py --base origin/main --skip-fetch --require-doc-as-test all --json-out /tmp/sdk-accuracy-social-community-relationship-drift.json`