### PR TITLE
Clarify push notification event availability

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8306,7 +8306,7 @@ The SDK exposes these scopes independently. Read and update the exact scope your
 | --- | --- |
 | `isEnabled` | Whether push notifications are enabled at the requested scope. |
 | Module modifier | User-level setting for chat, social, or video-streaming notifications. |
-| Event modifier | Community-level setting for post, comment, story, or livestream events. |
+| Event modifier | Community-level setting for post, comment, story, and platform-supported livestream events. |
 | Role filter | Optional filter that limits notification delivery by sender role where the SDK supports modifiers. |
 
 ---
@@ -8711,17 +8711,19 @@ Community notification settings control whether the signed-in user receives push
 
 ## Community events
 
-| Event value | TypeScript enum | iOS case | Android/Flutter modifier |
-| --- | --- | --- | --- |
-| `post.created` | `POST_CREATED` | `.postCreated` | `POST_CREATED` / `PostCreated` |
-| `post.reacted` | `POST_REACTED` | `.postReacted` | `POST_REACTED` / `PostReacted` |
-| `comment.created` | `COMMENT_CREATED` | `.commentCreated` | `COMMENT_CREATED` / `CommentCreated` |
-| `comment.replied` | `COMMENT_REPLIED` | `.commentReplied` | `COMMENT_REPLIED` / `CommentReplied` |
-| `comment.reacted` | `COMMENT_REACTED` | `.commentReacted` | `COMMENT_REACTED` / `CommentReacted` |
-| `story.created` | `STORY_CREATED` | `.storyCreated` | `STORY_CREATED` / `StoryCreated` |
-| `story.reacted` | `STORY_REACTED` | `.storyReacted` | `STORY_REACTED` / `StoryReacted` |
-| `story-comment.created` | `STORY_COMMENT_CREATED` | `.storyCommentCreated` | `STORY_COMMENT_CREATED` / `StoryCommentCreated` |
-| `video-streaming.didStart` | `LIVESTREAM_START` | `.livestreamStart` | `LIVESTREAM_START` |
+| Event value | TypeScript enum | iOS case | Android modifier | Flutter modifier |
+| --- | --- | --- | --- | --- |
+| `post.created` | `POST_CREATED` | `.postCreated` | `POST_CREATED` | `PostCreated` |
+| `post.reacted` | `POST_REACTED` | `.postReacted` | `POST_REACTED` | `PostReacted` |
+| `comment.created` | `COMMENT_CREATED` | `.commentCreated` | `COMMENT_CREATED` | `CommentCreated` |
+| `comment.replied` | `COMMENT_REPLIED` | `.commentReplied` | `COMMENT_REPLIED` | `CommentReplied` |
+| `comment.reacted` | `COMMENT_REACTED` | `.commentReacted` | `COMMENT_REACTED` | `CommentReacted` |
+| `story.created` | `STORY_CREATED` | `.storyCreated` | `STORY_CREATED` | `StoryCreated` |
+| `story.reacted` | `STORY_REACTED` | `.storyReacted` | `STORY_REACTED` | `StoryReacted` |
+| `story-comment.created` | `STORY_COMMENT_CREATED` | `.storyCommentCreated` | `STORY_COMMENT_CREATED` | `StoryCommentCreated` |
+| `video-streaming.didStart` | `LIVESTREAM_START` | `.livestreamStart` | `LIVESTREAM_START` | Not exposed |
+
+  Flutter exposes `video-streaming` as a user notification module, but this checkout does not expose a community-level livestream-start event modifier.
 
 ## Get community settings
 

--- a/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/community-settings.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/community-settings.mdx
@@ -25,17 +25,21 @@ Community notification settings control whether the signed-in user receives push
 
 ## Community events
 
-| Event value | TypeScript enum | iOS case | Android/Flutter modifier |
-| --- | --- | --- | --- |
-| `post.created` | `POST_CREATED` | `.postCreated` | `POST_CREATED` / `PostCreated` |
-| `post.reacted` | `POST_REACTED` | `.postReacted` | `POST_REACTED` / `PostReacted` |
-| `comment.created` | `COMMENT_CREATED` | `.commentCreated` | `COMMENT_CREATED` / `CommentCreated` |
-| `comment.replied` | `COMMENT_REPLIED` | `.commentReplied` | `COMMENT_REPLIED` / `CommentReplied` |
-| `comment.reacted` | `COMMENT_REACTED` | `.commentReacted` | `COMMENT_REACTED` / `CommentReacted` |
-| `story.created` | `STORY_CREATED` | `.storyCreated` | `STORY_CREATED` / `StoryCreated` |
-| `story.reacted` | `STORY_REACTED` | `.storyReacted` | `STORY_REACTED` / `StoryReacted` |
-| `story-comment.created` | `STORY_COMMENT_CREATED` | `.storyCommentCreated` | `STORY_COMMENT_CREATED` / `StoryCommentCreated` |
-| `video-streaming.didStart` | `LIVESTREAM_START` | `.livestreamStart` | `LIVESTREAM_START` |
+| Event value | TypeScript enum | iOS case | Android modifier | Flutter modifier |
+| --- | --- | --- | --- | --- |
+| `post.created` | `POST_CREATED` | `.postCreated` | `POST_CREATED` | `PostCreated` |
+| `post.reacted` | `POST_REACTED` | `.postReacted` | `POST_REACTED` | `PostReacted` |
+| `comment.created` | `COMMENT_CREATED` | `.commentCreated` | `COMMENT_CREATED` | `CommentCreated` |
+| `comment.replied` | `COMMENT_REPLIED` | `.commentReplied` | `COMMENT_REPLIED` | `CommentReplied` |
+| `comment.reacted` | `COMMENT_REACTED` | `.commentReacted` | `COMMENT_REACTED` | `CommentReacted` |
+| `story.created` | `STORY_CREATED` | `.storyCreated` | `STORY_CREATED` | `StoryCreated` |
+| `story.reacted` | `STORY_REACTED` | `.storyReacted` | `STORY_REACTED` | `StoryReacted` |
+| `story-comment.created` | `STORY_COMMENT_CREATED` | `.storyCommentCreated` | `STORY_COMMENT_CREATED` | `StoryCommentCreated` |
+| `video-streaming.didStart` | `LIVESTREAM_START` | `.livestreamStart` | `LIVESTREAM_START` | Not exposed |
+
+<Note>
+  Flutter exposes `video-streaming` as a user notification module, but this checkout does not expose a community-level livestream-start event modifier.
+</Note>
 
 ## Get community settings
 

--- a/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/overview.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/push-notifications/settings/overview.mdx
@@ -44,5 +44,5 @@ The SDK exposes these scopes independently. Read and update the exact scope your
 | --- | --- |
 | `isEnabled` | Whether push notifications are enabled at the requested scope. |
 | Module modifier | User-level setting for chat, social, or video-streaming notifications. |
-| Event modifier | Community-level setting for post, comment, story, or livestream events. |
+| Event modifier | Community-level setting for post, comment, story, and platform-supported livestream events. |
 | Role filter | Optional filter that limits notification delivery by sender role where the SDK supports modifiers. |


### PR DESCRIPTION
## Summary
- split Android and Flutter community notification event modifiers so platform availability is explicit
- clarify that Flutter does not expose the community-level livestream-start modifier in this checkout
- regenerate `llms-full.txt` for the docs text change

## Validation
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `python3 tools/check_internal_links.py social-plus-sdk`
- `cd llmstxt && go test ./... && go run ./cmd/main.go`
- `python3 .docs-ops/ci/check-drift.py --base origin/main --skip-fetch --require-doc-as-test all --json-out /tmp/sdk-accuracy-realtime-presence-push-drift.json`

Drift gate passed with TS 294/294, Flutter 191/191, Android 294 passed with 3 skipped and 1 warning, iOS 320 passed with 6 skipped and 320 warnings, and no blocking failures.