### PR TITLE
Normalize user management operation pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3816,7 +3816,7 @@ social.plus SDK creates new users through the `login` method. A single call to `
 
 The `login` method serves dual purposes: it creates new users when they don't exist and authenticates existing users when they do.
 
-## How user creation works
+## How User Creation Works
 
 When you call the `login` method:
 
@@ -3832,7 +3832,7 @@ When you call the `login` method:
 | `authToken` | No | Secure token used when your app enables secure mode. |
 | `sessionHandler` | Platform-dependent | Handles access-token renewal for authenticated sessions. |
 
-## Code examples
+## Code Examples
 
 Call the platform login method with a `userId`; include `displayName`, `authToken`, and session renewal handling when your integration needs them.
 
@@ -3906,7 +3906,7 @@ void login() async {
 }
 ```
 
-## Related topics
+## Related Topics
 
     Learn how to retrieve user data and profiles.
     Discover how to modify user profiles and settings.
@@ -3921,7 +3921,7 @@ Retrieve user information using the UserRepository to display profiles, user car
 
 **Live Objects**: User data is returned as Live Objects that automatically update when the underlying data changes, keeping your UI synchronized.
 
-## Common inputs
+## Common Inputs
 
 | Input | Description |
 | --- | --- |
@@ -3929,7 +3929,7 @@ Retrieve user information using the UserRepository to display profiles, user car
 | User repository | Platform-specific user repository or client method used to query user data. |
 | Observer or callback | Receives live object or live collection updates where supported. |
 
-## Get a single user
+## Get A Single User
 
 Retrieve a specific user by their unique ID:
 
@@ -4003,7 +4003,7 @@ void getUser() {
 }
 ```
 
-## Get multiple users
+## Get Multiple Users
 
 Retrieve multiple users efficiently using batch operations:
 
@@ -4159,7 +4159,7 @@ liveCollection.getStreamController().stream.listen((userList) {
 });
 ```
 
-## Related topics
+## Related Topics
 
     Search users by display name and query user collections.
 
@@ -4186,7 +4186,7 @@ Before setting an avatar, upload the image file first. Refer to the [Image Uploa
 | Avatar | No | Uploaded image reference used as the user's avatar. |
 | Metadata | No | Custom key-value data associated with the user profile. |
 
-## Code examples
+## Code Examples
 
 Call the platform update method with only the profile fields you want to change.
 
@@ -4273,15 +4273,15 @@ Future<void> updateUser() async {
 }
 ```
 
-## Best practices
+## Best Practices
 
-### Performance optimization
+### Performance Optimization
 
 When updating multiple user properties, combine them into a single update operation instead of making separate calls.
 
 Be mindful of update frequency to avoid hitting rate limits. Consider implementing debouncing for real-time input fields.
 
-## Related topics
+## Related Topics
 
     Learn how to retrieve updated user profiles.
     Understand user roles and permissions.
@@ -4296,11 +4296,11 @@ Client SDKs do not expose a public method to delete a user. User deletion is an 
 
 Do not implement user deletion directly in a client app. Treat deletion as a privileged backend workflow with explicit authorization, confirmation, and audit logging.
 
-## Admin-only feature
+## Admin-Only Feature
 
 User deletion can only be performed by **admin users** through the API or Console. Regular users cannot delete other users or themselves through the SDK.
 
-## SDK availability
+## SDK Availability
 
 | Surface | Availability |
 | --- | --- |
@@ -4310,7 +4310,7 @@ User deletion can only be performed by **admin users** through the API or Consol
 | Flutter SDK | No public delete-user method |
 | Admin flow | Use the Console or a server-side API integration where credentials and authorization stay off the client. |
 
-## Deleted user behavior
+## Deleted User Behavior
 
 Deletion behavior is controlled by the admin/API flow you use. Review the server-side API options for the exact data-removal scope before exposing this workflow in your product.
 
@@ -4326,12 +4326,11 @@ Deletion behavior is controlled by the admin/API flow you use. Review the server
     - Refresh affected lists after deletion so counts and user labels update.
     - Keep product-specific account state in sync with the backend operation.
 
-## SDK implementation
+## SDK Implementation
 
 User deletion is typically performed through the Admin Console or server-side API calls, not directly through client SDKs for security reasons. Refer to the API Reference introduction for endpoint availability.
 
-
-## Best practices
+## Best Practices
 
     - **Verify admin permissions**: Always check that the requesting user has admin privileges.
     - **User confirmation**: Implement confirmation dialogs for irreversible actions.
@@ -4351,13 +4350,13 @@ User deletion is typically performed through the Admin Console or server-side AP
     - **Reference cleanup**: Update any application-specific references to deleted users.
     - **Compliance documentation**: Maintain records for regulatory compliance.
 
-## Performance considerations
+## Performance Considerations
 
 When deleting multiple users through an admin workflow, process them in small batches to avoid overwhelming the server and to improve error handling.
 
 Users with extensive content may take longer to delete. Consider implementing progress indicators in your admin workflow.
 
-## Alternative approaches
+## Alternative Approaches
 
 Consider these alternatives before permanent deletion:
 
@@ -4366,7 +4365,7 @@ Consider these alternatives before permanent deletion:
 | User suspension | You need to temporarily block user access without deleting account data. |
 | Content moderation | You need to remove problematic content while preserving the user account. |
 
-## Compliance considerations
+## Compliance Considerations
 
 When implementing user deletion, ensure compliance with applicable data protection regulations such as GDPR, CCPA, and other privacy laws in your jurisdiction.
 
@@ -4380,31 +4379,31 @@ Use the user repository to find users by display name, or query the full user li
 
 Deleted users are automatically excluded from all search and query results to maintain data integrity.
 
-## Search and query options
+## Search And Query Options
 
 | Operation | Use when | SDK notes |
 | --- | --- | --- |
 | Search users | You need to find users by display name keyword. | iOS and Android use `searchUsers`; TypeScript and Flutter use `searchUserByDisplayName`. |
 | Query users | You need to retrieve a user collection with sorting and pagination. | Sort options vary by SDK. |
 
-## Search users by display name
+## Search Users By Display Name
 
 Query for users by their display name, receiving a collection of AmityUser matching your search. It requires two parameters: the display name you're searching for, and a 'sort option' from the AmityUserSortOption enum.
 
-### Search requirements
+### Search Requirements
 
 - **Search keywords must be at least 3 characters long**
 - When a keyword is provided, the list will be arranged based on search rank
 - iOS and TypeScript expose display-name sorting for search results
 
-### Sorting options
+### Sorting Options
 
 Users have the option to sort by:
 - **displayName**: Alphabetical sorting using ICU collation for English locale (default)
 - **lastCreated**: Most recently created users first
 - **firstCreated**: Oldest users first
 
-### Special character handling
+### Special Character Handling
 
 With the displayName sorting option, users are sorted alphabetically by their display names using ICU collation for the English locale. This means that special characters such as Ä are treated as variants of A. For example, a sorted list might appear as: **adam, Älex, Alice, Arthur, charlie, Kristen**.
 
@@ -4412,7 +4411,7 @@ When providing a search keyword, the API performs an **exact-match lookup for sp
 - Searching for "Äli" will only return users whose display name contains "Äli" (e.g., "Älise")
 - Searching for "Alice" will NOT return "Älice"
 
-### Search code examples
+### Search Code Examples
 
 Use the platform search method to retrieve users whose display name matches the search keyword.
 
@@ -4479,17 +4478,17 @@ void searchUserByDisplayName(String keyword) {
 }
 ```
 
-## Query users
+## Query Users
 
 Query for users to receive a collection of AmityUser objects. iOS, Android, and Flutter expose display-name sorting for query results. TypeScript query sorting supports `firstCreated` and `lastCreated`.
 
-### Sorting behavior
+### Sorting Behavior
 
 With the displayName sorting option, users are sorted alphabetically by their display names using ICU collation for the English locale. This means that special characters such as Ä are treated as variants of A. For example, a sorted list might appear as: **adam, Älex, Alice, Arthur, charlie, Kristen**.
 
 **Deleted users are excluded from the results**
 
-### Query code examples
+### Query Code Examples
 
 Use the platform query method when you need a paginated user list rather than keyword search.
 
@@ -4583,7 +4582,7 @@ void getUsers(AmityUserSortOption amityUserSortOption) {
 }
 ```
 
-## Best practices
+## Best Practices
 
     - Implement debouncing for real-time search to reduce API calls.
     - Use minimum character requirements before triggering search.
@@ -4600,7 +4599,7 @@ void getUsers(AmityUserSortOption amityUserSortOption) {
     - Provide filters for different user types or statuses.
     - Enable sorting options based on user needs.
 
-## Related topics
+## Related Topics
 
     Learn how to retrieve detailed user profiles.
     Discover how to modify user profiles.
@@ -4615,7 +4614,7 @@ Use user flagging to let members report inappropriate behavior for moderator rev
 
 Flagging a user helps moderators identify potential issues without immediately taking action. It's a reporting mechanism that requires admin review.
 
-## Available operations
+## Available Operations
 
 | Operation | Description |
 | --- | --- |
@@ -4623,7 +4622,7 @@ Flagging a user helps moderators identify potential issues without immediately t
 | Unflag user | Remove the current user's flag from a user. |
 | Check flag status | Check whether the current user has flagged a specific user. |
 
-## Flag a user
+## Flag A User
 
 To flag a user, call the following method:
 
@@ -4666,7 +4665,7 @@ void flagUser(AmityUser user) {
 }
 ```
 
-## Unflag a user
+## Unflag A User
 
 To unflag a user, call the following method:
 
@@ -4709,7 +4708,7 @@ void unflagUser(AmityUser user) {
 }
 ```
 
-## Check whether the current user flagged a user
+## Check Whether The Current User Flagged A User
 
 To check whether a user has been flagged by the current user:
 
@@ -4749,8 +4748,7 @@ void isFlaggedByMe(AmityUser user) {
 }
 ```
 
-
-## Best practices
+## Best Practices
 
     - Provide clear reasons for flagging options.
     - Show confirmation dialogs for flag actions.
@@ -4765,7 +4763,7 @@ void isFlaggedByMe(AmityUser user) {
     - Log flag operations for debugging.
     - Show appropriate error messages to users.
 
-## Related topics
+## Related Topics
 
     Learn how to retrieve user details and flag status.
     Understand user moderation privileges.
@@ -4780,7 +4778,7 @@ Use `AmityUserTokenManager` to create user credentials for flows that require a 
 
 Client SDKs do not provide APIs for using user tokens directly. To use a user token, call social.plus Server APIs from your own backend or trusted server-side workflow.
 
-## Create a user token
+## Create A User Token
 
 To create a new user token, refer to the following example and the parameters below.
 
@@ -4792,7 +4790,7 @@ To create a new user token, refer to the following example and the parameters be
 | `displayName` | String | No | Display name associated with the user credentials when provided. |
 | `authToken` | String | No | Secure authentication token used when your app enables secure mode. |
 
-### Code examples
+### Code Examples
 
 Create a user token from a trusted flow using the user's identifier and optional secure-mode credentials.
 
@@ -4861,7 +4859,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
 }
 ```
 
-## Token security
+## Token Security
 
     - Store tokens securely on the server side.
     - Use encryption for token storage.
@@ -4873,7 +4871,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
     - Use secure communication channels.
     - Log token usage for audit purposes.
 
-## Best practices
+## Best Practices
 
     - Cache tokens to avoid unnecessary creation.
     - Implement token validation before usage.
@@ -4890,7 +4888,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
     - Implement caching strategies.
     - Monitor token usage patterns.
 
-## Related topics
+## Related Topics
 
     Learn about standard user login and authentication.
     Explore social.plus API documentation.

--- a/social-plus-sdk/core-concepts/user-management/user-operations/create-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/create-user.mdx
@@ -9,7 +9,7 @@ social.plus SDK creates new users through the `login` method. A single call to `
 The `login` method serves dual purposes: it creates new users when they don't exist and authenticates existing users when they do.
 </Info>
 
-## How user creation works
+## How User Creation Works
 
 When you call the `login` method:
 
@@ -25,7 +25,7 @@ When you call the `login` method:
 | `authToken` | No | Secure token used when your app enables secure mode. |
 | `sessionHandler` | Platform-dependent | Handles access-token renewal for authenticated sessions. |
 
-## Code examples
+## Code Examples
 
 Call the platform login method with a `userId`; include `displayName`, `authToken`, and session renewal handling when your integration needs them.
 
@@ -101,7 +101,7 @@ void login() async {
 ```
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get User Information" href="./get-user-information" icon="user">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/delete-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/delete-user.mdx
@@ -9,13 +9,13 @@ Client SDKs do not expose a public method to delete a user. User deletion is an 
 Do not implement user deletion directly in a client app. Treat deletion as a privileged backend workflow with explicit authorization, confirmation, and audit logging.
 </Danger>
 
-## Admin-only feature
+## Admin-Only Feature
 
 <Info>
 User deletion can only be performed by **admin users** through the API or Console. Regular users cannot delete other users or themselves through the SDK.
 </Info>
 
-## SDK availability
+## SDK Availability
 
 | Surface | Availability |
 | --- | --- |
@@ -25,7 +25,7 @@ User deletion can only be performed by **admin users** through the API or Consol
 | Flutter SDK | No public delete-user method |
 | Admin flow | Use the Console or a server-side API integration where credentials and authorization stay off the client. |
 
-## Deleted user behavior
+## Deleted User Behavior
 
 Deletion behavior is controlled by the admin/API flow you use. Review the server-side API options for the exact data-removal scope before exposing this workflow in your product.
 
@@ -49,14 +49,13 @@ Deletion behavior is controlled by the admin/API flow you use. Review the server
   </Accordion>
 </AccordionGroup>
 
-## SDK implementation
+## SDK Implementation
 
 <Note>
 User deletion is typically performed through the Admin Console or server-side API calls, not directly through client SDKs for security reasons. Refer to the API Reference introduction for endpoint availability.
 </Note>
 
-
-## Best practices
+## Best Practices
 
 <AccordionGroup>
   <Accordion title="Before deletion">
@@ -84,7 +83,7 @@ User deletion is typically performed through the Admin Console or server-side AP
   </Accordion>
 </AccordionGroup>
 
-## Performance considerations
+## Performance Considerations
 
 <Tip>
 When deleting multiple users through an admin workflow, process them in small batches to avoid overwhelming the server and to improve error handling.
@@ -94,7 +93,7 @@ When deleting multiple users through an admin workflow, process them in small ba
 Users with extensive content may take longer to delete. Consider implementing progress indicators in your admin workflow.
 </Warning>
 
-## Alternative approaches
+## Alternative Approaches
 
 Consider these alternatives before permanent deletion:
 
@@ -103,7 +102,7 @@ Consider these alternatives before permanent deletion:
 | User suspension | You need to temporarily block user access without deleting account data. |
 | Content moderation | You need to remove problematic content while preserving the user account. |
 
-## Compliance considerations
+## Compliance Considerations
 
 <Info>
 When implementing user deletion, ensure compliance with applicable data protection regulations such as GDPR, CCPA, and other privacy laws in your jurisdiction.

--- a/social-plus-sdk/core-concepts/user-management/user-operations/flag-unflag-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/flag-unflag-user.mdx
@@ -9,7 +9,7 @@ Use user flagging to let members report inappropriate behavior for moderator rev
 Flagging a user helps moderators identify potential issues without immediately taking action. It's a reporting mechanism that requires admin review.
 </Info>
 
-## Available operations
+## Available Operations
 
 | Operation | Description |
 | --- | --- |
@@ -17,7 +17,7 @@ Flagging a user helps moderators identify potential issues without immediately t
 | Unflag user | Remove the current user's flag from a user. |
 | Check flag status | Check whether the current user has flagged a specific user. |
 
-## Flag a user
+## Flag A User
 
 To flag a user, call the following method:
 
@@ -62,7 +62,7 @@ void flagUser(AmityUser user) {
 ```
 </CodeGroup>
 
-## Unflag a user
+## Unflag A User
 
 To unflag a user, call the following method:
 
@@ -107,7 +107,7 @@ void unflagUser(AmityUser user) {
 ```
 </CodeGroup>
 
-## Check whether the current user flagged a user
+## Check Whether The Current User Flagged A User
 
 To check whether a user has been flagged by the current user:
 
@@ -149,8 +149,7 @@ void isFlaggedByMe(AmityUser user) {
 ```
 </CodeGroup>
 
-
-## Best practices
+## Best Practices
 
 <AccordionGroup>
   <Accordion title="User experience">
@@ -173,7 +172,7 @@ void isFlaggedByMe(AmityUser user) {
   </Accordion>
 </AccordionGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get User Information" href="./get-user-information" icon="user">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx
@@ -9,7 +9,7 @@ Retrieve user information using the UserRepository to display profiles, user car
 **Live Objects**: User data is returned as Live Objects that automatically update when the underlying data changes, keeping your UI synchronized.
 </Info>
 
-## Common inputs
+## Common Inputs
 
 | Input | Description |
 | --- | --- |
@@ -17,7 +17,7 @@ Retrieve user information using the UserRepository to display profiles, user car
 | User repository | Platform-specific user repository or client method used to query user data. |
 | Observer or callback | Receives live object or live collection updates where supported. |
 
-## Get a single user
+## Get A Single User
 
 Retrieve a specific user by their unique ID:
 
@@ -93,7 +93,7 @@ void getUser() {
 ```
 </CodeGroup>
 
-## Get multiple users
+## Get Multiple Users
 
 Retrieve multiple users efficiently using batch operations:
 
@@ -251,7 +251,7 @@ liveCollection.getStreamController().stream.listen((userList) {
 ```
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Search and Query Users" href="./search-and-query-users" icon="user-magnifying-glass">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
@@ -9,18 +9,18 @@ Use the user repository to find users by display name, or query the full user li
 Deleted users are automatically excluded from all search and query results to maintain data integrity.
 </Info>
 
-## Search and query options
+## Search And Query Options
 
 | Operation | Use when | SDK notes |
 | --- | --- | --- |
 | Search users | You need to find users by display name keyword. | iOS and Android use `searchUsers`; TypeScript and Flutter use `searchUserByDisplayName`. |
 | Query users | You need to retrieve a user collection with sorting and pagination. | Sort options vary by SDK. |
 
-## Search users by display name
+## Search Users By Display Name
 
 Query for users by their display name, receiving a collection of AmityUser matching your search. It requires two parameters: the display name you're searching for, and a 'sort option' from the AmityUserSortOption enum.
 
-### Search requirements
+### Search Requirements
 
 <Note>
 - **Search keywords must be at least 3 characters long**
@@ -28,14 +28,14 @@ Query for users by their display name, receiving a collection of AmityUser match
 - iOS and TypeScript expose display-name sorting for search results
 </Note>
 
-### Sorting options
+### Sorting Options
 
 Users have the option to sort by:
 - **displayName**: Alphabetical sorting using ICU collation for English locale (default)
 - **lastCreated**: Most recently created users first  
 - **firstCreated**: Oldest users first
 
-### Special character handling
+### Special Character Handling
 
 <Info>
 With the displayName sorting option, users are sorted alphabetically by their display names using ICU collation for the English locale. This means that special characters such as Ä are treated as variants of A. For example, a sorted list might appear as: **adam, Älex, Alice, Arthur, charlie, Kristen**.
@@ -45,7 +45,7 @@ When providing a search keyword, the API performs an **exact-match lookup for sp
 - Searching for "Alice" will NOT return "Älice"
 </Info>
 
-### Search code examples
+### Search Code Examples
 
 Use the platform search method to retrieve users whose display name matches the search keyword.
 
@@ -114,11 +114,11 @@ void searchUserByDisplayName(String keyword) {
 ```
 </CodeGroup>
 
-## Query users
+## Query Users
 
 Query for users to receive a collection of AmityUser objects. iOS, Android, and Flutter expose display-name sorting for query results. TypeScript query sorting supports `firstCreated` and `lastCreated`.
 
-### Sorting behavior
+### Sorting Behavior
 
 <Info>
 With the displayName sorting option, users are sorted alphabetically by their display names using ICU collation for the English locale. This means that special characters such as Ä are treated as variants of A. For example, a sorted list might appear as: **adam, Älex, Alice, Arthur, charlie, Kristen**.
@@ -126,7 +126,7 @@ With the displayName sorting option, users are sorted alphabetically by their di
 **Deleted users are excluded from the results**
 </Info>
 
-### Query code examples
+### Query Code Examples
 
 Use the platform query method when you need a paginated user list rather than keyword search.
 
@@ -222,7 +222,7 @@ void getUsers(AmityUserSortOption amityUserSortOption) {
 ```
 </CodeGroup>
 
-## Best practices
+## Best Practices
 
 <AccordionGroup>
   <Accordion title="Search performance">
@@ -247,7 +247,7 @@ void getUsers(AmityUserSortOption amityUserSortOption) {
   </Accordion>
 </AccordionGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get User Information" href="./get-user-information" icon="user">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/update-user-information.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/update-user-information.mdx
@@ -20,7 +20,7 @@ Before setting an avatar, upload the image file first. Refer to the [Image Uploa
 | Avatar | No | Uploaded image reference used as the user's avatar. |
 | Metadata | No | Custom key-value data associated with the user profile. |
 
-## Code examples
+## Code Examples
 
 Call the platform update method with only the profile fields you want to change.
 
@@ -109,9 +109,9 @@ Future<void> updateUser() async {
 ```
 </CodeGroup>
 
-## Best practices
+## Best Practices
 
-### Performance optimization
+### Performance Optimization
 
 <Tip>
 When updating multiple user properties, combine them into a single update operation instead of making separate calls.
@@ -121,7 +121,7 @@ When updating multiple user properties, combine them into a single update operat
 Be mindful of update frequency to avoid hitting rate limits. Consider implementing debouncing for real-time input fields.
 </Warning>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get User Information" href="./get-user-information" icon="user">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/user-token-management.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/user-token-management.mdx
@@ -9,7 +9,7 @@ Use `AmityUserTokenManager` to create user credentials for flows that require a 
 Client SDKs do not provide APIs for using user tokens directly. To use a user token, call social.plus Server APIs from your own backend or trusted server-side workflow.
 </Warning>
 
-## Create a user token
+## Create A User Token
 
 To create a new user token, refer to the following example and the parameters below.
 
@@ -21,7 +21,7 @@ To create a new user token, refer to the following example and the parameters be
 | `displayName` | String | No | Display name associated with the user credentials when provided. |
 | `authToken` | String | No | Secure authentication token used when your app enables secure mode. |
 
-### Code examples
+### Code Examples
 
 Create a user token from a trusted flow using the user's identifier and optional secure-mode credentials.
 
@@ -92,7 +92,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
 ```
 </CodeGroup>
 
-## Token security
+## Token Security
 
 <AccordionGroup>
   <Accordion title="Secure storage">
@@ -110,7 +110,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
   </Accordion>
 </AccordionGroup>
 
-## Best practices
+## Best Practices
 
 <AccordionGroup>
   <Accordion title="Token management">
@@ -135,7 +135,7 @@ void createUserToken(String userId, String displayname, String secureToken) {
   </Accordion>
 </AccordionGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="User Authentication" href="../../../getting-started/authentication" icon="key">


### PR DESCRIPTION
## Summary
- normalized heading style across user-management operation SDK pages
- tightened small spacing issues around section breaks
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Notes
- structure-only slice; no SDK snippets, parameters, or API semantics changed
- intentionally kept the large roles/permissions reference out of this PR

## Validation
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/core-concepts/user-management/user-operations`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/core-concepts/user-management/user-operations`
- `python3 tools/check_internal_links.py social-plus-sdk/core-concepts/user-management/user-operations`
- `cd llmstxt && go test ./...`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `git diff --check`