### PR TITLE
Normalize chat SDK page structure

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11694,7 +11694,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
 
   Looking for a product walkthrough? Use [Channels & Conversations](/use-cases/chat/channels-and-conversations) and [Sending Messages](/use-cases/chat/sending-messages). Use this section when you need the exact SDK objects and methods.
 
-## SDK area map
+## SDK Area Map
 
 | Area | Use it for | Start here |
 | --- | --- | --- |
@@ -11705,7 +11705,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
 | Engagement features | Read message previews, unread counts, read status, delivery status, and receipt sync state. | [Unread Status Overview](/social-plus-sdk/chat/engagement-features/unread-status/overview) |
 | Content moderation | Connect user reports, message deletion, and channel governance into a product moderation flow. | [Content Moderation](/social-plus-sdk/chat/moderation-safety/content-moderation/overview) |
 
-## Platform coverage
+## Platform Coverage
 
 | Capability group | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -11720,14 +11720,14 @@ The Chat SDK is the client surface for building channel-based messaging across T
 
   Platform gaps are documented on the specific feature pages. Do not copy a code snippet from another platform when a public SDK surface is not exposed for your target platform.
 
-## Implementation shape
+## Implementation Shape
 
     Create or query the channel that owns the conversation, then resolve the target `subChannelId` for message APIs.
     Use member state to decide whether the current user can read, join, send, or moderate.
     Query messages by subchannel, apply message-type filters, and handle edits or soft deletes from the message model.
     Read previews, unread counters, receipt counts, and receipt sync state from the SDK where supported.
 
-## Product boundaries
+## Product Boundaries
 
 | Concern | SDK owns | Your app owns |
 | --- | --- | --- |
@@ -11736,7 +11736,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
 | Moderation | Message flagging, message deletion, and channel governance APIs. | Review queues, escalation policy, audit notes, appeal flows, and compliance workflows. |
 | Notifications | Data fields such as unread count, mention state, and preview content. | Push-notification templates, routing, deep links, and notification preferences. |
 
-## Related topics
+## Related Topics
 
     Start a community, live, or conversation channel.
     Send text, media, custom, and reply messages.
@@ -11752,7 +11752,7 @@ Conversation management covers the SDK calls that decide where chat happens and 
 
   If you want an end-to-end product walkthrough before choosing SDK calls, read [Channels & Conversations](/use-cases/chat/channels-and-conversations).
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -11764,7 +11764,7 @@ Conversation management covers the SDK calls that decide where chat happens and 
 | Member operations | Join, leave, query, search, and preview channel members. | [Member Management](./members/overview) |
 | Channel governance | Add or remove channel members, roles, bans, and mutes. | [Channel Governance](./channels/governance/overview) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -11776,20 +11776,20 @@ Conversation management covers the SDK calls that decide where chat happens and 
 | Get multiple known channel IDs | Supported | Supported | Supported | Not exposed in the current public Flutter repository |
 | Archive channels | Supported | Supported | Supported | Supported |
 
-## Channel and message targets
+## Channel And Message Targets
 
 Channel APIs operate on `channelId`. Message APIs usually operate on `subChannelId`. Resolve the target subchannel from the channel or subchannel flow before creating, querying, or syncing messages.
 
   The channel pages describe channel lifecycle calls. The messaging pages describe message calls after a `subChannelId` is available.
 
-## Implementation shape
+## Implementation Shape
 
     Use community for public or private group chat, live for event-style chat, and conversation for direct or small-group chat.
     Use type, membership, tag, deletion, and platform-specific search filters to build channel lists.
     Read membership before showing composer, join, leave, or moderation actions.
     Use role, member, ban, and mute APIs for channel-level moderation workflows.
 
-## Related topics
+## Related Topics
 
     Create, query, edit, delete, reply to, and flag messages after the channel target is known.
     Show unread counts, read status, delivery status, and receipt sync state.
@@ -11803,7 +11803,7 @@ Channel APIs operate on `channelId`. Message APIs usually operate on `subChannel
 
 Member management is the SDK surface for deciding who is in a channel and how your app reads that membership state. Use these pages when you need join and leave flows, member lists, mention pickers, moderator lists, or membership-aware UI.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -11814,7 +11814,7 @@ Member management is the SDK surface for deciding who is in a channel and how yo
 | Search members | Build mention pickers and member directories. | [Query Members](./query-members) |
 | Preview members | Show a small channel-member sample where the platform exposes preview members. | [Preview Members](./preview-members) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -11836,14 +11836,14 @@ Member management is the SDK surface for deciding who is in a channel and how yo
 | Search keyword | No | Search member display names where the platform exposes member search. |
 | `includeDeleted` | No | Include deleted users in member query results where supported. |
 
-## Implementation shape
+## Implementation Shape
 
     Read membership before showing the composer, join button, leave action, or banned-state messaging.
     Query members by channel, membership state, role, search keyword, and deletion state where supported.
     Use member search for mention pickers and user-selection flows.
     Use preview members where exposed; otherwise query a small member page for fallback display.
 
-## Related topics
+## Related Topics
 
     Assign or remove channel roles for members.
     Remove channel access until a user is unbanned.
@@ -11857,7 +11857,7 @@ Member management is the SDK surface for deciding who is in a channel and how yo
 
 Channel governance is the SDK surface for changing who can participate in a chat channel and what they can do there. Use these pages when you are building moderator tools, channel settings, admin panels, or support workflows.
 
-## Capability map
+## Capability Map
 
 | Capability | Purpose | SDK page |
 | --- | --- | --- |
@@ -11867,7 +11867,7 @@ Channel governance is the SDK surface for changing who can participate in a chat
 | Mute management | Restrict users from sending messages while keeping channel access. | [Mute Management](./mute-management) |
 | Member queries | Read current member, role, banned, and muted state. | [Query Members](/social-plus-sdk/chat/conversation-management/members/query-members) |
 
-## Platform coverage
+## Platform Coverage
 
 | Platform | Member add/remove | Role add/remove | Ban/unban | Mute/unmute |
 | --- | --- | --- | --- | --- |
@@ -11878,14 +11878,14 @@ Channel governance is the SDK surface for changing who can participate in a chat
 
   Governance operations are subject to channel type, membership state, and moderation permissions. If the server rejects an operation, treat that result as authoritative and show an actionable error in your product UI.
 
-## Implementation shape
+## Implementation Shape
 
     Use the governance pages for SDK calls that change membership, roles, bans, or mutes.
     Use member query and search APIs to render member lists, moderator lists, muted members, and banned members.
     Store reason codes, escalation rules, appeals, and audit records in your own backend if your product needs them.
     Some governance operations are only meaningful on channel types that support the target moderation behavior.
 
-## Related topics
+## Related Topics
 
     Create channels before applying governance operations.
     Read membership, role, banned, and muted state.
@@ -11904,7 +11904,7 @@ Use chat message APIs to build the message composer, message list, replies, reac
     Edit supported message types, soft-delete messages, and clear failed local messages where supported.
     Let users report or unreport messages for moderation review.
 
-## Message creation coverage
+## Message Creation Coverage
 
 | Message type | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -11917,7 +11917,7 @@ Use chat message APIs to build the message composer, message list, replies, reac
 
 Media-message inputs differ by platform. TypeScript creates media messages from uploaded file IDs. iOS accepts `AmityMessageAttachment` values such as `.localURL` or `.fileId`. Android accepts `AmityMessageAttachment` values such as `FILE_ID` or `URL`. Flutter creates image, file, and video messages from a `Uri`.
 
-## Implementation notes
+## Implementation Notes
 
 - Resolve the `subChannelId` from your channel flow before creating messages.
 - Use `parentId` when creating replies.
@@ -11925,7 +11925,7 @@ Media-message inputs differ by platform. TypeScript creates media messages from 
 - Upload or select media first when your target platform expects a file ID or attachment object.
 - Keep message state handling in the UI tied to the platform model returned by the SDK.
 
-## Related topics
+## Related Topics
 
     Choose the right create API for each message type.
     Create threaded replies with `parentId`.
@@ -11942,7 +11942,7 @@ Use message flagging when a signed-in user reports a chat message. The SDKs expo
 
 Flagged messages are sent to the moderation backend. Keep product policy, review workflow, and enforcement copy outside the SDK integration layer so this page stays focused on the calls your app makes.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Flag with reason | Unflag | Check current user's flag |
 | --- | --- | --- | --- |
@@ -11963,7 +11963,7 @@ The older Android no-reason `flagMessage(messageId)` overload and Flutter `flag(
 | Check flag state | `messageId` | Yes | Message ID to check through the repository where supported. |
 | Check flag state | Fetched message object | Depends | Android and Flutter expose `isFlaggedByMe` on a fetched `AmityMessage`. |
 
-## Flag a message
+## Flag A Message
 
 Flag a message with a moderation reason so your product can route it into review.
 
@@ -12011,7 +12011,7 @@ final isFlaggedByMe = flaggedMessage.isFlaggedByMe;
 ```
 
 
-## Use a custom reason
+## Use A Custom Reason
 
 Use the `Others` reason only when your UI collects additional detail from the reporter.
 
@@ -12063,7 +12063,7 @@ final flagCount = flaggedMessage.flagCount;
 ```
 
 
-## Unflag a message
+## Unflag A Message
 
 Remove the current user's flag from a message when the user reverses the report action.
 
@@ -12098,7 +12098,7 @@ final isFlaggedByMe = unflaggedMessage.isFlaggedByMe;
 ```
 
 
-## Check flag state
+## Check Flag State
 
 TypeScript and iOS can ask the repository for the current user's flag state by message ID. Android and Flutter expose the state on fetched message objects.
 
@@ -12141,7 +12141,7 @@ final isFlaggedByMe = fetchedMessage.isFlaggedByMe;
 ```
 
 
-## Related topics
+## Related Topics
 
     Refresh list state after flag or unflag actions.
     Modify or soft-delete your own messages.
@@ -12155,7 +12155,7 @@ final isFlaggedByMe = fetchedMessage.isFlaggedByMe;
 
 Unread status is the SDK surface for showing unread counts, marking messages read or delivered, and keeping receipt state current while a chat screen is active.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -12164,7 +12164,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
 | Message delivery status | Mark messages delivered and query receipt users where supported. | [Message Delivery Status](./message-delivery-status) |
 | Message receipt sync | Subscribe to receipt updates for the active subchannel. | [Message Receipt Sync](./message-receipt-sync) |
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12178,14 +12178,14 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
 
   Platform gaps are intentional documentation facts, not missing code snippets. Add a Flutter snippet for delivered users or receipt sync only after the Flutter SDK exposes a public API for that operation.
 
-## Implementation shape
+## Implementation Shape
 
     Use channel unread fields, total unread observers, mention flags, and message previews.
     Start receipt sync where supported, render messages, and call `message.markRead()` when messages are seen.
     Use read and delivered counts, then query receipt users where the platform exposes those APIs.
     Stop receipt sync when a screen closes or switches to a different subchannel.
 
-## Data ownership
+## Data Ownership
 
 | Data | Source |
 | --- | --- |
@@ -12195,7 +12195,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
 | Read and delivered user lists | Receipt-user query APIs where supported. |
 | Receipt sync state | Explicit subchannel receipt-sync APIs where supported. |
 
-## Related topics
+## Related Topics
 
     Show latest-message preview data beside unread state.
     Load message models before marking messages read.
@@ -12211,7 +12211,7 @@ Content moderation in the Chat SDK is built from specific client actions: users 
 
 Keep review policy, escalation rules, audit notes, and compliance workflows in your own product or backend. The SDK supplies the client-side actions and state needed to connect those workflows to chat.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -12222,7 +12222,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | Query deleted state | Include or exclude deleted messages where the platform exposes the filter. | [Query Messages](/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages) |
 | Channel governance | Manage members, roles, bans, and mutes for channel-level enforcement. | [Channel Governance](/social-plus-sdk/chat/conversation-management/channels/governance/overview) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12233,14 +12233,14 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | Query deleted messages | Supported | Supported | Supported | Supported |
 | Channel bans and mutes | Supported | Supported | Supported | Supported |
 
-## Moderation flow
+## Moderation Flow
 
     Call the platform flag API with the message ID and reason selected in your UI.
     Re-read or observe the message when the UI needs current flag, deletion, reaction, or receipt state.
     Treat soft-deleted messages as deleted in your renderer and avoid showing original content.
     Use role, ban, mute, and member APIs when moderation affects participation rather than a single message.
 
-## Product boundaries
+## Product Boundaries
 
 | Concern | SDK surface | Product or backend responsibility |
 | --- | --- | --- |
@@ -12249,7 +12249,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | User enforcement | Channel role, ban, mute, and member APIs. | Appeals, staff permissions, case notes, and cross-channel policy. |
 | Automation | Client-visible state after moderation actions. | Automated classifiers, review queues, escalation, and compliance exports. |
 
-## Related topics
+## Related Topics
 
     Flag, unflag, and read the current user's flag state.
     Update or soft-delete supported message types.
@@ -12265,7 +12265,7 @@ Use channel creation when your app needs a new chat container before sending mes
 
 For new integrations, let the SDK and server generate channel IDs. Custom channel IDs are not exposed on the current TypeScript, iOS, or Android creation APIs, and Flutter's custom `channelId` builder is deprecated.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Entry point | Channel types exposed here | Notes |
 | --- | --- | --- | --- |
@@ -12286,7 +12286,7 @@ For new integrations, let the SDK and server generate channel IDs. Custom channe
 | `isPublic` | No | Community-channel visibility flag where exposed. |
 | `isDistinct` | No | Conversation de-duplication flag where exposed; iOS distinct conversations default to `true`. |
 
-## Create a community channel
+## Create A Community Channel
 
 Create a community channel when your app needs a group chat space with optional public visibility, tags, and metadata.
 
@@ -12355,7 +12355,7 @@ final createdChannelId = channel.channelId;
 ```
 
 
-## Create a conversation channel
+## Create A Conversation Channel
 
 Conversation channels are for one-to-one or small-group private chat. Where the SDK exposes distinct conversation behavior, the default is to return the existing conversation for the same membership instead of creating a duplicate.
 
@@ -12412,7 +12412,7 @@ final channelId = conversation.channelId;
 ```
 
 
-## Create a live channel
+## Create A Live Channel
 
 Live channels support event-style chat. The platform builders expose optional metadata, tags, and members; iOS and Android also expose live-channel linkage fields such as room or post IDs in their builders.
 
@@ -12469,7 +12469,7 @@ final channelId = liveChannel.channelId;
 ```
 
 
-## Related topics
+## Related Topics
 
     Retrieve a single channel or load known channel IDs.
     Build channel lists with type, membership, tag, and deletion filters.
@@ -12486,7 +12486,7 @@ Use channel retrieval when your app already has a `channelId` and needs the curr
 
 Single-channel retrieval is available on all current SDKs. Batch lookup by channel IDs is exposed on TypeScript, iOS, and Android; the current public Flutter repository does not expose a batch-by-IDs method.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12503,7 +12503,7 @@ Single-channel retrieval is available on all current SDKs. Batch lookup by chann
 | Get one channel | Unsubscriber / token / disposable | No | Handle returned by live APIs; retain it while observing and release it when done. |
 | Get known channel IDs | `channelIds` | Yes | List of channel IDs to resolve into channel objects where the platform exposes batch lookup. |
 
-## Get one channel
+## Get One Channel
 
 Retrieve or observe one channel when your app already has its `channelId`.
 
@@ -12556,7 +12556,7 @@ final fetchedChannelId = channel.channelId;
 ```
 
 
-## Get known channel IDs
+## Get Known Channel IDs
 
 Use batch lookup when your app has a small list of known channel IDs and wants the matching channel objects. The collection is not the same as a general channel search; use [Query Channels](./query-channels) when you need filters or pagination.
 
@@ -12608,7 +12608,7 @@ val disposable = channelRepository
 ```
 
 
-## Related topics
+## Related Topics
 
     Create community, live, or conversation channels.
     Build paginated channel lists from filters.
@@ -12623,7 +12623,7 @@ val disposable = channelRepository
 
 Use channel queries to build inboxes, public channel discovery, event chat lists, and moderation views. Query support is similar across platforms, but not identical: TypeScript and Flutter expose keyword/display-name style searching, while Android's public channel query builder focuses on type, membership, tags, and deleted-state filters.
 
-## Filter surface
+## Filter Surface
 
 | Filter | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12650,7 +12650,7 @@ Use channel queries to build inboxes, public channel discovery, event chat lists
 | `sortBy` | No | Sort channel lists where the platform exposes sort options. |
 | Pagination controls | No | Use collection callbacks, live collections, or paging data to load additional channels. |
 
-## Query a channel list
+## Query A Channel List
 
 Query channels with type, membership, tag, deletion, archive, search, and pagination options where each platform exposes them.
 
@@ -12743,7 +12743,7 @@ await liveCollection.loadNext();
 ```
 
 
-## Query a specific type
+## Query A Specific Type
 
 Use the type-specific helpers when the platform exposes them. Some helpers apply membership defaults: for example, Flutter's `conversationType()` and `liveType()` also set the filter to `MEMBER`.
 
@@ -12809,7 +12809,7 @@ conversations.getStreamController().stream.listen((channels) {
 
 If you already have channel IDs, use [Get Channels](./get-channel) instead of a filtered query. Batch get-by-IDs is currently exposed on TypeScript, iOS, and Android.
 
-## Related topics
+## Related Topics
 
     Create a channel before it appears in query results.
     Retrieve a single channel or a known list of IDs.
@@ -12824,7 +12824,7 @@ If you already have channel IDs, use [Get Channels](./get-channel) instead of a 
 
 Use channel updates when the app needs to change channel attributes after creation. Keep updates narrow: send only fields that actually changed, because metadata and tag updates replace the submitted values rather than merging app-side state for you.
 
-## Update surface
+## Update Surface
 
 | Field | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12845,7 +12845,7 @@ Use channel updates when the app needs to change channel attributes after creati
 | `metadata` | No | Replacement metadata stored with the channel. |
 | `notificationMode` | No | Channel notification mode where TypeScript and Flutter expose it. |
 
-## Update channel fields
+## Update Channel Fields
 
 Update channel profile fields such as display name, avatar, tags, or metadata where the platform exposes those setters.
 
@@ -12907,7 +12907,7 @@ final updatedChannelId = channel.channelId;
 ```
 
 
-## Update notification mode
+## Update Notification Mode
 
 The channel update API exposes notification mode on TypeScript and Flutter. Use platform-specific notification settings pages for broader notification configuration.
 
@@ -12938,7 +12938,7 @@ final notificationMode = channel.notificationMode;
 ```
 
 
-## Related topics
+## Related Topics
 
     Observe the updated channel object.
     Refresh channel lists after an update.
@@ -12953,7 +12953,7 @@ final notificationMode = channel.notificationMode;
 
 Archiving is a per-user chat-list operation. It hides a channel from the active list for the current user without deleting the channel or its messages. In the current public SDKs, archive APIs are exposed on TypeScript and Flutter; iOS and Android do not expose public channel archive methods in this checkout.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -12970,7 +12970,7 @@ Archiving is a per-user chat-list operation. It hides a channel from the active 
 | Query archived channels | `limit` | No | TypeScript collection page size. |
 | Query archived channels | Pagination controls | No | Use TypeScript collection callbacks or Flutter live collection loading to fetch more archived channels. |
 
-## Archive or unarchive
+## Archive Or Unarchive
 
 Archive or unarchive a channel for the current user when the platform exposes archive state.
 
@@ -12990,7 +12990,7 @@ await repository.unarchiveChannel(channelId);
 ```
 
 
-## Query archived channels
+## Query Archived Channels
 
 Use the archived-channel collection for an archived inbox. The TypeScript API accepts live collection parameters such as `limit`; the Flutter API returns a live collection stream for the current user.
 
@@ -13036,7 +13036,7 @@ await archivedChannels.loadNext();
 | Channel deletion | Archiving is separate from channel deletion or soft deletion. |
 | Platform gaps | Use platform checks before exposing archive UI on iOS or Android. |
 
-## Related topics
+## Related Topics
 
     Use `excludeArchives` where the platform query supports it.
     Resolve an archived channel by ID before opening it.
@@ -13051,7 +13051,7 @@ await archivedChannels.loadNext();
 
 Use member management when your app needs to add users to a channel or remove users from a channel. Channel type, membership rules, and moderator permissions can still determine whether a request is accepted by the server.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13067,7 +13067,7 @@ Use member management when your app needs to add users to a channel or remove us
 | `userIds` | Yes | One or more user IDs to add or remove. Empty lists are rejected. |
 | Membership permission | Yes | The current user must be allowed to manage members for the target channel. |
 
-## Add members
+## Add Members
 
 Add members when an existing channel should include additional users. For conversation channels, prefer the conversation creation APIs when creating the conversation membership for the first time.
 
@@ -13108,7 +13108,7 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Remove members
+## Remove Members
 
 Remove members when users should no longer participate in the channel. If the user is currently viewing the channel, update the route or composer state after removal succeeds.
 
@@ -13149,14 +13149,14 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     All platforms accept a list of user IDs, so use one call for a small batch instead of looping one user at a time.
     Some channel types or roles can reject member changes. Treat failures as server authority, not as local state to override.
     Use join and leave APIs when the current user is entering or exiting a channel themselves.
     Query members after add or remove operations when your UI needs confirmed membership, role, or banned-state data.
 
-## Related topics
+## Related Topics
 
     Let the current user join or leave a channel.
     Retrieve and filter channel membership.
@@ -13170,7 +13170,7 @@ await AmityChatClient.newChannelRepository()
 
 Use channel roles when selected members need elevated channel permissions, such as moderator behavior. Role names are app-defined or configured for your Social+ project; the SDK applies or removes the role for the listed channel members.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13187,7 +13187,7 @@ Use channel roles when selected members need elevated channel permissions, such 
 | `userIds` | Yes | One or more member user IDs. Empty lists are rejected. |
 | Moderation permission | Yes | The current user must have permission to manage roles in the target channel. |
 
-## Add a role
+## Add A Role
 
 Add a role when channel members should receive the permissions represented by that role.
 
@@ -13231,7 +13231,7 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Remove a role
+## Remove A Role
 
 Remove a role when members should no longer have the permissions represented by that role.
 
@@ -13275,14 +13275,14 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     Pass the role ID string exactly as configured for your project. The SDK does not create new role definitions from this call.
     Assign roles to users who are channel members. Query the member list first when your UI needs to confirm eligibility.
     Role operations require moderation permission and can fail if the current user cannot manage the target role.
     Role moderation is meaningful on channel types that support member roles. Unsupported channel types can reject the request.
 
-## Related topics
+## Related Topics
 
     Add users before assigning channel roles.
     Filter members by role and membership state.
@@ -13296,7 +13296,7 @@ await AmityChatClient.newChannelRepository()
 
 Use channel bans when a member should lose access to a specific chat channel until a moderator restores access. The SDK operation is per-channel; ban reasons, appeal flows, and moderation audit logs are app-owned product logic.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13312,7 +13312,7 @@ Use channel bans when a member should lose access to a specific chat channel unt
 | `userIds` | Yes | One or more user IDs to ban or unban. Empty lists are rejected. |
 | Moderation permission | Yes | The current user must have permission to moderate the target channel. |
 
-## Ban members
+## Ban Members
 
 Ban removes the users from channel participation and prevents them from rejoining until they are unbanned.
 
@@ -13352,7 +13352,7 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Unban members
+## Unban Members
 
 Unban restores the users to the channel's allowed membership state. If your app shows a ban list, refresh that list after the operation succeeds.
 
@@ -13392,14 +13392,14 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     The SDK call can fail when the current user cannot moderate the channel or the target user cannot be moderated. Handle permission and validation errors in your UI.
     A channel ban applies to the target channel. It is not a global user block and does not replace user-level block or content flag workflows.
     Store ban reasons, moderator notes, appeal state, or compliance records in your own system if your product requires them.
     Query channel members with banned-membership filters when you need to render a ban list or confirm current ban state.
 
-## Related topics
+## Related Topics
 
     Filter channel members by membership state.
     Temporarily restrict message sending.
@@ -13413,7 +13413,7 @@ await AmityChatClient.newChannelRepository()
 
 Use member mute when a user should keep channel access but lose the ability to send messages for a period of time. Mute duration units differ by platform, so pass the value in the unit expected by the SDK you are using.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13431,7 +13431,7 @@ Use member mute when a user should keep channel access but lose the ability to s
 | `mutePeriod` / `timeout` / `millis` | Mute only | Duration of the mute. TypeScript and iOS take seconds, Android takes a `Duration`, and Flutter takes milliseconds. |
 | Moderation permission | Yes | The current user must have permission to moderate the target channel. |
 
-## Mute members
+## Mute Members
 
 Mute members when you want a temporary or indefinite send-message restriction without removing channel access. TypeScript's omitted `mutePeriod` means an indefinite mute until unmuted.
 
@@ -13482,7 +13482,7 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Unmute members
+## Unmute Members
 
 Unmute restores the users' ability to send messages in the channel.
 
@@ -13524,14 +13524,14 @@ await AmityChatClient.newChannelRepository()
 ```
 
 
-## Duration notes
+## Duration Notes
 
     Pass seconds. Omit `mutePeriod` to mute indefinitely until a later `unmuteMembers` call.
     Pass seconds through `mutePeriod`. The SDK converts the value before sending the request.
     Pass an `org.joda.time.Duration`, such as `Duration.standardMinutes(10)`.
     Pass milliseconds through `millis`. If omitted, the current public SDK default is 600000 milliseconds.
 
-## Related topics
+## Related Topics
 
     Remove channel access until a user is unbanned.
     Filter members by muted or banned membership states.
@@ -13545,7 +13545,7 @@ await AmityChatClient.newChannelRepository()
 
 Use join and leave operations when the current user needs to enter or exit an existing channel. Joining does not create a missing channel, and conversation channels are already membership-managed by the SDK, so calling join or leave on a conversation channel can fail on platforms that enforce that restriction.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13565,7 +13565,7 @@ Use join and leave operations when the current user needs to enter or exit an ex
 | Check membership | Channel object | Depends | TypeScript and iOS can also read membership state from an observed channel object. |
 | Check membership | Observer / disposable | Depends | Required by live APIs when observing channel or membership changes. |
 
-## Join a channel
+## Join A Channel
 
 Join adds the current user as a member of an existing channel. On iOS, joining an already joined channel returns the existing channel. On TypeScript, the API returns `true` when the returned membership is `member`.
 
@@ -13602,7 +13602,7 @@ await channelRepository.joinChannel(channelId);
 ```
 
 
-## Leave a channel
+## Leave A Channel
 
 Leave removes the current user's membership from the channel. After leaving, stop routing the user into the channel UI and refresh any channel list or unread-count state that depends on membership.
 
@@ -13639,7 +13639,7 @@ await channelRepository.leaveChannel(channelId);
 ```
 
 
-## Check current membership
+## Check Current Membership
 
 Use current membership state to hide composer controls, redirect banned users, or distinguish a channel that is only visible from one the user has joined.
 
@@ -13705,7 +13705,7 @@ final isBanned = membership.isBanned == true;
 ```
 
 
-## Related topics
+## Related Topics
 
     Retrieve and filter channel members.
     Render lightweight participant previews where the SDK exposes them.
@@ -13720,7 +13720,7 @@ final isBanned = membership.isBanned == true;
 
 Use member queries for member lists, mention pickers, moderation screens, and channel participant management. All current SDKs expose channel member query and search APIs, but the filter names are not identical across platforms.
 
-## Platform surface
+## Platform Surface
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -13745,7 +13745,7 @@ Use member queries for member lists, mention pickers, moderation screens, and ch
 | Search members | `memberships` / `membershipFilter` | No | Membership status filter for search results. |
 | Search members | `roles` | No | Role filters applied to search results. |
 
-## Query members
+## Query Members
 
 Query members when you need a paginated channel member list. The default sort is newest first on platforms that define a default.
 
@@ -13828,7 +13828,7 @@ controller.fetchNextPage();
 ```
 
 
-## Search members
+## Search Members
 
 Search members when the user enters a display-name keyword, such as in a mention picker. TypeScript names this parameter `search`; Android and Flutter name it `keyword`; iOS names it `displayName`.
 
@@ -13910,14 +13910,14 @@ final members = await AmityChatClient.newChannelRepository()
 ```
 
 
-## Filter notes
+## Filter Notes
 
     TypeScript accepts `memberships: ['member' | 'banned' | 'muted']`. Android query uses `AmityChannelMembershipFilter.ALL`, `MEMBER`, or `BANNED`; Android search uses `AmityChannelMembership`. Flutter query uses `AmityChannelMembershipFilter.ALL`, `MUTED`, or `BANNED`; Flutter search uses `AmityChannelMembership`.
     `includeDeleted: false` filters deleted users out of the result. iOS defaults this argument to `true`, so pass `false` when you want only active user records.
     Role filters match channel roles assigned to members, such as `moderator` or custom roles configured for your app.
     TypeScript live collections expose `hasNextPage` and `onNextPage`; Android returns `PagingData`; Flutter uses `PagingController` or `getPagingData`.
 
-## Related topics
+## Related Topics
 
     Manage the current user's channel membership.
     Display a lightweight set of participant avatars.
@@ -13932,7 +13932,7 @@ final members = await AmityChatClient.newChannelRepository()
 
 Preview members are a small set of members attached to a channel object for compact UI surfaces such as channel rows, headers, and avatar stacks. In the current public SDKs, direct channel-level preview members are exposed by TypeScript and iOS. Android and Flutter do not expose a direct `previewMembers` channel property, so use [Query Channel Members](./query-members) and render the first few results when you need the same UI pattern.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Direct preview member surface | Notes |
 | --- | --- | --- |
@@ -13953,7 +13953,7 @@ Preview members are a small set of members attached to a channel object for comp
 | Fallback preview query | `sortBy` | No | Member ordering for the fallback preview list. |
 | Fallback preview query | `limit` / page size | No | Small page size for avatar stacks or compact participant previews. |
 
-## Read preview members
+## Read Preview Members
 
 Fetch or observe the channel first, then read the preview members from the returned channel object.
 
@@ -13994,7 +13994,7 @@ token = channelRepository.getChannel(channelId).observe { liveObject, error in
 ```
 
 
-## Fallback preview query
+## Fallback Preview Query
 
 Use this approach on Android and Flutter, or anywhere you need filtering that the channel-level preview does not provide.
 
@@ -14030,7 +14030,7 @@ controller.fetchNextPage();
 ```
 
 
-## Related topics
+## Related Topics
 
     Load the channel object that carries preview members on supported platforms.
     Retrieve paginated members for full member lists and fallback previews.
@@ -14064,7 +14064,7 @@ Use message creation APIs after your app has resolved the target `subChannelId`.
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined JSON-style metadata stored with the message. |
 
-## Send a text message
+## Send A Text Message
 
 Create a text message after resolving the target `subChannelId`.
 
@@ -14117,7 +14117,7 @@ final messageId = message.messageId;
 ```
 
 
-## Return shapes
+## Return Shapes
 
 | Platform | Create call result |
 | --- | --- |
@@ -14126,7 +14126,7 @@ final messageId = message.messageId;
 | Android | Returns a `Completable`; observe the message list for the created message |
 | Flutter | Returns `Future<AmityMessage>` |
 
-## Related topics
+## Related Topics
 
     Add text, tags, metadata, mentions, and replies.
     Use `parentId` to create message replies.
@@ -14152,7 +14152,7 @@ Use text messages for standard chat content. All SDKs support creating text mess
 | `mentionees` / `mentionUsers` | No | Users mentioned by the text message when the platform exposes mention builders. |
 | `parentId` | No | Parent message ID when the text message is a reply. |
 
-## Basic text message
+## Basic Text Message
 
 Create a basic text message with a `subChannelId` and text body.
 
@@ -14205,7 +14205,7 @@ final messageId = message.messageId;
 ```
 
 
-## Text with context
+## Text With Context
 
 Add tags, metadata, mentions, or reply context when the text message needs extra app-owned behavior.
 
@@ -14272,7 +14272,7 @@ final message = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Related topics
+## Related Topics
 
     Create a text reply with `parentId`.
     Query text messages and reply threads.
@@ -14297,7 +14297,7 @@ Use image messages after the user selects or uploads an image. TypeScript create
 | `tags` | No | App-defined tags for filtering or grouping image messages. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send an image message
+## Send An Image Message
 
 Create an image message from an uploaded file ID, native attachment, or Flutter image URI.
 
@@ -14354,7 +14354,7 @@ final message = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Optional context
+## Optional Context
 
 Add captions, tags, metadata, or reply context when your product needs richer image-message behavior.
 
@@ -14392,7 +14392,7 @@ val disposable = AmityChatClient.newMessageRepository()
 ```
 
 
-## Related topics
+## Related Topics
 
     Send non-image file attachments.
     Send video attachments.
@@ -14416,7 +14416,7 @@ Use file messages for document and generic attachment sharing. TypeScript create
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send a file message
+## Send A File Message
 
 Create a file message from an uploaded file ID, native attachment, or Flutter file URI.
 
@@ -14474,7 +14474,7 @@ final message = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Replies and metadata
+## Replies And Metadata
 
 Add reply context or metadata when the file message belongs to a thread or needs app-owned rendering context.
 
@@ -14507,7 +14507,7 @@ final reply = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Related topics
+## Related Topics
 
     Send image attachments.
     Send audio attachments where supported.
@@ -14533,7 +14533,7 @@ Flutter supports text, image, file, video, and custom message creators in the cu
 | `tags` | No | App-defined tags for message filtering, where supported by the platform builder. |
 | `metadata` | No | App-defined metadata stored with the message, where supported by the platform builder. |
 
-## Send an audio message
+## Send An Audio Message
 
 Create an audio message from an uploaded file ID or platform attachment, depending on the SDK.
 
@@ -14579,7 +14579,7 @@ val disposable = AmityChatClient.newMessageRepository()
 ```
 
 
-## Related topics
+## Related Topics
 
     Send the audio file as a generic file attachment if that fits your product behavior.
     Send video attachments.
@@ -14603,7 +14603,7 @@ Use video messages for video attachments inside chat. TypeScript creates video m
 | `tags` | No | App-defined tags for message filtering, where supported by the platform builder. |
 | `metadata` | No | App-defined metadata stored with the message, where supported by the platform builder. |
 
-## Send a video message
+## Send A Video Message
 
 Create a video message from an uploaded file ID, native attachment, or Flutter video URI.
 
@@ -14658,7 +14658,7 @@ final message = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Related topics
+## Related Topics
 
     Send generic file attachments.
     Send audio attachments where supported.
@@ -14681,7 +14681,7 @@ Use custom messages when your app needs to send structured data that is not one 
 | `tags` | No | App-defined tags for filtering or grouping custom messages. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send a custom message
+## Send A Custom Message
 
 Create a custom message with a JSON-serializable payload that your app knows how to render.
 
@@ -14749,7 +14749,7 @@ final messageId = message.messageId;
 ```
 
 
-## Add tags, metadata, or reply context
+## Add Tags, Metadata, Or Reply Context
 
 Attach app-owned tags, metadata, or a `parentId` when the custom message needs filtering, rendering context, or reply threading.
 
@@ -14785,14 +14785,14 @@ final reply = await AmityChatClient.newMessageRepository()
 ```
 
 
-## Rendering guidance
+## Rendering Guidance
 
 - Treat `data` as an app-owned contract.
 - Include a type or version field such as `kind` so clients can choose the renderer.
 - Provide a fallback renderer for unknown custom payloads.
 - Keep sensitive data out of custom payloads unless your product explicitly requires it.
 
-## Related topics
+## Related Topics
 
     Send plain chat content.
     Send custom replies with `parentId`.
@@ -14818,7 +14818,7 @@ Replies are created with the same message-type APIs as top-level messages. Set `
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined metadata stored with the reply. |
 
-## Reply with text
+## Reply With Text
 
 Create a text reply by setting `parentId` to the message being replied to.
 
@@ -14875,7 +14875,7 @@ final replyId = reply.messageId;
 ```
 
 
-## Reply with media or custom data
+## Reply With Media Or Custom Data
 
 Use the same reply pattern with media or custom payloads when the reply is not plain text.
 
@@ -14904,11 +14904,11 @@ val disposable = AmityChatClient.newMessageRepository()
 ```
 
 
-## Query reply threads
+## Query Reply Threads
 
 After creating replies, query messages by `parentId` when you need to render a thread. See [Query & Filter Messages](../messages/query-and-filter-messages) for platform-specific query examples.
 
-## Related topics
+## Related Topics
 
     Create text messages and text replies.
     Query top-level messages and replies.
@@ -14923,7 +14923,7 @@ Use message management APIs after your app already has the target `messageId`. T
 
 Soft deletion marks a message as deleted and lets message queries or single-message observers reflect that state. It is not a hard-delete or recovery API.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -14945,7 +14945,7 @@ The Flutter `updateMessage(channelId, messageId)` builder is deprecated. Use `ed
 | Edit custom | `data` / custom payload | Yes | Replacement JSON-serializable custom payload. |
 | Soft delete | `messageId` | Yes | Message ID to soft-delete. |
 
-## Edit a text message
+## Edit A Text Message
 
 Update the text body and optional app-owned context for an existing text message.
 
@@ -15004,7 +15004,7 @@ final editedAt = updatedMessage.editedAt;
 ```
 
 
-## Edit a custom message
+## Edit A Custom Message
 
 Update the JSON-serializable payload for an existing custom message.
 
@@ -15058,7 +15058,7 @@ final editedAt = updatedMessage.editedAt;
 ```
 
 
-## Soft-delete a message
+## Soft-Delete A Message
 
 Soft-delete a message by ID so list and single-message observers can reflect deleted state.
 
@@ -15092,14 +15092,14 @@ await AmityChatClient.newMessageRepository()
 ```
 
 
-## After edit or delete
+## After Edit Or Delete
 
 - Observe the message or query collection again instead of mutating app UI state by hand.
 - Use `editedAt` to render edited indicators after an edit.
 - Use `isDeleted` to render deleted placeholders or hide deleted messages depending on your product rule.
 - Pass `includeDeleted` on query APIs only where the platform exposes that filter.
 
-## Related topics
+## Related Topics
 
     Create the message before editing or deleting it.
     Observe one message after an edit or delete.
@@ -15115,7 +15115,7 @@ Use a single-message lookup when your app needs to open a message permalink, ref
 
 The SDK returns the same message model used by message queries. Rendering is app-owned: inspect `messageType` or `dataType`, read the typed data payload, and handle `isDeleted` before displaying content.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Retrieval shape | Update behavior |
 | --- | --- | --- |
@@ -15132,7 +15132,7 @@ The SDK returns the same message model used by message queries. Rendering is app
 | Callback / observer | Depends | Required by TypeScript and native live-object APIs to receive loading, error, and data updates. |
 | Unsubscriber / token / disposable | No | Handle returned by live APIs; retain it while observing and release it when the UI no longer needs updates. |
 
-## Retrieve a message
+## Retrieve A Message
 
 Retrieve or observe a single message by `messageId`.
 
@@ -15192,7 +15192,7 @@ final isDeleted = fetchedMessage.isDeleted ?? false;
 ```
 
 
-## Inspect message content
+## Inspect Message Content
 
 Read the message type and data payload before choosing the renderer for your UI.
 
@@ -15257,7 +15257,7 @@ switch (fetchedMessage.dataType) {
 ```
 
 
-## Deletion and edit fields
+## Deletion And Edit Fields
 
 | Field | What to use it for |
 | --- | --- |
@@ -15269,7 +15269,7 @@ switch (fetchedMessage.dataType) {
 
 Single-message retrieval does not replace list queries. Use `getMessages` for timelines and use `getMessage` for detail refresh, deep links, or focused observation.
 
-## Related topics
+## Related Topics
 
     Load message lists and thread replies.
     Update or soft-delete a message after sending.
@@ -15285,7 +15285,7 @@ Use message queries to build timelines, reply threads, media views, and jump-to-
 
 For chat timelines, prefer live collections or reactive streams where the platform provides them. They keep edits, deletes, reactions, and newly created messages in sync without a manual refresh loop.
 
-## Filter surface
+## Filter Surface
 
 | Filter | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -15309,7 +15309,7 @@ For chat timelines, prefer live collections or reactive streams where the platfo
 | `sortBy` / `stackFromEnd` | No | Control timeline ordering where the platform exposes sort options. |
 | Pagination controls | No | Use callbacks, live collections, or paging data to load additional results. |
 
-## Query a timeline
+## Query A Timeline
 
 Query the main message timeline for a subchannel with optional tag and sort filters.
 
@@ -15390,7 +15390,7 @@ liveCollection.loadNext();
 ```
 
 
-## Query by type or deleted state
+## Query By Type Or Deleted State
 
 Use message type and deleted-state filters to build focused views such as media galleries or moderation queues.
 
@@ -15505,7 +15505,7 @@ final replyCount = replies.length;
 ```
 
 
-## Jump to a message
+## Jump To A Message
 
 Use `aroundMessageId` when your app opens a deep link or search result and needs the target message plus nearby context.
 
@@ -15561,7 +15561,7 @@ final count = messagesAroundTarget.length;
 ```
 
 
-## Related topics
+## Related Topics
 
     Create messages that appear in the queried subchannel.
     Retrieve or observe one message by ID.
@@ -15577,7 +15577,7 @@ Use message preview when your app needs a lightweight latest-message summary for
 
   Message preview is configured outside these client SDK calls, typically through network settings. Client SDKs read the preview that is returned with channel or subchannel data; they do not enable the setting themselves.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -15595,7 +15595,7 @@ Use message preview when your app needs a lightweight latest-message summary for
 | Preview setting | Yes | The network must have message preview enabled before new messages produce preview data. |
 | `messagePreview` null handling | Yes | A channel or subchannel can return no preview when no eligible message exists, preview is disabled, or the preview has not been cached yet. |
 
-## Read channel preview
+## Read Channel Preview
 
 Read the preview from the channel object you already use for channel lists. Treat the preview as optional and render a fallback for empty channels.
 
@@ -15669,7 +15669,7 @@ if (preview != null) {
 ```
 
 
-## Read subchannel preview
+## Read Subchannel Preview
 
 Use subchannel preview when your UI lists subchannels directly. Flutter currently exposes `messagePreviewId` on `AmitySubChannel`, but not the composed `AmityMessagePreview` object.
 
@@ -15723,7 +15723,7 @@ val disposable = subChannelRepository
 ```
 
 
-## Preview fields
+## Preview Fields
 
 | Field | Description |
 | --- | --- |
@@ -15736,7 +15736,7 @@ val disposable = subChannelRepository
 | `isDeleted` | Whether the previewed message is deleted. Availability depends on the network preview setting. |
 | `user` | User object for the previewed message creator when the SDK has the user data. |
 
-## Related topics
+## Related Topics
 
     Load channel lists that include preview data.
     Load full message timelines when preview data is not enough.
@@ -15750,7 +15750,7 @@ val disposable = subChannelRepository
 
 Use channel unread count when your app needs inbox badges, mention indicators, or total chat unread state. The SDK exposes unread state on channel models and provides an aggregate total for channels known to the current user.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -15769,7 +15769,7 @@ Use channel unread count when your app needs inbox badges, mention indicators, o
 | Aggregate observer | Yes for total unread | Subscribe to the total-unread API for cross-channel badge state. |
 | Unsubscriber / token / disposable | Yes for live observers | Keep the returned handle while observing and release it when the UI no longer needs updates. |
 
-## Read channel unread state
+## Read Channel Unread State
 
 Read unread count and mention state from the channel object. If the platform exposes a support flag, check it before showing unread count for channel types that do not support markers.
 
@@ -15840,7 +15840,7 @@ final isMentioned = fetchedChannel.isMentioned;
 ```
 
 
-## Observe total channel unread
+## Observe Total Channel Unread
 
 Use total unread APIs for app-level badges or global chat navigation. The aggregate contains the unread count and whether any unread message mentions the current user.
 
@@ -15906,14 +15906,14 @@ AmityChatClient.newChannelRepository()
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     Per-channel values come from channel or subchannel models, so update the UI from SDK observations instead of maintaining a separate unread counter.
     Use `isMentioned` to visually prioritize channels where the current user has unread mentions.
     When your app uses subchannels directly, read subchannel unread fields from the subchannel model where the platform exposes them.
     Mark messages as read from the message model to update unread state.
 
-## Related topics
+## Related Topics
 
     Mark messages as read.
     Subscribe to receipt topics while a chat screen is open.
@@ -15927,7 +15927,7 @@ AmityChatClient.newChannelRepository()
 
 Use message read status when a user views a message and your app needs unread counts to move forward. The SDK exposes `markRead()` on message models across TypeScript, iOS, Android, and Flutter.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -15944,7 +15944,7 @@ Use message read status when a user views a message and your app needs unread co
 | `subChannelId` | Indirect | The SDK reads this from the message model where needed. |
 | `channelSegment` / segment | Indirect | The SDK reads this from the message model to sync the read position. |
 
-## Mark message read
+## Mark Message Read
 
 Call `markRead()` after your app decides the message has been seen, such as when the message becomes visible in an active chat screen.
 
@@ -15985,7 +15985,7 @@ final readCount = fetchedMessage.readCount ?? 0;
 ```
 
 
-## Inspect receipt counts
+## Inspect Receipt Counts
 
 Read-count and delivered-count fields are available on message models. Use user-list queries from [Message Delivery Status](./message-delivery-status) when you need the user identities behind the counts.
 
@@ -16030,14 +16030,14 @@ final deliveredCount = fetchedMessage.deliveredCount ?? 0;
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     `markRead()` is a method on the message object, so load or query messages before marking them read.
     Marking messages read is the write path that lets unread count state advance for the current user.
     Your app decides when a message is considered visible enough to mark as read.
     Use receipt-user APIs where supported when you need identities, not just count fields.
 
-## Related topics
+## Related Topics
 
     Read per-channel and total unread counts.
     Mark delivered and query receipt users where supported.
@@ -16051,7 +16051,7 @@ final deliveredCount = fetchedMessage.deliveredCount ?? 0;
 
 Use message delivery status when your app needs delivered receipts, read-user lists, or delivered-user lists for a message. TypeScript, iOS, and Android expose explicit delivery and receipt-user APIs. Flutter currently exposes message count fields, but not public APIs for marking a message delivered or querying receipt users.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -16072,7 +16072,7 @@ Use message delivery status when your app needs delivered receipts, read-user li
 | `memberships` | No | Filters receipt users by membership state. Supported values are member, banned, muted, non-member, and deleted. |
 | Pagination controls | No | TypeScript returns a paged response; Android returns `PagingData`; iOS returns an `AmityCollection`. |
 
-## Mark message delivered
+## Mark Message Delivered
 
 Call the delivered API when a received message has reached the recipient device and your app needs to sync that delivery state.
 
@@ -16119,7 +16119,7 @@ val disposable = currentMessage
 ```
 
 
-## Query read users
+## Query Read Users
 
 Use read-user queries when you need to show who has read a message. Apply membership filters when your product only wants active members or needs to include muted, banned, non-member, or deleted users.
 
@@ -16175,7 +16175,7 @@ val disposable = currentMessage
 ```
 
 
-## Query delivered users
+## Query Delivered Users
 
 Use delivered-user queries when your sender UI or moderation tooling needs to know which recipients have received a message.
 
@@ -16231,7 +16231,7 @@ val disposable = currentMessage
 ```
 
 
-## Receipt user filters
+## Receipt User Filters
 
 | Logical value | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -16241,7 +16241,7 @@ val disposable = currentMessage
 | Non-member | `'non-member'` | `.nonMember` | `NOT_MEMBER` |
 | Deleted | `'deleted'` | `.deleted` | `DELETED` |
 
-## Related topics
+## Related Topics
 
     Mark messages as read and inspect read count fields.
     Start receipt sync while a chat screen is active.
@@ -16257,7 +16257,7 @@ Use message receipt sync while a user is viewing a chat screen. It subscribes th
 
   This page covers the explicit public receipt-sync APIs. Flutter does not expose `startMessageReceiptSync` or `stopMessageReceiptSync` in the current public SDK surface.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -16274,7 +16274,7 @@ Use message receipt sync while a user is viewing a chat screen. It subscribes th
 | Channel object | No | If you only have a channel, use its default subchannel ID where the platform exposes it. |
 | Cleanup handle | Depends | TypeScript stop is explicit; Android and iOS use explicit stop calls; keep your own screen lifecycle ownership. |
 
-## Start receipt sync
+## Start Receipt Sync
 
 Start sync before or while rendering the active message list for a subchannel.
 
@@ -16313,7 +16313,7 @@ val disposable = subChannelRepository
 ```
 
 
-## Stop receipt sync
+## Stop Receipt Sync
 
 Stop sync when the active chat view closes, changes to another subchannel, or no longer needs live receipt state.
 
@@ -16350,14 +16350,14 @@ val disposable = subChannelRepository
 ```
 
 
-## Implementation notes
+## Implementation Notes
 
     Tie receipt sync to the active chat screen, not to app startup.
     The public APIs take a `subChannelId`, so resolve the default subchannel from the channel when needed.
     Receipt sync keeps receipt state fresh; use `message.markRead()` to mark messages read.
     Do not add Flutter start/stop examples unless the Flutter SDK exposes public APIs for them.
 
-## Related topics
+## Related Topics
 
     Mark messages as read.
     Mark delivered and query receipt users.

--- a/social-plus-sdk/chat/conversation-management/channels/archive-channels.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/archive-channels.mdx
@@ -5,7 +5,7 @@ description: "Archive, unarchive, and query archived chat channels where the cur
 
 Archiving is a per-user chat-list operation. It hides a channel from the active list for the current user without deleting the channel or its messages. In the current public SDKs, archive APIs are exposed on TypeScript and Flutter; iOS and Android do not expose public channel archive methods in this checkout.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ Archiving is a per-user chat-list operation. It hides a channel from the active 
 | Query archived channels | `limit` | No | TypeScript collection page size. |
 | Query archived channels | Pagination controls | No | Use TypeScript collection callbacks or Flutter live collection loading to fetch more archived channels. |
 
-## Archive or unarchive
+## Archive Or Unarchive
 
 Archive or unarchive a channel for the current user when the platform exposes archive state.
 
@@ -44,7 +44,7 @@ await repository.unarchiveChannel(channelId);
 
 </CodeGroup>
 
-## Query archived channels
+## Query Archived Channels
 
 Use the archived-channel collection for an archived inbox. The TypeScript API accepts live collection parameters such as `limit`; the Flutter API returns a live collection stream for the current user.
 
@@ -92,7 +92,7 @@ await archivedChannels.loadNext();
 | Channel deletion | Archiving is separate from channel deletion or soft deletion. |
 | Platform gaps | Use platform checks before exposing archive UI on iOS or Android. |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Query Channels" href="./query-channels" icon="list-filter">

--- a/social-plus-sdk/chat/conversation-management/channels/create-channel.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/create-channel.mdx
@@ -7,7 +7,7 @@ Use channel creation when your app needs a new chat container before sending mes
 
 For new integrations, let the SDK and server generate channel IDs. Custom channel IDs are not exposed on the current TypeScript, iOS, or Android creation APIs, and Flutter's custom `channelId` builder is deprecated.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Entry point | Channel types exposed here | Notes |
 | --- | --- | --- | --- |
@@ -28,7 +28,7 @@ For new integrations, let the SDK and server generate channel IDs. Custom channe
 | `isPublic` | No | Community-channel visibility flag where exposed. |
 | `isDistinct` | No | Conversation de-duplication flag where exposed; iOS distinct conversations default to `true`. |
 
-## Create a community channel
+## Create A Community Channel
 
 Create a community channel when your app needs a group chat space with optional public visibility, tags, and metadata.
 
@@ -99,7 +99,7 @@ final createdChannelId = channel.channelId;
 
 </CodeGroup>
 
-## Create a conversation channel
+## Create A Conversation Channel
 
 Conversation channels are for one-to-one or small-group private chat. Where the SDK exposes distinct conversation behavior, the default is to return the existing conversation for the same membership instead of creating a duplicate.
 
@@ -158,7 +158,7 @@ final channelId = conversation.channelId;
 
 </CodeGroup>
 
-## Create a live channel
+## Create A Live Channel
 
 Live channels support event-style chat. The platform builders expose optional metadata, tags, and members; iOS and Android also expose live-channel linkage fields such as room or post IDs in their builders.
 
@@ -217,7 +217,7 @@ final channelId = liveChannel.channelId;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get Channels" href="./get-channel" icon="file">

--- a/social-plus-sdk/chat/conversation-management/channels/get-channel.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/get-channel.mdx
@@ -7,7 +7,7 @@ Use channel retrieval when your app already has a `channelId` and needs the curr
 
 Single-channel retrieval is available on all current SDKs. Batch lookup by channel IDs is exposed on TypeScript, iOS, and Android; the current public Flutter repository does not expose a batch-by-IDs method.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -24,7 +24,7 @@ Single-channel retrieval is available on all current SDKs. Batch lookup by chann
 | Get one channel | Unsubscriber / token / disposable | No | Handle returned by live APIs; retain it while observing and release it when done. |
 | Get known channel IDs | `channelIds` | Yes | List of channel IDs to resolve into channel objects where the platform exposes batch lookup. |
 
-## Get one channel
+## Get One Channel
 
 Retrieve or observe one channel when your app already has its `channelId`.
 
@@ -79,7 +79,7 @@ final fetchedChannelId = channel.channelId;
 
 </CodeGroup>
 
-## Get known channel IDs
+## Get Known Channel IDs
 
 Use batch lookup when your app has a small list of known channel IDs and wants the matching channel objects. The collection is not the same as a general channel search; use [Query Channels](./query-channels) when you need filters or pagination.
 
@@ -135,7 +135,7 @@ val disposable = channelRepository
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Create Channels" href="./create-channel" icon="plus">

--- a/social-plus-sdk/chat/conversation-management/channels/governance/ban-management.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/governance/ban-management.mdx
@@ -5,7 +5,7 @@ description: "Ban and unban chat channel members with the current SDK APIs."
 
 Use channel bans when a member should lose access to a specific chat channel until a moderator restores access. The SDK operation is per-channel; ban reasons, appeal flows, and moderation audit logs are app-owned product logic.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -21,7 +21,7 @@ Use channel bans when a member should lose access to a specific chat channel unt
 | `userIds` | Yes | One or more user IDs to ban or unban. Empty lists are rejected. |
 | Moderation permission | Yes | The current user must have permission to moderate the target channel. |
 
-## Ban members
+## Ban Members
 
 Ban removes the users from channel participation and prevents them from rejoining until they are unbanned.
 
@@ -63,7 +63,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Unban members
+## Unban Members
 
 Unban restores the users to the channel's allowed membership state. If your app shows a ban list, refresh that list after the operation succeeds.
 
@@ -105,7 +105,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Permission Checks" icon="shield">
@@ -122,7 +122,7 @@ await AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Query Members" href="/social-plus-sdk/chat/conversation-management/members/query-members" icon="users">

--- a/social-plus-sdk/chat/conversation-management/channels/governance/member-management.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/governance/member-management.mdx
@@ -5,7 +5,7 @@ description: "Add and remove chat channel members with the current SDK APIs."
 
 Use member management when your app needs to add users to a channel or remove users from a channel. Channel type, membership rules, and moderator permissions can still determine whether a request is accepted by the server.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -21,7 +21,7 @@ Use member management when your app needs to add users to a channel or remove us
 | `userIds` | Yes | One or more user IDs to add or remove. Empty lists are rejected. |
 | Membership permission | Yes | The current user must be allowed to manage members for the target channel. |
 
-## Add members
+## Add Members
 
 Add members when an existing channel should include additional users. For conversation channels, prefer the conversation creation APIs when creating the conversation membership for the first time.
 
@@ -64,7 +64,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Remove members
+## Remove Members
 
 Remove members when users should no longer participate in the channel. If the user is currently viewing the channel, update the route or composer state after removal succeeds.
 
@@ -107,7 +107,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Bulk Input" icon="users">
@@ -124,7 +124,7 @@ await AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Join and Leave" href="/social-plus-sdk/chat/conversation-management/members/join-leave-channel" icon="door-open">

--- a/social-plus-sdk/chat/conversation-management/channels/governance/mute-management.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/governance/mute-management.mdx
@@ -5,7 +5,7 @@ description: "Mute and unmute chat channel members with the current SDK APIs."
 
 Use member mute when a user should keep channel access but lose the ability to send messages for a period of time. Mute duration units differ by platform, so pass the value in the unit expected by the SDK you are using.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -23,7 +23,7 @@ Use member mute when a user should keep channel access but lose the ability to s
 | `mutePeriod` / `timeout` / `millis` | Mute only | Duration of the mute. TypeScript and iOS take seconds, Android takes a `Duration`, and Flutter takes milliseconds. |
 | Moderation permission | Yes | The current user must have permission to moderate the target channel. |
 
-## Mute members
+## Mute Members
 
 Mute members when you want a temporary or indefinite send-message restriction without removing channel access. TypeScript's omitted `mutePeriod` means an indefinite mute until unmuted.
 
@@ -76,7 +76,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Unmute members
+## Unmute Members
 
 Unmute restores the users' ability to send messages in the channel.
 
@@ -120,7 +120,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Duration notes
+## Duration Notes
 
 <CardGroup cols={2}>
   <Card title="TypeScript" icon="code">
@@ -137,7 +137,7 @@ await AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Ban Management" href="./ban-management" icon="user-slash">

--- a/social-plus-sdk/chat/conversation-management/channels/governance/overview.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/governance/overview.mdx
@@ -5,7 +5,7 @@ description: "Understand the SDK surfaces for chat channel roles, member managem
 
 Channel governance is the SDK surface for changing who can participate in a chat channel and what they can do there. Use these pages when you are building moderator tools, channel settings, admin panels, or support workflows.
 
-## Capability map
+## Capability Map
 
 | Capability | Purpose | SDK page |
 | --- | --- | --- |
@@ -15,7 +15,7 @@ Channel governance is the SDK surface for changing who can participate in a chat
 | Mute management | Restrict users from sending messages while keeping channel access. | [Mute Management](./mute-management) |
 | Member queries | Read current member, role, banned, and muted state. | [Query Members](/social-plus-sdk/chat/conversation-management/members/query-members) |
 
-## Platform coverage
+## Platform Coverage
 
 | Platform | Member add/remove | Role add/remove | Ban/unban | Mute/unmute |
 | --- | --- | --- | --- | --- |
@@ -28,7 +28,7 @@ Channel governance is the SDK surface for changing who can participate in a chat
   Governance operations are subject to channel type, membership state, and moderation permissions. If the server rejects an operation, treat that result as authoritative and show an actionable error in your product UI.
 </Info>
 
-## Implementation shape
+## Implementation Shape
 
 <CardGroup cols={2}>
   <Card title="Write Operations" icon="pen-to-square">
@@ -45,7 +45,7 @@ Channel governance is the SDK surface for changing who can participate in a chat
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Create Channels" href="/social-plus-sdk/chat/conversation-management/channels/create-channel" icon="plus">

--- a/social-plus-sdk/chat/conversation-management/channels/governance/role-management.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/governance/role-management.mdx
@@ -5,7 +5,7 @@ description: "Add and remove chat channel roles with the current SDK APIs."
 
 Use channel roles when selected members need elevated channel permissions, such as moderator behavior. Role names are app-defined or configured for your Social+ project; the SDK applies or removes the role for the listed channel members.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ Use channel roles when selected members need elevated channel permissions, such 
 | `userIds` | Yes | One or more member user IDs. Empty lists are rejected. |
 | Moderation permission | Yes | The current user must have permission to manage roles in the target channel. |
 
-## Add a role
+## Add A Role
 
 Add a role when channel members should receive the permissions represented by that role.
 
@@ -68,7 +68,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Remove a role
+## Remove A Role
 
 Remove a role when members should no longer have the permissions represented by that role.
 
@@ -114,7 +114,7 @@ await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Role IDs" icon="key">
@@ -131,7 +131,7 @@ await AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Member Management" href="./member-management" icon="users">

--- a/social-plus-sdk/chat/conversation-management/channels/query-channels.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/query-channels.mdx
@@ -5,7 +5,7 @@ description: "Query chat channels by type, membership, tags, deletion state, arc
 
 Use channel queries to build inboxes, public channel discovery, event chat lists, and moderation views. Query support is similar across platforms, but not identical: TypeScript and Flutter expose keyword/display-name style searching, while Android's public channel query builder focuses on type, membership, tags, and deleted-state filters.
 
-## Filter surface
+## Filter Surface
 
 | Filter | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -32,7 +32,7 @@ Use channel queries to build inboxes, public channel discovery, event chat lists
 | `sortBy` | No | Sort channel lists where the platform exposes sort options. |
 | Pagination controls | No | Use collection callbacks, live collections, or paging data to load additional channels. |
 
-## Query a channel list
+## Query A Channel List
 
 Query channels with type, membership, tag, deletion, archive, search, and pagination options where each platform exposes them.
 
@@ -127,7 +127,7 @@ await liveCollection.loadNext();
 
 </CodeGroup>
 
-## Query a specific type
+## Query A Specific Type
 
 Use the type-specific helpers when the platform exposes them. Some helpers apply membership defaults: for example, Flutter's `conversationType()` and `liveType()` also set the filter to `MEMBER`.
 
@@ -195,7 +195,7 @@ conversations.getStreamController().stream.listen((channels) {
 
 If you already have channel IDs, use [Get Channels](./get-channel) instead of a filtered query. Batch get-by-IDs is currently exposed on TypeScript, iOS, and Android.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Create Channels" href="./create-channel" icon="plus">

--- a/social-plus-sdk/chat/conversation-management/channels/update-channel.mdx
+++ b/social-plus-sdk/chat/conversation-management/channels/update-channel.mdx
@@ -5,7 +5,7 @@ description: "Update chat channel display name, avatar, tags, metadata, and noti
 
 Use channel updates when the app needs to change channel attributes after creation. Keep updates narrow: send only fields that actually changed, because metadata and tag updates replace the submitted values rather than merging app-side state for you.
 
-## Update surface
+## Update Surface
 
 | Field | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -26,7 +26,7 @@ Use channel updates when the app needs to change channel attributes after creati
 | `metadata` | No | Replacement metadata stored with the channel. |
 | `notificationMode` | No | Channel notification mode where TypeScript and Flutter expose it. |
 
-## Update channel fields
+## Update Channel Fields
 
 Update channel profile fields such as display name, avatar, tags, or metadata where the platform exposes those setters.
 
@@ -90,7 +90,7 @@ final updatedChannelId = channel.channelId;
 
 </CodeGroup>
 
-## Update notification mode
+## Update Notification Mode
 
 The channel update API exposes notification mode on TypeScript and Flutter. Use platform-specific notification settings pages for broader notification configuration.
 
@@ -123,7 +123,7 @@ final notificationMode = channel.notificationMode;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get Channels" href="./get-channel" icon="file">

--- a/social-plus-sdk/chat/conversation-management/members/join-leave-channel.mdx
+++ b/social-plus-sdk/chat/conversation-management/members/join-leave-channel.mdx
@@ -5,7 +5,7 @@ description: "Add the current user to a chat channel, remove them from a channel
 
 Use join and leave operations when the current user needs to enter or exit an existing channel. Joining does not create a missing channel, and conversation channels are already membership-managed by the SDK, so calling join or leave on a conversation channel can fail on platforms that enforce that restriction.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ Use join and leave operations when the current user needs to enter or exit an ex
 | Check membership | Channel object | Depends | TypeScript and iOS can also read membership state from an observed channel object. |
 | Check membership | Observer / disposable | Depends | Required by live APIs when observing channel or membership changes. |
 
-## Join a channel
+## Join A Channel
 
 Join adds the current user as a member of an existing channel. On iOS, joining an already joined channel returns the existing channel. On TypeScript, the API returns `true` when the returned membership is `member`.
 
@@ -64,7 +64,7 @@ await channelRepository.joinChannel(channelId);
 
 </CodeGroup>
 
-## Leave a channel
+## Leave A Channel
 
 Leave removes the current user's membership from the channel. After leaving, stop routing the user into the channel UI and refresh any channel list or unread-count state that depends on membership.
 
@@ -103,7 +103,7 @@ await channelRepository.leaveChannel(channelId);
 
 </CodeGroup>
 
-## Check current membership
+## Check Current Membership
 
 Use current membership state to hide composer controls, redirect banned users, or distinguish a channel that is only visible from one the user has joined.
 
@@ -171,7 +171,7 @@ final isBanned = membership.isBanned == true;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Query Members" href="./query-members" icon="users">

--- a/social-plus-sdk/chat/conversation-management/members/overview.mdx
+++ b/social-plus-sdk/chat/conversation-management/members/overview.mdx
@@ -5,7 +5,7 @@ description: "Choose the SDK surfaces for joining, leaving, querying, searching,
 
 Member management is the SDK surface for deciding who is in a channel and how your app reads that membership state. Use these pages when you need join and leave flows, member lists, mention pickers, moderator lists, or membership-aware UI.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -16,7 +16,7 @@ Member management is the SDK surface for deciding who is in a channel and how yo
 | Search members | Build mention pickers and member directories. | [Query Members](./query-members) |
 | Preview members | Show a small channel-member sample where the platform exposes preview members. | [Preview Members](./preview-members) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -38,7 +38,7 @@ Member management is the SDK surface for deciding who is in a channel and how yo
 | Search keyword | No | Search member display names where the platform exposes member search. |
 | `includeDeleted` | No | Include deleted users in member query results where supported. |
 
-## Implementation shape
+## Implementation Shape
 
 <CardGroup cols={2}>
   <Card title="Gate channel UI" href="./join-leave-channel" icon="door-open">
@@ -55,7 +55,7 @@ Member management is the SDK surface for deciding who is in a channel and how yo
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Role Management" href="../channels/governance/role-management" icon="user-gear">

--- a/social-plus-sdk/chat/conversation-management/members/preview-members.mdx
+++ b/social-plus-sdk/chat/conversation-management/members/preview-members.mdx
@@ -5,7 +5,7 @@ description: "Display lightweight channel member previews where the current SDK 
 
 Preview members are a small set of members attached to a channel object for compact UI surfaces such as channel rows, headers, and avatar stacks. In the current public SDKs, direct channel-level preview members are exposed by TypeScript and iOS. Android and Flutter do not expose a direct `previewMembers` channel property, so use [Query Channel Members](./query-members) and render the first few results when you need the same UI pattern.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Direct preview member surface | Notes |
 | --- | --- | --- |
@@ -26,7 +26,7 @@ Preview members are a small set of members attached to a channel object for comp
 | Fallback preview query | `sortBy` | No | Member ordering for the fallback preview list. |
 | Fallback preview query | `limit` / page size | No | Small page size for avatar stacks or compact participant previews. |
 
-## Read preview members
+## Read Preview Members
 
 Fetch or observe the channel first, then read the preview members from the returned channel object.
 
@@ -71,7 +71,7 @@ token = channelRepository.getChannel(channelId).observe { liveObject, error in
 
 </CodeGroup>
 
-## Fallback preview query
+## Fallback Preview Query
 
 Use this approach on Android and Flutter, or anywhere you need filtering that the channel-level preview does not provide.
 
@@ -109,7 +109,7 @@ controller.fetchNextPage();
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get Channels" href="../channels/get-channel" icon="info">

--- a/social-plus-sdk/chat/conversation-management/members/query-members.mdx
+++ b/social-plus-sdk/chat/conversation-management/members/query-members.mdx
@@ -5,7 +5,7 @@ description: "Retrieve and search chat channel members with the current SDK filt
 
 Use member queries for member lists, mention pickers, moderation screens, and channel participant management. All current SDKs expose channel member query and search APIs, but the filter names are not identical across platforms.
 
-## Platform surface
+## Platform Surface
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -30,7 +30,7 @@ Use member queries for member lists, mention pickers, moderation screens, and ch
 | Search members | `memberships` / `membershipFilter` | No | Membership status filter for search results. |
 | Search members | `roles` | No | Role filters applied to search results. |
 
-## Query members
+## Query Members
 
 Query members when you need a paginated channel member list. The default sort is newest first on platforms that define a default.
 
@@ -115,7 +115,7 @@ controller.fetchNextPage();
 
 </CodeGroup>
 
-## Search members
+## Search Members
 
 Search members when the user enters a display-name keyword, such as in a mention picker. TypeScript names this parameter `search`; Android and Flutter name it `keyword`; iOS names it `displayName`.
 
@@ -199,7 +199,7 @@ final members = await AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Filter notes
+## Filter Notes
 
 <CardGroup cols={2}>
   <Card title="Status Filters" icon="filter">
@@ -216,7 +216,7 @@ final members = await AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Join and Leave Channels" href="./join-leave-channel" icon="door-open">

--- a/social-plus-sdk/chat/conversation-management/overview.mdx
+++ b/social-plus-sdk/chat/conversation-management/overview.mdx
@@ -9,7 +9,7 @@ Conversation management covers the SDK calls that decide where chat happens and 
   If you want an end-to-end product walkthrough before choosing SDK calls, read [Channels & Conversations](/use-cases/chat/channels-and-conversations).
 </Tip>
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -21,7 +21,7 @@ Conversation management covers the SDK calls that decide where chat happens and 
 | Member operations | Join, leave, query, search, and preview channel members. | [Member Management](./members/overview) |
 | Channel governance | Add or remove channel members, roles, bans, and mutes. | [Channel Governance](./channels/governance/overview) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -33,7 +33,7 @@ Conversation management covers the SDK calls that decide where chat happens and 
 | Get multiple known channel IDs | Supported | Supported | Supported | Not exposed in the current public Flutter repository |
 | Archive channels | Supported | Supported | Supported | Supported |
 
-## Channel and message targets
+## Channel And Message Targets
 
 Channel APIs operate on `channelId`. Message APIs usually operate on `subChannelId`. Resolve the target subchannel from the channel or subchannel flow before creating, querying, or syncing messages.
 
@@ -41,7 +41,7 @@ Channel APIs operate on `channelId`. Message APIs usually operate on `subChannel
   The channel pages describe channel lifecycle calls. The messaging pages describe message calls after a `subChannelId` is available.
 </Info>
 
-## Implementation shape
+## Implementation Shape
 
 <CardGroup cols={2}>
   <Card title="Choose a channel type" href="./channels/create-channel" icon="layer-group">
@@ -58,7 +58,7 @@ Channel APIs operate on `channelId`. Message APIs usually operate on `subChannel
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Messaging Features" href="/social-plus-sdk/chat/messaging-features/overview" icon="comment">

--- a/social-plus-sdk/chat/engagement-features/message-preview.mdx
+++ b/social-plus-sdk/chat/engagement-features/message-preview.mdx
@@ -9,7 +9,7 @@ Use message preview when your app needs a lightweight latest-message summary for
   Message preview is configured outside these client SDK calls, typically through network settings. Client SDKs read the preview that is returned with channel or subchannel data; they do not enable the setting themselves.
 </Info>
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -27,7 +27,7 @@ Use message preview when your app needs a lightweight latest-message summary for
 | Preview setting | Yes | The network must have message preview enabled before new messages produce preview data. |
 | `messagePreview` null handling | Yes | A channel or subchannel can return no preview when no eligible message exists, preview is disabled, or the preview has not been cached yet. |
 
-## Read channel preview
+## Read Channel Preview
 
 Read the preview from the channel object you already use for channel lists. Treat the preview as optional and render a fallback for empty channels.
 
@@ -103,7 +103,7 @@ if (preview != null) {
 
 </CodeGroup>
 
-## Read subchannel preview
+## Read Subchannel Preview
 
 Use subchannel preview when your UI lists subchannels directly. Flutter currently exposes `messagePreviewId` on `AmitySubChannel`, but not the composed `AmityMessagePreview` object.
 
@@ -159,7 +159,7 @@ val disposable = subChannelRepository
 
 </CodeGroup>
 
-## Preview fields
+## Preview Fields
 
 | Field | Description |
 | --- | --- |
@@ -172,7 +172,7 @@ val disposable = subChannelRepository
 | `isDeleted` | Whether the previewed message is deleted. Availability depends on the network preview setting. |
 | `user` | User object for the previewed message creator when the SDK has the user data. |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Query Channels" href="/social-plus-sdk/chat/conversation-management/channels/query-channels" icon="list">

--- a/social-plus-sdk/chat/engagement-features/unread-status/channel-unread-count.mdx
+++ b/social-plus-sdk/chat/engagement-features/unread-status/channel-unread-count.mdx
@@ -5,7 +5,7 @@ description: "Read per-channel and total chat unread counts from SDK channel obj
 
 Use channel unread count when your app needs inbox badges, mention indicators, or total chat unread state. The SDK exposes unread state on channel models and provides an aggregate total for channels known to the current user.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -24,7 +24,7 @@ Use channel unread count when your app needs inbox badges, mention indicators, o
 | Aggregate observer | Yes for total unread | Subscribe to the total-unread API for cross-channel badge state. |
 | Unsubscriber / token / disposable | Yes for live observers | Keep the returned handle while observing and release it when the UI no longer needs updates. |
 
-## Read channel unread state
+## Read Channel Unread State
 
 Read unread count and mention state from the channel object. If the platform exposes a support flag, check it before showing unread count for channel types that do not support markers.
 
@@ -97,7 +97,7 @@ final isMentioned = fetchedChannel.isMentioned;
 
 </CodeGroup>
 
-## Observe total channel unread
+## Observe Total Channel Unread
 
 Use total unread APIs for app-level badges or global chat navigation. The aggregate contains the unread count and whether any unread message mentions the current user.
 
@@ -165,7 +165,7 @@ AmityChatClient.newChannelRepository()
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Model Source" icon="database">
@@ -182,7 +182,7 @@ AmityChatClient.newChannelRepository()
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Message Read Status" href="./message-read-status" icon="eye">

--- a/social-plus-sdk/chat/engagement-features/unread-status/message-delivery-status.mdx
+++ b/social-plus-sdk/chat/engagement-features/unread-status/message-delivery-status.mdx
@@ -5,7 +5,7 @@ description: "Mark chat messages as delivered and query read or delivered users 
 
 Use message delivery status when your app needs delivered receipts, read-user lists, or delivered-user lists for a message. TypeScript, iOS, and Android expose explicit delivery and receipt-user APIs. Flutter currently exposes message count fields, but not public APIs for marking a message delivered or querying receipt users.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -28,7 +28,7 @@ Use message delivery status when your app needs delivered receipts, read-user li
 | `memberships` | No | Filters receipt users by membership state. Supported values are member, banned, muted, non-member, and deleted. |
 | Pagination controls | No | TypeScript returns a paged response; Android returns `PagingData`; iOS returns an `AmityCollection`. |
 
-## Mark message delivered
+## Mark Message Delivered
 
 Call the delivered API when a received message has reached the recipient device and your app needs to sync that delivery state.
 
@@ -77,7 +77,7 @@ val disposable = currentMessage
 
 </CodeGroup>
 
-## Query read users
+## Query Read Users
 
 Use read-user queries when you need to show who has read a message. Apply membership filters when your product only wants active members or needs to include muted, banned, non-member, or deleted users.
 
@@ -135,7 +135,7 @@ val disposable = currentMessage
 
 </CodeGroup>
 
-## Query delivered users
+## Query Delivered Users
 
 Use delivered-user queries when your sender UI or moderation tooling needs to know which recipients have received a message.
 
@@ -193,7 +193,7 @@ val disposable = currentMessage
 
 </CodeGroup>
 
-## Receipt user filters
+## Receipt User Filters
 
 | Logical value | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -203,7 +203,7 @@ val disposable = currentMessage
 | Non-member | `'non-member'` | `.nonMember` | `NOT_MEMBER` |
 | Deleted | `'deleted'` | `.deleted` | `DELETED` |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Message Read Status" href="./message-read-status" icon="eye">

--- a/social-plus-sdk/chat/engagement-features/unread-status/message-read-status.mdx
+++ b/social-plus-sdk/chat/engagement-features/unread-status/message-read-status.mdx
@@ -5,7 +5,7 @@ description: "Mark chat messages as read and inspect read-count fields from SDK 
 
 Use message read status when a user views a message and your app needs unread counts to move forward. The SDK exposes `markRead()` on message models across TypeScript, iOS, Android, and Flutter.
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ Use message read status when a user views a message and your app needs unread co
 | `subChannelId` | Indirect | The SDK reads this from the message model where needed. |
 | `channelSegment` / segment | Indirect | The SDK reads this from the message model to sync the read position. |
 
-## Mark message read
+## Mark Message Read
 
 Call `markRead()` after your app decides the message has been seen, such as when the message becomes visible in an active chat screen.
 
@@ -65,7 +65,7 @@ final readCount = fetchedMessage.readCount ?? 0;
 
 </CodeGroup>
 
-## Inspect receipt counts
+## Inspect Receipt Counts
 
 Read-count and delivered-count fields are available on message models. Use user-list queries from [Message Delivery Status](./message-delivery-status) when you need the user identities behind the counts.
 
@@ -112,7 +112,7 @@ final deliveredCount = fetchedMessage.deliveredCount ?? 0;
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Message Model" icon="message">
@@ -129,7 +129,7 @@ final deliveredCount = fetchedMessage.deliveredCount ?? 0;
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Channel Unread Count" href="./channel-unread-count" icon="hashtag">

--- a/social-plus-sdk/chat/engagement-features/unread-status/message-receipt-sync.mdx
+++ b/social-plus-sdk/chat/engagement-features/unread-status/message-receipt-sync.mdx
@@ -9,7 +9,7 @@ Use message receipt sync while a user is viewing a chat screen. It subscribes th
   This page covers the explicit public receipt-sync APIs. Flutter does not expose `startMessageReceiptSync` or `stopMessageReceiptSync` in the current public SDK surface.
 </Info>
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -26,7 +26,7 @@ Use message receipt sync while a user is viewing a chat screen. It subscribes th
 | Channel object | No | If you only have a channel, use its default subchannel ID where the platform exposes it. |
 | Cleanup handle | Depends | TypeScript stop is explicit; Android and iOS use explicit stop calls; keep your own screen lifecycle ownership. |
 
-## Start receipt sync
+## Start Receipt Sync
 
 Start sync before or while rendering the active message list for a subchannel.
 
@@ -67,7 +67,7 @@ val disposable = subChannelRepository
 
 </CodeGroup>
 
-## Stop receipt sync
+## Stop Receipt Sync
 
 Stop sync when the active chat view closes, changes to another subchannel, or no longer needs live receipt state.
 
@@ -106,7 +106,7 @@ val disposable = subChannelRepository
 
 </CodeGroup>
 
-## Implementation notes
+## Implementation Notes
 
 <CardGroup cols={2}>
   <Card title="Screen Owned" icon="window">
@@ -123,7 +123,7 @@ val disposable = subChannelRepository
   </Card>
 </CardGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Message Read Status" href="./message-read-status" icon="eye">

--- a/social-plus-sdk/chat/engagement-features/unread-status/overview.mdx
+++ b/social-plus-sdk/chat/engagement-features/unread-status/overview.mdx
@@ -5,7 +5,7 @@ description: "Choose the correct SDK APIs for chat unread counts, read status, d
 
 Unread status is the SDK surface for showing unread counts, marking messages read or delivered, and keeping receipt state current while a chat screen is active.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -14,7 +14,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
 | Message delivery status | Mark messages delivered and query receipt users where supported. | [Message Delivery Status](./message-delivery-status) |
 | Message receipt sync | Subscribe to receipt updates for the active subchannel. | [Message Receipt Sync](./message-receipt-sync) |
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -30,7 +30,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
   Platform gaps are intentional documentation facts, not missing code snippets. Add a Flutter snippet for delivered users or receipt sync only after the Flutter SDK exposes a public API for that operation.
 </Info>
 
-## Implementation shape
+## Implementation Shape
 
 <CardGroup cols={2}>
   <Card title="Chat List" icon="list">
@@ -47,7 +47,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
   </Card>
 </CardGroup>
 
-## Data ownership
+## Data Ownership
 
 | Data | Source |
 | --- | --- |
@@ -57,7 +57,7 @@ Unread status is the SDK surface for showing unread counts, marking messages rea
 | Read and delivered user lists | Receipt-user query APIs where supported. |
 | Receipt sync state | Explicit subchannel receipt-sync APIs where supported. |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Message Preview" href="/social-plus-sdk/chat/engagement-features/message-preview" icon="message">

--- a/social-plus-sdk/chat/messaging-features/message-creation/audio-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/audio-message.mdx
@@ -20,7 +20,7 @@ Flutter supports text, image, file, video, and custom message creators in the cu
 | `tags` | No | App-defined tags for message filtering, where supported by the platform builder. |
 | `metadata` | No | App-defined metadata stored with the message, where supported by the platform builder. |
 
-## Send an audio message
+## Send An Audio Message
 
 Create an audio message from an uploaded file ID or platform attachment, depending on the SDK.
 
@@ -68,7 +68,7 @@ val disposable = AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="File Message" href="./file-message" icon="file">

--- a/social-plus-sdk/chat/messaging-features/message-creation/custom-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/custom-message.mdx
@@ -15,7 +15,7 @@ Use custom messages when your app needs to send structured data that is not one 
 | `tags` | No | App-defined tags for filtering or grouping custom messages. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send a custom message
+## Send A Custom Message
 
 Create a custom message with a JSON-serializable payload that your app knows how to render.
 
@@ -85,7 +85,7 @@ final messageId = message.messageId;
 
 </CodeGroup>
 
-## Add tags, metadata, or reply context
+## Add Tags, Metadata, Or Reply Context
 
 Attach app-owned tags, metadata, or a `parentId` when the custom message needs filtering, rendering context, or reply threading.
 
@@ -123,14 +123,14 @@ final reply = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Rendering guidance
+## Rendering Guidance
 
 - Treat `data` as an app-owned contract.
 - Include a type or version field such as `kind` so clients can choose the renderer.
 - Provide a fallback renderer for unknown custom payloads.
 - Keep sensitive data out of custom payloads unless your product explicitly requires it.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Text Message" href="./text-message" icon="message-square">

--- a/social-plus-sdk/chat/messaging-features/message-creation/file-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/file-message.mdx
@@ -16,7 +16,7 @@ Use file messages for document and generic attachment sharing. TypeScript create
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send a file message
+## Send A File Message
 
 Create a file message from an uploaded file ID, native attachment, or Flutter file URI.
 
@@ -76,7 +76,7 @@ final message = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Replies and metadata
+## Replies And Metadata
 
 Add reply context or metadata when the file message belongs to a thread or needs app-owned rendering context.
 
@@ -111,7 +111,7 @@ final reply = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Image Message" href="./image-message" icon="image">

--- a/social-plus-sdk/chat/messaging-features/message-creation/image-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/image-message.mdx
@@ -17,7 +17,7 @@ Use image messages after the user selects or uploads an image. TypeScript create
 | `tags` | No | App-defined tags for filtering or grouping image messages. |
 | `metadata` | No | App-defined metadata stored with the message. |
 
-## Send an image message
+## Send An Image Message
 
 Create an image message from an uploaded file ID, native attachment, or Flutter image URI.
 
@@ -76,7 +76,7 @@ final message = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Optional context
+## Optional Context
 
 Add captions, tags, metadata, or reply context when your product needs richer image-message behavior.
 
@@ -116,7 +116,7 @@ val disposable = AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="File Message" href="./file-message" icon="file">

--- a/social-plus-sdk/chat/messaging-features/message-creation/reply-to-a-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/reply-to-a-message.mdx
@@ -20,7 +20,7 @@ Replies are created with the same message-type APIs as top-level messages. Set `
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined metadata stored with the reply. |
 
-## Reply with text
+## Reply With Text
 
 Create a text reply by setting `parentId` to the message being replied to.
 
@@ -79,7 +79,7 @@ final replyId = reply.messageId;
 
 </CodeGroup>
 
-## Reply with media or custom data
+## Reply With Media Or Custom Data
 
 Use the same reply pattern with media or custom payloads when the reply is not plain text.
 
@@ -110,11 +110,11 @@ val disposable = AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Query reply threads
+## Query Reply Threads
 
 After creating replies, query messages by `parentId` when you need to render a thread. See [Query & Filter Messages](../messages/query-and-filter-messages) for platform-specific query examples.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Text Message" href="./text-message" icon="message-square">

--- a/social-plus-sdk/chat/messaging-features/message-creation/send-a-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/send-a-message.mdx
@@ -38,7 +38,7 @@ Use message creation APIs after your app has resolved the target `subChannelId`.
 | `tags` | No | App-defined tags for later filtering or grouping. |
 | `metadata` | No | App-defined JSON-style metadata stored with the message. |
 
-## Send a text message
+## Send A Text Message
 
 Create a text message after resolving the target `subChannelId`.
 
@@ -93,7 +93,7 @@ final messageId = message.messageId;
 
 </CodeGroup>
 
-## Return shapes
+## Return Shapes
 
 | Platform | Create call result |
 | --- | --- |
@@ -102,7 +102,7 @@ final messageId = message.messageId;
 | Android | Returns a `Completable`; observe the message list for the created message |
 | Flutter | Returns `Future<AmityMessage>` |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Text Message" href="./text-message" icon="message-square">

--- a/social-plus-sdk/chat/messaging-features/message-creation/text-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/text-message.mdx
@@ -16,7 +16,7 @@ Use text messages for standard chat content. All SDKs support creating text mess
 | `mentionees` / `mentionUsers` | No | Users mentioned by the text message when the platform exposes mention builders. |
 | `parentId` | No | Parent message ID when the text message is a reply. |
 
-## Basic text message
+## Basic Text Message
 
 Create a basic text message with a `subChannelId` and text body.
 
@@ -71,7 +71,7 @@ final messageId = message.messageId;
 
 </CodeGroup>
 
-## Text with context
+## Text With Context
 
 Add tags, metadata, mentions, or reply context when the text message needs extra app-owned behavior.
 
@@ -140,7 +140,7 @@ final message = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Reply to a Message" href="./reply-to-a-message" icon="reply">

--- a/social-plus-sdk/chat/messaging-features/message-creation/video-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-creation/video-message.mdx
@@ -16,7 +16,7 @@ Use video messages for video attachments inside chat. TypeScript creates video m
 | `tags` | No | App-defined tags for message filtering, where supported by the platform builder. |
 | `metadata` | No | App-defined metadata stored with the message, where supported by the platform builder. |
 
-## Send a video message
+## Send A Video Message
 
 Create a video message from an uploaded file ID, native attachment, or Flutter video URI.
 
@@ -73,7 +73,7 @@ final message = await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="File Message" href="./file-message" icon="file">

--- a/social-plus-sdk/chat/messaging-features/message-flagging.mdx
+++ b/social-plus-sdk/chat/messaging-features/message-flagging.mdx
@@ -7,7 +7,7 @@ Use message flagging when a signed-in user reports a chat message. The SDKs expo
 
 Flagged messages are sent to the moderation backend. Keep product policy, review workflow, and enforcement copy outside the SDK integration layer so this page stays focused on the calls your app makes.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Flag with reason | Unflag | Check current user's flag |
 | --- | --- | --- | --- |
@@ -30,7 +30,7 @@ The older Android no-reason `flagMessage(messageId)` overload and Flutter `flag(
 | Check flag state | `messageId` | Yes | Message ID to check through the repository where supported. |
 | Check flag state | Fetched message object | Depends | Android and Flutter expose `isFlaggedByMe` on a fetched `AmityMessage`. |
 
-## Flag a message
+## Flag A Message
 
 Flag a message with a moderation reason so your product can route it into review.
 
@@ -80,7 +80,7 @@ final isFlaggedByMe = flaggedMessage.isFlaggedByMe;
 
 </CodeGroup>
 
-## Use a custom reason
+## Use A Custom Reason
 
 Use the `Others` reason only when your UI collects additional detail from the reporter.
 
@@ -134,7 +134,7 @@ final flagCount = flaggedMessage.flagCount;
 
 </CodeGroup>
 
-## Unflag a message
+## Unflag A Message
 
 Remove the current user's flag from a message when the user reverses the report action.
 
@@ -171,7 +171,7 @@ final isFlaggedByMe = unflaggedMessage.isFlaggedByMe;
 
 </CodeGroup>
 
-## Check flag state
+## Check Flag State
 
 TypeScript and iOS can ask the repository for the current user's flag state by message ID. Android and Flutter expose the state on fetched message objects.
 
@@ -216,7 +216,7 @@ final isFlaggedByMe = fetchedMessage.isFlaggedByMe;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Query Messages" href="./messages/query-and-filter-messages" icon="list-filter">

--- a/social-plus-sdk/chat/messaging-features/messages/edit-and-delete-messages.mdx
+++ b/social-plus-sdk/chat/messaging-features/messages/edit-and-delete-messages.mdx
@@ -7,7 +7,7 @@ Use message management APIs after your app already has the target `messageId`. T
 
 Soft deletion marks a message as deleted and lets message queries or single-message observers reflect that state. It is not a hard-delete or recovery API.
 
-## Platform surface
+## Platform Surface
 
 | Operation | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -31,7 +31,7 @@ The Flutter `updateMessage(channelId, messageId)` builder is deprecated. Use `ed
 | Edit custom | `data` / custom payload | Yes | Replacement JSON-serializable custom payload. |
 | Soft delete | `messageId` | Yes | Message ID to soft-delete. |
 
-## Edit a text message
+## Edit A Text Message
 
 Update the text body and optional app-owned context for an existing text message.
 
@@ -92,7 +92,7 @@ final editedAt = updatedMessage.editedAt;
 
 </CodeGroup>
 
-## Edit a custom message
+## Edit A Custom Message
 
 Update the JSON-serializable payload for an existing custom message.
 
@@ -148,7 +148,7 @@ final editedAt = updatedMessage.editedAt;
 
 </CodeGroup>
 
-## Soft-delete a message
+## Soft-Delete A Message
 
 Soft-delete a message by ID so list and single-message observers can reflect deleted state.
 
@@ -184,14 +184,14 @@ await AmityChatClient.newMessageRepository()
 
 </CodeGroup>
 
-## After edit or delete
+## After Edit Or Delete
 
 - Observe the message or query collection again instead of mutating app UI state by hand.
 - Use `editedAt` to render edited indicators after an edit.
 - Use `isDeleted` to render deleted placeholders or hide deleted messages depending on your product rule.
 - Pass `includeDeleted` on query APIs only where the platform exposes that filter.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Send Messages" href="../message-creation/send-a-message" icon="paper-plane">

--- a/social-plus-sdk/chat/messaging-features/messages/get-and-view-a-message.mdx
+++ b/social-plus-sdk/chat/messaging-features/messages/get-and-view-a-message.mdx
@@ -7,7 +7,7 @@ Use a single-message lookup when your app needs to open a message permalink, ref
 
 The SDK returns the same message model used by message queries. Rendering is app-owned: inspect `messageType` or `dataType`, read the typed data payload, and handle `isDeleted` before displaying content.
 
-## Platform surface
+## Platform Surface
 
 | Platform | Retrieval shape | Update behavior |
 | --- | --- | --- |
@@ -24,7 +24,7 @@ The SDK returns the same message model used by message queries. Rendering is app
 | Callback / observer | Depends | Required by TypeScript and native live-object APIs to receive loading, error, and data updates. |
 | Unsubscriber / token / disposable | No | Handle returned by live APIs; retain it while observing and release it when the UI no longer needs updates. |
 
-## Retrieve a message
+## Retrieve A Message
 
 Retrieve or observe a single message by `messageId`.
 
@@ -86,7 +86,7 @@ final isDeleted = fetchedMessage.isDeleted ?? false;
 
 </CodeGroup>
 
-## Inspect message content
+## Inspect Message Content
 
 Read the message type and data payload before choosing the renderer for your UI.
 
@@ -153,7 +153,7 @@ switch (fetchedMessage.dataType) {
 
 </CodeGroup>
 
-## Deletion and edit fields
+## Deletion And Edit Fields
 
 | Field | What to use it for |
 | --- | --- |
@@ -167,7 +167,7 @@ switch (fetchedMessage.dataType) {
 Single-message retrieval does not replace list queries. Use `getMessages` for timelines and use `getMessage` for detail refresh, deep links, or focused observation.
 </Note>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Query Messages" href="./query-and-filter-messages" icon="list-filter">

--- a/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages.mdx
+++ b/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages.mdx
@@ -7,7 +7,7 @@ Use message queries to build timelines, reply threads, media views, and jump-to-
 
 For chat timelines, prefer live collections or reactive streams where the platform provides them. They keep edits, deletes, reactions, and newly created messages in sync without a manual refresh loop.
 
-## Filter surface
+## Filter Surface
 
 | Filter | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -31,7 +31,7 @@ For chat timelines, prefer live collections or reactive streams where the platfo
 | `sortBy` / `stackFromEnd` | No | Control timeline ordering where the platform exposes sort options. |
 | Pagination controls | No | Use callbacks, live collections, or paging data to load additional results. |
 
-## Query a timeline
+## Query A Timeline
 
 Query the main message timeline for a subchannel with optional tag and sort filters.
 
@@ -114,7 +114,7 @@ liveCollection.loadNext();
 
 </CodeGroup>
 
-## Query by type or deleted state
+## Query By Type Or Deleted State
 
 Use message type and deleted-state filters to build focused views such as media galleries or moderation queues.
 
@@ -233,7 +233,7 @@ final replyCount = replies.length;
 
 </CodeGroup>
 
-## Jump to a message
+## Jump To A Message
 
 Use `aroundMessageId` when your app opens a deep link or search result and needs the target message plus nearby context.
 
@@ -291,7 +291,7 @@ final count = messagesAroundTarget.length;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Send Messages" href="../message-creation/send-a-message" icon="paper-plane">

--- a/social-plus-sdk/chat/messaging-features/overview.mdx
+++ b/social-plus-sdk/chat/messaging-features/overview.mdx
@@ -20,7 +20,7 @@ Use chat message APIs to build the message composer, message list, replies, reac
   </Card>
 </CardGroup>
 
-## Message creation coverage
+## Message Creation Coverage
 
 | Message type | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -35,7 +35,7 @@ Use chat message APIs to build the message composer, message list, replies, reac
 Media-message inputs differ by platform. TypeScript creates media messages from uploaded file IDs. iOS accepts `AmityMessageAttachment` values such as `.localURL` or `.fileId`. Android accepts `AmityMessageAttachment` values such as `FILE_ID` or `URL`. Flutter creates image, file, and video messages from a `Uri`.
 </Info>
 
-## Implementation notes
+## Implementation Notes
 
 - Resolve the `subChannelId` from your channel flow before creating messages.
 - Use `parentId` when creating replies.
@@ -43,7 +43,7 @@ Media-message inputs differ by platform. TypeScript creates media messages from 
 - Upload or select media first when your target platform expects a file ID or attachment object.
 - Keep message state handling in the UI tied to the platform model returned by the SDK.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Send a Message" href="./message-creation/send-a-message" icon="send">

--- a/social-plus-sdk/chat/moderation-safety/content-moderation/overview.mdx
+++ b/social-plus-sdk/chat/moderation-safety/content-moderation/overview.mdx
@@ -7,7 +7,7 @@ Content moderation in the Chat SDK is built from specific client actions: users 
 
 Keep review policy, escalation rules, audit notes, and compliance workflows in your own product or backend. The SDK supplies the client-side actions and state needed to connect those workflows to chat.
 
-## Capability map
+## Capability Map
 
 | Capability | Use it for | SDK page |
 | --- | --- | --- |
@@ -18,7 +18,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | Query deleted state | Include or exclude deleted messages where the platform exposes the filter. | [Query Messages](/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages) |
 | Channel governance | Manage members, roles, bans, and mutes for channel-level enforcement. | [Channel Governance](/social-plus-sdk/chat/conversation-management/channels/governance/overview) |
 
-## Platform surface
+## Platform Surface
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -29,7 +29,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | Query deleted messages | Supported | Supported | Supported | Supported |
 | Channel bans and mutes | Supported | Supported | Supported | Supported |
 
-## Moderation flow
+## Moderation Flow
 
 <CardGroup cols={2}>
   <Card title="Collect a report" href="/social-plus-sdk/chat/messaging-features/message-flagging" icon="flag">
@@ -46,7 +46,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
   </Card>
 </CardGroup>
 
-## Product boundaries
+## Product Boundaries
 
 | Concern | SDK surface | Product or backend responsibility |
 | --- | --- | --- |
@@ -55,7 +55,7 @@ Keep review policy, escalation rules, audit notes, and compliance workflows in y
 | User enforcement | Channel role, ban, mute, and member APIs. | Appeals, staff permissions, case notes, and cross-channel policy. |
 | Automation | Client-visible state after moderation actions. | Automated classifiers, review queues, escalation, and compliance exports. |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Message Flagging" href="/social-plus-sdk/chat/messaging-features/message-flagging" icon="flag">

--- a/social-plus-sdk/chat/overview.mdx
+++ b/social-plus-sdk/chat/overview.mdx
@@ -9,7 +9,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
   Looking for a product walkthrough? Use [Channels & Conversations](/use-cases/chat/channels-and-conversations) and [Sending Messages](/use-cases/chat/sending-messages). Use this section when you need the exact SDK objects and methods.
 </Tip>
 
-## SDK area map
+## SDK Area Map
 
 | Area | Use it for | Start here |
 | --- | --- | --- |
@@ -20,7 +20,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
 | Engagement features | Read message previews, unread counts, read status, delivery status, and receipt sync state. | [Unread Status Overview](/social-plus-sdk/chat/engagement-features/unread-status/overview) |
 | Content moderation | Connect user reports, message deletion, and channel governance into a product moderation flow. | [Content Moderation](/social-plus-sdk/chat/moderation-safety/content-moderation/overview) |
 
-## Platform coverage
+## Platform Coverage
 
 | Capability group | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -37,7 +37,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
   Platform gaps are documented on the specific feature pages. Do not copy a code snippet from another platform when a public SDK surface is not exposed for your target platform.
 </Info>
 
-## Implementation shape
+## Implementation Shape
 
 <CardGroup cols={2}>
   <Card title="Resolve the channel" href="/social-plus-sdk/chat/conversation-management/channels/create-channel" icon="comments">
@@ -54,7 +54,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
   </Card>
 </CardGroup>
 
-## Product boundaries
+## Product Boundaries
 
 | Concern | SDK owns | Your app owns |
 | --- | --- | --- |
@@ -63,7 +63,7 @@ The Chat SDK is the client surface for building channel-based messaging across T
 | Moderation | Message flagging, message deletion, and channel governance APIs. | Review queues, escalation policy, audit notes, appeal flows, and compliance workflows. |
 | Notifications | Data fields such as unread count, mention state, and preview content. | Push-notification templates, routing, deep links, and notification preferences. |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Create Channels" href="/social-plus-sdk/chat/conversation-management/channels/create-channel" icon="plus">


### PR DESCRIPTION
## Summary
- normalized heading style across chat SDK pages: conversation management, messaging, engagement, and chat moderation
- verified chat SDK code fences are inside `CodeGroup` blocks
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Notes
- structure-only slice; no SDK snippets, parameters, or API semantics changed
- kept table labels and card copy unchanged unless they were section headings

## Validation
- `awk ... social-plus-sdk/chat` check for SDK code fences outside `CodeGroup` returned no results
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/chat`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/chat`
- `python3 tools/check_internal_links.py social-plus-sdk/chat`
- `cd llmstxt && go test ./...`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `git diff --check`