### PR TITLE
Normalize realtime SDK page structure

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6131,7 +6131,7 @@ The Android SDK exposes live objects and collections through RxJava 3 streams. S
 
 Use RxJava directly, or convert supported streams to Kotlin `Flow` with the SDK coroutine bridge.
 
-## Platform surface
+## Platform Surface
 
 | Surface | Public shape | Notes |
 | --- | --- | --- |
@@ -6151,7 +6151,7 @@ Use RxJava directly, or convert supported streams to Kotlin `Flow` with the SDK 
 | `subscribeOn(Schedulers.io())` | RxJava streams | Runs SDK work on an IO scheduler. |
 | `observeOn(AndroidSchedulers.mainThread())` | UI observers | Delivers callbacks on the Android main thread for UI updates. |
 
-## Observe a live object
+## Observe A Live Object
 
 Observe a live object when your Android UI needs one SDK object to stay current after server or local-store changes.
 
@@ -6174,7 +6174,7 @@ disposable.dispose()
 ```
 
 
-## Observe a paged live collection
+## Observe A Paged Live Collection
 
 The SDK query emits `PagingData<AmityPost>`. Feed it into your Paging 3 adapter or Compose paging collector.
 
@@ -6222,7 +6222,7 @@ val postFlow = AmitySocialClient.newPostRepository()
 - Dispose RxJava subscriptions in the matching lifecycle owner or ViewModel. For coroutines, cancel the collecting scope.
 - Use `subscribeOn(Schedulers.io())` for SDK work and `observeOn(AndroidSchedulers.mainThread())` before mutating UI state.
 
-## Related topics
+## Related Topics
 
     See post-specific Android query examples.
     Configure Android notification setup alongside real-time data.
@@ -6235,7 +6235,7 @@ val postFlow = AmitySocialClient.newPostRepository()
 
 The Flutter SDK exposes live objects as Dart streams and live collections through `LiveCollection` / `LiveCollectionStream`. A live collection emits `LiveResult<T>`, which contains the current `data` list and an `isFetching` flag.
 
-## Platform surface
+## Platform Surface
 
 | Surface | Public shape | Notes |
 | --- | --- | --- |
@@ -6256,7 +6256,7 @@ The Flutter SDK exposes live objects as Dart streams and live collections throug
 | `LiveResult<T>.data` | Collection stream | Current list snapshot. |
 | `LiveResult<T>.isFetching` | Collection stream | Whether the collection is currently fetching. |
 
-## Observe a live object
+## Observe A Live Object
 
 Observe a live object when your Flutter UI needs one SDK object to stay current after server or local-cache changes.
 
@@ -6274,7 +6274,7 @@ await subscription.cancel();
 ```
 
 
-## Observe a live collection
+## Observe A Live Collection
 
 `getStream()` emits `LiveResult<AmityPost>`. Keep the collection instance so you can load more pages and dispose it later.
 
@@ -6313,7 +6313,7 @@ await liveCollection.dispose();
 - Call `reset()` to clear the collection and reload the first page.
 - Cancel every `StreamSubscription` and call `dispose()` on live collections that are no longer used.
 
-## Related topics
+## Related Topics
 
     See post-specific Flutter retrieval examples.
     Configure Flutter notification setup alongside real-time data.
@@ -6596,7 +6596,7 @@ Real-time events are MQTT topic subscriptions managed by the SDK. Subscribe to t
 
 Topic subscriptions do not replace Live Objects & Collections. Use subscriptions to tell the SDK which event streams matter now, then render from the live data APIs.
 
-## Platform surface
+## Platform Surface
 
 | Area | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -6604,7 +6604,7 @@ Topic subscriptions do not replace Live Objects & Collections. Use subscriptions
 | Chat topics | `getSubChannelTopic(subChannel)` with `subscribeTopic(topic)` | `AmitySubChannelTopic` with `AmityTopicSubscription` | `subChannel.subscription()` | `subChannel.subscription()` |
 | Unsubscribe | Call the `Amity.Unsubscriber` returned by `subscribeTopic` | `unsubscribeTopic(...)` | `unsubscribeTopic()` | `unsubscribeTopic()` |
 
-## Topic lifecycle
+## Topic Lifecycle
 
 ```mermaid
 flowchart LR
@@ -6614,7 +6614,7 @@ flowchart LR
     D --> E["Unsubscribe when no longer needed"]
 ```
 
-## When to subscribe
+## When To Subscribe
 
 | UI need | Recommended topic |
 | --- | --- |
@@ -6627,7 +6627,7 @@ flowchart LR
 | Follow/follower list changes | Follow topic on platforms that expose follow topic helpers |
 | Story updates | Story topic or community-story topic where available |
 
-## Subscription discipline
+## Subscription Discipline
 
     Topic APIs usually require an SDK model object such as `AmityCommunity`, `AmityPost`, `AmityComment`, `AmityUser`, or `AmitySubChannel`. Fetch or observe the model first, then subscribe while that model is visible.
 
@@ -6637,7 +6637,7 @@ flowchart LR
 
     A topic subscription activates event delivery. Your UI should still read from the SDK live object or live collection so cache updates, loading state, and error handling stay consistent.
 
-## Related topics
+## Related Topics
 
     Subscribe to community, post, comment, user, follow, and story topics.
 
@@ -6655,7 +6655,7 @@ Chat real-time event subscriptions keep a thread's live data moving while the us
 
 Conversation and community channel members receive many chat updates through normal SDK live objects and collections. Use a subchannel topic when the screen needs explicit realtime delivery for a specific message thread.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Public API | Cleanup |
 | --- | --- | --- |
@@ -6673,7 +6673,7 @@ Conversation and community channel members receive many chat updates through nor
 | Android | `subChannel` | Yes | `AmitySubChannel` model exposing the public `subscription()` method. |
 | Flutter | `subChannel` | Yes | `AmitySubChannel` model exposing the public `subscription()` method. |
 
-## Subscribe to a subchannel
+## Subscribe To A Subchannel
 
 Subscribe when the thread screen becomes active, and unsubscribe when it leaves the screen or switches to another subchannel.
 
@@ -6733,7 +6733,7 @@ Future<void> unsubscribeFromSubChannel(AmitySubChannel subChannel) async {
 ```
 
 
-## Best practices
+## Best Practices
 
     Bind the subchannel subscription to the active message thread, not to the entire chat module. Switch the subscription when the user changes threads.
 
@@ -6741,7 +6741,7 @@ Future<void> unsubscribeFromSubChannel(AmitySubChannel subChannel) async {
 
     After subscribing, render messages from the SDK query or live collection APIs so local cache updates and pagination stay consistent.
 
-## Related topics
+## Related Topics
 
     Query and render messages for a subchannel.
 
@@ -6757,7 +6757,7 @@ Social real-time events let an app receive live updates for the social models th
 
 Community and user-scoped topics are useful for feed screens. Post and comment topics are better for focused detail screens. The user must have access to the target community, post, comment, user, or story for events to be delivered.
 
-## Platform surface
+## Platform Surface
 
 | Topic | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -6768,11 +6768,11 @@ Community and user-scoped topics are useful for feed screens. Post and comment t
 | Follow | `getMyFollowersTopic()`, `getMyFollowingsTopic()` | `AmityFollowTopic` | `AmityCoreClient.subscription(AmityTopic.FOLLOW(...))` | Not exposed in this checkout |
 | Story | `getStoryTopic(...)`, `getCommunityStoriesTopic(...)` | `AmityStoryTopic` | `story.subscription()` | `story.subscription()` |
 
-## Community topic
+## Community Topic
 
 Use a community topic when a screen is scoped to a community, such as a community profile, feed, or moderation surface.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -6842,11 +6842,11 @@ Future<void> subscribeToCommunityFeed(AmityCommunity community) async {
 ```
 
 
-## Post topic
+## Post Topic
 
 Use a post topic for a single post detail screen or a moderation/action surface focused on one post.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -6908,11 +6908,11 @@ Future<void> subscribeToPostComments(AmityPost post) async {
 ```
 
 
-## Comment topic
+## Comment Topic
 
 Use a comment topic for a focused comment detail, moderation, or realtime reply surface.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -6971,11 +6971,11 @@ Future<void> subscribeToComment(AmityComment comment) async {
 ```
 
 
-## User topic
+## User Topic
 
 Use a user topic when a screen needs live updates for a user profile or that user's feed activity.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -7038,13 +7038,13 @@ Future<void> subscribeToUserPosts(AmityUser user) async {
 ```
 
 
-## Follow topic
+## Follow Topic
 
 Follow topics observe changes to the current user's follower and following lists.
 
 The current Flutter SDK checkout does not expose a public follow topic subscription helper. Use this section for TypeScript, iOS, and Android.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -7095,11 +7095,11 @@ fun subscribeToMyFollowers() {
 ```
 
 
-## Story topic
+## Story Topic
 
 Story topics observe one story or a community's story stream.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -7212,7 +7212,7 @@ Future<void> unsubscribeFromCommunityFeed(AmityCommunity community) async {
 ```
 
 
-## Related topics
+## Related Topics
 
     Learn how topic subscriptions fit with live objects and collections.
 
@@ -7309,7 +7309,7 @@ The current TypeScript and Flutter SDKs in this checkout do not expose a user pr
 
 The SDK limits active presence syncing to 20 user IDs at a time. Unsync users when their row, card, or profile preview is no longer visible.
 
-## getUserPresence()
+## Read User Presence
 
 Fetch presence for known users as a one-shot read.
 
@@ -7343,7 +7343,7 @@ repository.getUserPresence(listOf(userId))
 ```
 
 
-## syncUserPresence()
+## Sync User Presence
 
 Sync user presence while users are visible, then unsync them when the UI no longer needs updates.
 
@@ -7390,7 +7390,7 @@ repository.unsyncUserPresence(userId)
 ```
 
 
-## getOnlineUsersCount() and getOnlineUsersSnapshot()
+## Read Online Users Count And Snapshot
 
 Use the count for a network-wide online total. Use the snapshot when you need actual user objects at the time of the query.
 
@@ -7485,7 +7485,7 @@ Only conversation channels support channel presence. The SDK sync limit is 20 ch
 | User presences | `presence.userPresences` | `presence.getUserPresences()` | Presence records for members in the channel. |
 | Any other member online | `presence.isAnyMemberOnline` | `presence.isAnyMemberOnline()` | `true` when at least one member other than the current user is online. |
 
-## syncChannelPresence()
+## Sync Channel Presence
 
 Start syncing when a conversation channel becomes visible, then unsync it when the row or screen is gone.
 
@@ -7534,7 +7534,7 @@ repository.unsyncChannelPresence(channelId)
 ```
 
 
-## unsyncAllChannelPresence()
+## Unsync All Channel Presence
 
 Use `unsyncAllChannelPresence` when leaving a channel list, tearing down a view model, or replacing the whole visible channel set.
 
@@ -7731,7 +7731,7 @@ Room presence is available on iOS, Android, and TypeScript. It is not available 
 | `observeOnlineUsersCount` | Android | `interval` | No | Poll interval in seconds. Defaults to 15 seconds. |
 | `getRoomOnlineUsers` / `getOnlineUsersSnapshot` | All supported platforms | None or `roomId` | Platform-dependent | Reads a point-in-time list or snapshot of online room users. Android snapshots paginate 20 users at a time. |
 
-## startHeartbeat()
+## Start Room Heartbeat
 
 Start the room heartbeat when the user enters the room, and stop it when they leave. The SDK sends the first heartbeat immediately and continues at the server-configured interval.
 
@@ -7771,7 +7771,7 @@ RoomPresenceRepository.stopHeartbeat(roomId);
 ```
 
 
-## getRoomUserCount()
+## Read Room User Count
 
 Use the count as the source of truth for how many users are currently present in the room.
 
@@ -7844,7 +7844,7 @@ clearInterval(timer);
 ```
 
 
-## getRoomOnlineUsers()
+## Read Room Online Users
 
 Use the online-user list when the app needs actual user objects, such as avatars in a "who is watching" panel. For large rooms, display the count as the total and treat the list as a snapshot.
 
@@ -8189,7 +8189,7 @@ Device registration connects the current signed-in user to the device token that
 
 The TypeScript SDK does not expose a client-side device registration API. Use the native iOS, Android, or Flutter SDK APIs on device, and use server-side/webhook flows for web delivery.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Register | Unregister | Token argument |
 | --- | --- | --- | --- |
@@ -8207,7 +8207,7 @@ The TypeScript SDK does not expose a client-side device registration API. Use th
 
 Android registration does not accept a token argument in the current SDK API. The Android SDK registers the current signed-in user/device through `AmityCoreClient.registerPushNotification()`.
 
-## Register a device
+## Register A Device
 
 Register the current signed-in user/device after platform push setup and SDK initialization are complete.
 
@@ -8234,7 +8234,7 @@ await AmityCoreClient.registerDeviceNotification(fcmToken);
 
 On Android, `registerPushNotification()` is a no-op for visitor and bot users. Register only after the app has a signed-in user session.
 
-## Unregister a device
+## Unregister A Device
 
 Call unregister when the user signs out or when this app installation should stop receiving push notifications for the currently registered user.
 
@@ -8259,7 +8259,7 @@ await AmityCoreClient.unregisterDeviceNotification();
 ```
 
 
-## Related setup
+## Related Setup
 
 Complete platform setup before calling the SDK registration API:
 

--- a/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/android.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/android.mdx
@@ -7,7 +7,7 @@ The Android SDK exposes live objects and collections through RxJava 3 streams. S
 
 Use RxJava directly, or convert supported streams to Kotlin `Flow` with the SDK coroutine bridge.
 
-## Platform surface
+## Platform Surface
 
 | Surface | Public shape | Notes |
 | --- | --- | --- |
@@ -27,7 +27,7 @@ Use RxJava directly, or convert supported streams to Kotlin `Flow` with the SDK 
 | `subscribeOn(Schedulers.io())` | RxJava streams | Runs SDK work on an IO scheduler. |
 | `observeOn(AndroidSchedulers.mainThread())` | UI observers | Delivers callbacks on the Android main thread for UI updates. |
 
-## Observe a live object
+## Observe A Live Object
 
 Observe a live object when your Android UI needs one SDK object to stay current after server or local-store changes.
 
@@ -52,7 +52,7 @@ disposable.dispose()
 
 </CodeGroup>
 
-## Observe a paged live collection
+## Observe A Paged Live Collection
 
 The SDK query emits `PagingData<AmityPost>`. Feed it into your Paging 3 adapter or Compose paging collector.
 
@@ -104,7 +104,7 @@ val postFlow = AmitySocialClient.newPostRepository()
 - Dispose RxJava subscriptions in the matching lifecycle owner or ViewModel. For coroutines, cancel the collecting scope.
 - Use `subscribeOn(Schedulers.io())` for SDK work and `observeOn(AndroidSchedulers.mainThread())` before mutating UI state.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Post Retrieval" icon="newspaper" href="/social-plus-sdk/social/content-management/posts/retrieval/get-post">

--- a/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/flutter.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/flutter.mdx
@@ -5,7 +5,7 @@ description: "Observe Social+ Flutter SDK objects and collections with Dart stre
 
 The Flutter SDK exposes live objects as Dart streams and live collections through `LiveCollection` / `LiveCollectionStream`. A live collection emits `LiveResult<T>`, which contains the current `data` list and an `isFetching` flag.
 
-## Platform surface
+## Platform Surface
 
 | Surface | Public shape | Notes |
 | --- | --- | --- |
@@ -26,7 +26,7 @@ The Flutter SDK exposes live objects as Dart streams and live collections throug
 | `LiveResult<T>.data` | Collection stream | Current list snapshot. |
 | `LiveResult<T>.isFetching` | Collection stream | Whether the collection is currently fetching. |
 
-## Observe a live object
+## Observe A Live Object
 
 Observe a live object when your Flutter UI needs one SDK object to stay current after server or local-cache changes.
 
@@ -46,7 +46,7 @@ await subscription.cancel();
 
 </CodeGroup>
 
-## Observe a live collection
+## Observe A Live Collection
 
 `getStream()` emits `LiveResult<AmityPost>`. Keep the collection instance so you can load more pages and dispose it later.
 
@@ -87,7 +87,7 @@ await liveCollection.dispose();
 - Call `reset()` to clear the collection and reload the first page.
 - Cancel every `StreamSubscription` and call `dispose()` on live collections that are no longer used.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Post Retrieval" icon="newspaper" href="/social-plus-sdk/social/content-management/posts/retrieval/get-post">

--- a/social-plus-sdk/core-concepts/realtime-communication/presence-state/channel-presence.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/presence-state/channel-presence.mdx
@@ -41,7 +41,7 @@ Only conversation channels support channel presence. The SDK sync limit is 20 ch
 | User presences | `presence.userPresences` | `presence.getUserPresences()` | Presence records for members in the channel. |
 | Any other member online | `presence.isAnyMemberOnline` | `presence.isAnyMemberOnline()` | `true` when at least one member other than the current user is online. |
 
-## syncChannelPresence()
+## Sync Channel Presence
 
 Start syncing when a conversation channel becomes visible, then unsync it when the row or screen is gone.
 
@@ -92,7 +92,7 @@ repository.unsyncChannelPresence(channelId)
 
 </CodeGroup>
 
-## unsyncAllChannelPresence()
+## Unsync All Channel Presence
 
 Use `unsyncAllChannelPresence` when leaving a channel list, tearing down a view model, or replacing the whole visible channel set.
 

--- a/social-plus-sdk/core-concepts/realtime-communication/presence-state/room-presence.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/presence-state/room-presence.mdx
@@ -31,7 +31,7 @@ Room presence is available on iOS, Android, and TypeScript. It is not available 
 | `observeOnlineUsersCount` | Android | `interval` | No | Poll interval in seconds. Defaults to 15 seconds. |
 | `getRoomOnlineUsers` / `getOnlineUsersSnapshot` | All supported platforms | None or `roomId` | Platform-dependent | Reads a point-in-time list or snapshot of online room users. Android snapshots paginate 20 users at a time. |
 
-## startHeartbeat()
+## Start Room Heartbeat
 
 Start the room heartbeat when the user enters the room, and stop it when they leave. The SDK sends the first heartbeat immediately and continues at the server-configured interval.
 
@@ -73,7 +73,7 @@ RoomPresenceRepository.stopHeartbeat(roomId);
 
 </CodeGroup>
 
-## getRoomUserCount()
+## Read Room User Count
 
 Use the count as the source of truth for how many users are currently present in the room.
 
@@ -150,7 +150,7 @@ clearInterval(timer);
 
 </CodeGroup>
 
-## getRoomOnlineUsers()
+## Read Room Online Users
 
 Use the online-user list when the app needs actual user objects, such as avatars in a "who is watching" panel. For large rooms, display the count as the total and treat the list as a snapshot.
 

--- a/social-plus-sdk/core-concepts/realtime-communication/presence-state/user-presence.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/presence-state/user-presence.mdx
@@ -44,7 +44,7 @@ The current TypeScript and Flutter SDKs in this checkout do not expose a user pr
 The SDK limits active presence syncing to 20 user IDs at a time. Unsync users when their row, card, or profile preview is no longer visible.
 </Info>
 
-## getUserPresence()
+## Read User Presence
 
 Fetch presence for known users as a one-shot read.
 
@@ -80,7 +80,7 @@ repository.getUserPresence(listOf(userId))
 
 </CodeGroup>
 
-## syncUserPresence()
+## Sync User Presence
 
 Sync user presence while users are visible, then unsync them when the UI no longer needs updates.
 
@@ -129,7 +129,7 @@ repository.unsyncUserPresence(userId)
 
 </CodeGroup>
 
-## getOnlineUsersCount() and getOnlineUsersSnapshot()
+## Read Online Users Count And Snapshot
 
 Use the count for a network-wide online total. Use the snapshot when you need actual user objects at the time of the query.
 

--- a/social-plus-sdk/core-concepts/realtime-communication/push-notifications/register-and-unregister-push-notifications-on-a-device.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/push-notifications/register-and-unregister-push-notifications-on-a-device.mdx
@@ -9,7 +9,7 @@ Device registration connects the current signed-in user to the device token that
 The TypeScript SDK does not expose a client-side device registration API. Use the native iOS, Android, or Flutter SDK APIs on device, and use server-side/webhook flows for web delivery.
 </Warning>
 
-## Platform surface
+## Platform Surface
 
 | Platform | Register | Unregister | Token argument |
 | --- | --- | --- | --- |
@@ -27,7 +27,7 @@ The TypeScript SDK does not expose a client-side device registration API. Use th
 
 Android registration does not accept a token argument in the current SDK API. The Android SDK registers the current signed-in user/device through `AmityCoreClient.registerPushNotification()`.
 
-## Register a device
+## Register A Device
 
 Register the current signed-in user/device after platform push setup and SDK initialization are complete.
 
@@ -58,7 +58,7 @@ await AmityCoreClient.registerDeviceNotification(fcmToken);
 On Android, `registerPushNotification()` is a no-op for visitor and bot users. Register only after the app has a signed-in user session.
 </Note>
 
-## Unregister a device
+## Unregister A Device
 
 Call unregister when the user signs out or when this app installation should stop receiving push notifications for the currently registered user.
 
@@ -85,7 +85,7 @@ await AmityCoreClient.unregisterDeviceNotification();
 
 </CodeGroup>
 
-## Related setup
+## Related Setup
 
 Complete platform setup before calling the SDK registration API:
 

--- a/social-plus-sdk/core-concepts/realtime-communication/realtime-events/chat-realtime-events.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/realtime-events/chat-realtime-events.mdx
@@ -9,7 +9,7 @@ Chat real-time event subscriptions keep a thread's live data moving while the us
 Conversation and community channel members receive many chat updates through normal SDK live objects and collections. Use a subchannel topic when the screen needs explicit realtime delivery for a specific message thread.
 </Info>
 
-## Platform surface
+## Platform Surface
 
 | Platform | Public API | Cleanup |
 | --- | --- | --- |
@@ -27,7 +27,7 @@ Conversation and community channel members receive many chat updates through nor
 | Android | `subChannel` | Yes | `AmitySubChannel` model exposing the public `subscription()` method. |
 | Flutter | `subChannel` | Yes | `AmitySubChannel` model exposing the public `subscription()` method. |
 
-## Subscribe to a subchannel
+## Subscribe To A Subchannel
 
 Subscribe when the thread screen becomes active, and unsubscribe when it leaves the screen or switches to another subchannel.
 
@@ -89,7 +89,7 @@ Future<void> unsubscribeFromSubChannel(AmitySubChannel subChannel) async {
 
 </CodeGroup>
 
-## Best practices
+## Best Practices
 
 <AccordionGroup>
   <Accordion title="Subscribe per visible thread" icon="messages-square">
@@ -105,7 +105,7 @@ Future<void> unsubscribeFromSubChannel(AmitySubChannel subChannel) async {
   </Accordion>
 </AccordionGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Messages" href="/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages" icon="message-square">

--- a/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
@@ -9,7 +9,7 @@ Real-time events are MQTT topic subscriptions managed by the SDK. Subscribe to t
 Topic subscriptions do not replace Live Objects & Collections. Use subscriptions to tell the SDK which event streams matter now, then render from the live data APIs.
 </Info>
 
-## Platform surface
+## Platform Surface
 
 | Area | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -17,7 +17,7 @@ Topic subscriptions do not replace Live Objects & Collections. Use subscriptions
 | Chat topics | `getSubChannelTopic(subChannel)` with `subscribeTopic(topic)` | `AmitySubChannelTopic` with `AmityTopicSubscription` | `subChannel.subscription()` | `subChannel.subscription()` |
 | Unsubscribe | Call the `Amity.Unsubscriber` returned by `subscribeTopic` | `unsubscribeTopic(...)` | `unsubscribeTopic()` | `unsubscribeTopic()` |
 
-## Topic lifecycle
+## Topic Lifecycle
 
 ```mermaid
 flowchart LR
@@ -27,7 +27,7 @@ flowchart LR
     D --> E["Unsubscribe when no longer needed"]
 ```
 
-## When to subscribe
+## When To Subscribe
 
 | UI need | Recommended topic |
 | --- | --- |
@@ -40,7 +40,7 @@ flowchart LR
 | Follow/follower list changes | Follow topic on platforms that expose follow topic helpers |
 | Story updates | Story topic or community-story topic where available |
 
-## Subscription discipline
+## Subscription Discipline
 
 <AccordionGroup>
   <Accordion title="Subscribe from the visible model" icon="eye">
@@ -60,7 +60,7 @@ flowchart LR
   </Accordion>
 </AccordionGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Social Real-time Events" href="/social-plus-sdk/core-concepts/realtime-communication/realtime-events/social-realtime-events" icon="users">

--- a/social-plus-sdk/core-concepts/realtime-communication/realtime-events/social-realtime-events.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/realtime-events/social-realtime-events.mdx
@@ -9,7 +9,7 @@ Social real-time events let an app receive live updates for the social models th
 Community and user-scoped topics are useful for feed screens. Post and comment topics are better for focused detail screens. The user must have access to the target community, post, comment, user, or story for events to be delivered.
 </Info>
 
-## Platform surface
+## Platform Surface
 
 | Topic | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -20,11 +20,11 @@ Community and user-scoped topics are useful for feed screens. Post and comment t
 | Follow | `getMyFollowersTopic()`, `getMyFollowingsTopic()` | `AmityFollowTopic` | `AmityCoreClient.subscription(AmityTopic.FOLLOW(...))` | Not exposed in this checkout |
 | Story | `getStoryTopic(...)`, `getCommunityStoriesTopic(...)` | `AmityStoryTopic` | `story.subscription()` | `story.subscription()` |
 
-## Community topic
+## Community Topic
 
 Use a community topic when a screen is scoped to a community, such as a community profile, feed, or moderation surface.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -96,11 +96,11 @@ Future<void> subscribeToCommunityFeed(AmityCommunity community) async {
 
 </CodeGroup>
 
-## Post topic
+## Post Topic
 
 Use a post topic for a single post detail screen or a moderation/action surface focused on one post.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -164,11 +164,11 @@ Future<void> subscribeToPostComments(AmityPost post) async {
 
 </CodeGroup>
 
-## Comment topic
+## Comment Topic
 
 Use a comment topic for a focused comment detail, moderation, or realtime reply surface.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -229,11 +229,11 @@ Future<void> subscribeToComment(AmityComment comment) async {
 
 </CodeGroup>
 
-## User topic
+## User Topic
 
 Use a user topic when a screen needs live updates for a user profile or that user's feed activity.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -298,7 +298,7 @@ Future<void> subscribeToUserPosts(AmityUser user) async {
 
 </CodeGroup>
 
-## Follow topic
+## Follow Topic
 
 Follow topics observe changes to the current user's follower and following lists.
 
@@ -306,7 +306,7 @@ Follow topics observe changes to the current user's follower and following lists
 The current Flutter SDK checkout does not expose a public follow topic subscription helper. Use this section for TypeScript, iOS, and Android.
 </Warning>
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -359,11 +359,11 @@ fun subscribeToMyFollowers() {
 
 </CodeGroup>
 
-## Story topic
+## Story Topic
 
 Story topics observe one story or a community's story stream.
 
-### Event levels
+### Event Levels
 
 | Intent | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -480,7 +480,7 @@ Future<void> unsubscribeFromCommunityFeed(AmityCommunity community) async {
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Real-time Events Overview" href="/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview" icon="refresh-cw">


### PR DESCRIPTION
## Summary
- normalized realtime SDK headings across presence, live objects/collections, realtime events, and device registration pages
- changed raw method-name section headings into reader-friendly action headings while keeping method names in parameter tables and snippets
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Notes
- structure-only slice; no SDK snippets or API semantics changed
- live objects and live collections content was left intentionally conservative because those pages are complex

## Validation
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/core-concepts/realtime-communication`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/core-concepts/realtime-communication`
- `python3 tools/check_internal_links.py social-plus-sdk/core-concepts/realtime-communication`
- `cd llmstxt && go test ./...`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `git diff --check`