### PR TITLE
Normalize core SDK page structure

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4905,7 +4905,7 @@ Use file handling when your app needs to upload a generic attachment such as a P
 
 This page covers generic files. Use the image and video pages for media-specific helpers such as image sizes, alt text, video status, and video resolution URLs.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Delete | Notes |
 | --- | --- | --- | --- | --- |
@@ -4924,7 +4924,7 @@ This page covers generic files. Use the image and video pages for media-specific
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. TypeScript emits a percentage; iOS emits `0.0...1.0`; Android and Flutter expose progress through `AmityUploadResult`. |
 | `uploadId` | Android, Flutter | Optional lower-level identifier for tracking or canceling a specific upload. The default public upload methods generate one for you. |
 
-## Upload a file
+## Upload A File
 
 Upload a local file first, then use the returned `fileId` or file object in content creation APIs.
 
@@ -5012,7 +5012,7 @@ AmityCoreClient.newFileRepository()
 ```
 
 
-## Read file data
+## Read File Data
 
 Read file data when your app needs a direct file URL, filename, or MIME type for a previously uploaded file.
 
@@ -5063,7 +5063,7 @@ void inspectFile(AmityFile uploadedFile) {
 ```
 
 
-## Delete a file
+## Delete A File
 
 Delete only files your app no longer needs. If a file is still referenced by a post, comment, message, user profile, community, or channel, update that content first so users do not see broken attachments.
 
@@ -5104,7 +5104,7 @@ Use image handling when your app needs to upload image files for avatars, posts,
 
 For image posts, comments, messages, and avatars, first upload the image through the file repository, then pass the returned image object or `fileId` into the relevant creation or update API.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Sized URLs | Alt text |
 | --- | --- | --- | --- | --- |
@@ -5119,12 +5119,12 @@ For image posts, comments, messages, and avatars, first upload the image through
 | --- | --- | --- |
 | `formData` / `image` / `url` / `uri` / `file` | TypeScript, iOS, Android, Flutter | The image input. TypeScript accepts `FormData`; iOS accepts `UIImage` or a local image `URL`; Android accepts `Uri`; Flutter accepts `File`. |
 | `altText` | TypeScript, iOS, Android | Optional accessibility text stored on the image file. Flutter's current public upload method does not expose this parameter. |
-| `isFullImage` / `isFullImage` | iOS, Flutter | Whether the uploaded image should be treated as the full image. iOS documents this on the URL-based upload; Flutter exposes `isFullImage` on public upload. |
+| `isFullImage` | iOS, Flutter | Whether the uploaded image should be treated as the full image. iOS documents this on the URL-based upload; Flutter exposes `isFullImage` on public upload. |
 | `fileId` | TypeScript, iOS, Android | ID returned by upload or embedded in content data. Used for direct fetch, size lookup, or alt-text update where available. |
 | `size` | TypeScript, iOS, Android, Flutter | Requested display size. Size names differ slightly by platform, and Android currently exposes `SMALL`, `MEDIUM`, and `LARGE`. |
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. |
 
-## Upload an image
+## Upload An Image
 
 Upload an image first, then use the returned image object or `fileId` in avatar, post, comment, message, or story APIs.
 
@@ -5215,7 +5215,7 @@ AmityCoreClient.newFileRepository()
 ```
 
 
-## Read image data
+## Read Image Data
 
 Read image data when your app needs image dimensions, alt text, or a sized image URL for rendering.
 
@@ -5272,7 +5272,7 @@ void inspectImage(AmityImage image) {
 ```
 
 
-## Related topics
+## Related Topics
 
     Attach uploaded images to social posts.
     Attach uploaded images to comments.
@@ -5288,7 +5288,7 @@ Use video handling when your app needs to upload video files for posts, messages
 
 The SDK exposes upload progress and video file metadata. Playback UI, caching, retry policy, and adaptive player behavior remain application concerns.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Status and resolutions | Notes |
 | --- | --- | --- | --- | --- |
@@ -5307,7 +5307,7 @@ The SDK exposes upload progress and video file metadata. Playback UI, caching, r
 | `resolution` | TypeScript, iOS, Android, Flutter | Requested generated video URL. Exposed values include original, 1080p, 720p, 480p, and 360p where available for that upload. |
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. |
 
-## Upload a video
+## Upload A Video
 
 Upload a video first, then use the returned video object or `fileId` in video-based content APIs.
 
@@ -5400,7 +5400,7 @@ AmityCoreClient.newFileRepository()
 ```
 
 
-## Read video status and URLs
+## Read Video Status And URLs
 
 Read video status and resolution URLs when your UI needs to render playback or processing state.
 
@@ -5449,7 +5449,7 @@ void inspectVideo(AmityVideo video) {
 ```
 
 
-## Related topics
+## Related Topics
 
     Attach uploaded videos to social posts.
     Upload and inspect generic file attachments.
@@ -7900,7 +7900,7 @@ renderResults(users);
 
 Use SDK logging and error surfaces while you build and debug an integration. Keep request and response logging out of production logs unless your app has an explicit redaction and retention policy.
 
-## SDK surface
+## SDK Surface
 
 | Need | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -7910,7 +7910,7 @@ Use SDK logging and error surfaces while you build and debug an integration. Kee
 
 Use the network observer as a development diagnostic tool. It can expose request metadata, response metadata, and payloads depending on platform, so avoid storing raw logs that may contain user content or credentials.
 
-## Network activity
+## Network Activity
 
 Observe network activity only while debugging an integration, then unsubscribe or dispose the observer when the debug session ends.
 
@@ -7961,7 +7961,7 @@ val disposable = AmityCoreClient.observeNetworkActivities()
 disposable.dispose()
 ```
 
-### Observer parameters
+### Observer Parameters
 
 | Platform | Callback or stream value | Notes |
 | --- | --- | --- |
@@ -7970,7 +7970,7 @@ disposable.dispose()
 | Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
 | Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
 
-## Error handling
+## Error Handling
 
 SDK operations throw or emit platform-native errors. Convert those errors to SDK error enums before deciding whether to retry, show a user message, or end the session.
 
@@ -8026,7 +8026,7 @@ if (error is AmityException) {
 }
 ```
 
-### Common SDK error constants
+### Common SDK Error Constants
 
 | Meaning | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -8039,7 +8039,7 @@ if (error is AmityException) {
 | Bot permission denied | `Amity.ServerError.BOT_PERMISSION_DENIED` | `.botPermissionDenied` | `AmityError.BOT_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
 | Connection error | `Amity.ClientError.CONNECTION_ERROR` | `.connectionError` | `AmityError.CONNECTION_ERROR` | `AmityError.CONNECTION_ERROR` |
 
-## Production checklist
+## Production Checklist
 
 - Disable broad network payload logging outside development builds.
 - Redact tokens, authorization headers, user identifiers, and message or post bodies before writing logs.

--- a/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file.mdx
@@ -7,7 +7,7 @@ Use file handling when your app needs to upload a generic attachment such as a P
 
 This page covers generic files. Use the image and video pages for media-specific helpers such as image sizes, alt text, video status, and video resolution URLs.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Delete | Notes |
 | --- | --- | --- | --- | --- |
@@ -26,7 +26,7 @@ This page covers generic files. Use the image and video pages for media-specific
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. TypeScript emits a percentage; iOS emits `0.0...1.0`; Android and Flutter expose progress through `AmityUploadResult`. |
 | `uploadId` | Android, Flutter | Optional lower-level identifier for tracking or canceling a specific upload. The default public upload methods generate one for you. |
 
-## Upload a file
+## Upload A File
 
 Upload a local file first, then use the returned `fileId` or file object in content creation APIs.
 
@@ -116,7 +116,7 @@ AmityCoreClient.newFileRepository()
 
 </CodeGroup>
 
-## Read file data
+## Read File Data
 
 Read file data when your app needs a direct file URL, filename, or MIME type for a previously uploaded file.
 
@@ -169,7 +169,7 @@ void inspectFile(AmityFile uploadedFile) {
 
 </CodeGroup>
 
-## Delete a file
+## Delete A File
 
 Delete only files your app no longer needs. If a file is still referenced by a post, comment, message, user profile, community, or channel, update that content first so users do not see broken attachments.
 

--- a/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling.mdx
@@ -7,7 +7,7 @@ Use image handling when your app needs to upload image files for avatars, posts,
 
 For image posts, comments, messages, and avatars, first upload the image through the file repository, then pass the returned image object or `fileId` into the relevant creation or update API.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Sized URLs | Alt text |
 | --- | --- | --- | --- | --- |
@@ -22,12 +22,12 @@ For image posts, comments, messages, and avatars, first upload the image through
 | --- | --- | --- |
 | `formData` / `image` / `url` / `uri` / `file` | TypeScript, iOS, Android, Flutter | The image input. TypeScript accepts `FormData`; iOS accepts `UIImage` or a local image `URL`; Android accepts `Uri`; Flutter accepts `File`. |
 | `altText` | TypeScript, iOS, Android | Optional accessibility text stored on the image file. Flutter's current public upload method does not expose this parameter. |
-| `isFullImage` / `isFullImage` | iOS, Flutter | Whether the uploaded image should be treated as the full image. iOS documents this on the URL-based upload; Flutter exposes `isFullImage` on public upload. |
+| `isFullImage` | iOS, Flutter | Whether the uploaded image should be treated as the full image. iOS documents this on the URL-based upload; Flutter exposes `isFullImage` on public upload. |
 | `fileId` | TypeScript, iOS, Android | ID returned by upload or embedded in content data. Used for direct fetch, size lookup, or alt-text update where available. |
 | `size` | TypeScript, iOS, Android, Flutter | Requested display size. Size names differ slightly by platform, and Android currently exposes `SMALL`, `MEDIUM`, and `LARGE`. |
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. |
 
-## Upload an image
+## Upload An Image
 
 Upload an image first, then use the returned image object or `fileId` in avatar, post, comment, message, or story APIs.
 
@@ -120,7 +120,7 @@ AmityCoreClient.newFileRepository()
 
 </CodeGroup>
 
-## Read image data
+## Read Image Data
 
 Read image data when your app needs image dimensions, alt text, or a sized image URL for rendering.
 
@@ -179,7 +179,7 @@ void inspectImage(AmityImage image) {
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Image Posts" icon="image" href="/social-plus-sdk/social/content-management/posts/creation/image-post">

--- a/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling.mdx
+++ b/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling.mdx
@@ -7,7 +7,7 @@ Use video handling when your app needs to upload video files for posts, messages
 
 The SDK exposes upload progress and video file metadata. Playback UI, caching, retry policy, and adaptive player behavior remain application concerns.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Upload | Fetch | Status and resolutions | Notes |
 | --- | --- | --- | --- | --- |
@@ -26,7 +26,7 @@ The SDK exposes upload progress and video file metadata. Playback UI, caching, r
 | `resolution` | TypeScript, iOS, Android, Flutter | Requested generated video URL. Exposed values include original, 1080p, 720p, 480p, and 360p where available for that upload. |
 | `onProgress` / `progress` | TypeScript, iOS, Android, Flutter | Upload progress callback or stream event. |
 
-## Upload a video
+## Upload A Video
 
 Upload a video first, then use the returned video object or `fileId` in video-based content APIs.
 
@@ -121,7 +121,7 @@ AmityCoreClient.newFileRepository()
 
 </CodeGroup>
 
-## Read video status and URLs
+## Read Video Status And URLs
 
 Read video status and resolution URLs when your UI needs to render playback or processing state.
 
@@ -172,7 +172,7 @@ void inspectVideo(AmityVideo video) {
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Video Posts" icon="video" href="/social-plus-sdk/social/content-management/posts/creation/video-post">

--- a/social-plus-sdk/core-concepts/foundation/logging.mdx
+++ b/social-plus-sdk/core-concepts/foundation/logging.mdx
@@ -5,7 +5,7 @@ description: "Monitor SDK network activity during integration and handle SDK err
 
 Use SDK logging and error surfaces while you build and debug an integration. Keep request and response logging out of production logs unless your app has an explicit redaction and retention policy.
 
-## SDK surface
+## SDK Surface
 
 | Need | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -17,7 +17,7 @@ Use SDK logging and error surfaces while you build and debug an integration. Kee
 Use the network observer as a development diagnostic tool. It can expose request metadata, response metadata, and payloads depending on platform, so avoid storing raw logs that may contain user content or credentials.
 </Info>
 
-## Network activity
+## Network Activity
 
 Observe network activity only while debugging an integration, then unsubscribe or dispose the observer when the debug session ends.
 
@@ -70,7 +70,7 @@ disposable.dispose()
 ```
 </CodeGroup>
 
-### Observer parameters
+### Observer Parameters
 
 | Platform | Callback or stream value | Notes |
 | --- | --- | --- |
@@ -79,7 +79,7 @@ disposable.dispose()
 | Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
 | Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
 
-## Error handling
+## Error Handling
 
 SDK operations throw or emit platform-native errors. Convert those errors to SDK error enums before deciding whether to retry, show a user message, or end the session.
 
@@ -137,7 +137,7 @@ if (error is AmityException) {
 ```
 </CodeGroup>
 
-### Common SDK error constants
+### Common SDK Error Constants
 
 | Meaning | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -150,7 +150,7 @@ if (error is AmityException) {
 | Bot permission denied | `Amity.ServerError.BOT_PERMISSION_DENIED` | `.botPermissionDenied` | `AmityError.BOT_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
 | Connection error | `Amity.ClientError.CONNECTION_ERROR` | `.connectionError` | `AmityError.CONNECTION_ERROR` | `AmityError.CONNECTION_ERROR` |
 
-## Production checklist
+## Production Checklist
 
 - Disable broad network payload logging outside development builds.
 - Redact tokens, authorization headers, user identifiers, and message or post bodies before writing logs.


### PR DESCRIPTION
## Summary
- normalized heading structure across core file, image, video, and logging SDK docs
- fixed a duplicate `isFullImage` parameter label in image handling
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Source audit
- reviewed the targeted content-handling, foundation, and safety/privacy SDK pages against the current SDK sources
- no large API drift found in this slice; the only source-backed correction needed was the duplicate `isFullImage` parameter label

## Validation
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/core-concepts/content-handling social-plus-sdk/core-concepts/foundation social-plus-sdk/core-concepts/safety-privacy`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/core-concepts/content-handling social-plus-sdk/core-concepts/foundation social-plus-sdk/core-concepts/safety-privacy`
- `cd llmstxt && go test ./... && go run ./cmd/main.go`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `python3 tools/check_internal_links.py social-plus-sdk`
- `python3 .docs-ops/ci/check-drift.py --base origin/main --skip-fetch --json-out /tmp/sdk-core-content-foundation-drift.json`

Drift gate result: PASS, regex drift delta 0; TypeScript 294 passed; Flutter 191 passed; Android 294 passed / 3 skipped / 1 warning; iOS 320 passed / 6 skipped / 320 warnings.