### PR TITLE
Normalize social discovery engagement pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24958,7 +24958,7 @@ Discovery and engagement APIs help users find content, communities, and activity
     Retrieve tray items, item status, tray seen status, and notification event metadata.
     Add engagement affordances on posts, comments, stories, and other supported content.
 
-## Choose the right surface
+## Choose The Right Surface
 
 | Goal | Use |
 | --- | --- |
@@ -24970,7 +24970,7 @@ Discovery and engagement APIs help users find content, communities, and activity
 
 Platform coverage varies by surface. Each linked page includes the platform-specific SDK availability and code examples for that feature.
 
-## Related topics
+## Related Topics
 
     Query feed content for discovery surfaces.
     Compare post and community search options.
@@ -24996,7 +24996,7 @@ Use `AmityFeedRepository` to read feed-style post collections. The SDK exposes u
 
 TypeScript still exports `queryGlobalFeed()`, but the SDK source marks it deprecated. Use the live collection APIs for new integrations.
 
-## Query global feed
+## Query Global Feed
 
 Global feed returns a paginated collection of posts for the current user's global feed surface. Use data type filters when your UI only needs a subset of post types, such as an image or video feed.
 
@@ -25072,7 +25072,7 @@ showError(posts.length);
 ```
 
 
-## Query custom-ranking global feed
+## Query Custom-Ranking Global Feed
 
 Use custom-ranking global feed when your app has enabled the backend-ranked global feed experience. The SDK does not expose ranking weights or formulas; it only requests the custom-ranking feed and returns the posts provided by the backend.
 
@@ -25145,7 +25145,7 @@ showError(posts.length);
 ```
 
 
-## Android cache invalidation
+## Android Cache Invalidation
 
 Android feed builders expose `invalidateCache(true)`. Use it for deliberate refresh flows, such as pull-to-refresh, when the first page should not reuse the existing paging cache.
 
@@ -25171,7 +25171,7 @@ AmitySocialClient.newFeedRepository()
 - Dispose live collection subscriptions, notification tokens, and stream subscriptions when the screen is destroyed.
 - Treat custom-ranking behavior as backend-owned. Do not hardcode ranking assumptions in client UI logic.
 
-## Related topics
+## Related Topics
 
     Query user and community post collections with more filters.
     Search posts semantically or by hashtag.
@@ -25186,7 +25186,7 @@ The SDK search pages in this section cover the client-side APIs for finding post
 
 Semantic search availability depends on your network configuration. Confirm that the feature is enabled for your network before building UI that depends on semantic search results.
 
-## Search surfaces
+## Search Surfaces
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -25206,7 +25206,7 @@ Semantic search availability depends on your network configuration. Confirm that
 | Post data types | Not applicable | Supported for semantic post search; hashtag search support differs by platform |
 | Mixed structure | Not applicable | Supported by TypeScript, iOS, and Android post search APIs |
 
-## Implementation guides
+## Implementation Guides
 
     Find communities by semantic query, category, tag, and membership status
     Search posts by semantic query or by hashtag
@@ -25228,7 +25228,7 @@ Use post search when users need to find content across accessible post targets. 
 
 The current public Flutter SDK source reviewed for this page does not expose semantic post search or hashtag post search repository methods.
 
-## Semantic search filters
+## Semantic Search Filters
 
 | Filter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -25238,7 +25238,7 @@ The current public Flutter SDK source reviewed for this page does not expose sem
 | Parent-only matching | `matchingOnlyParentPost` | `matchingOnlyParentPost` | `matchingOnlyParentPosts` |
 | Mixed structure | `includeMixedStructure` | `includeMixedStructure` | `includeMixedStructure` |
 
-## Semantic search posts
+## Semantic Search Posts
 
 Use semantic search when a natural-language query should match accessible posts for the requested target and data types.
 
@@ -25320,7 +25320,7 @@ AmitySocialClient.newPostRepository()
 ```
 
 
-## Hashtag search posts
+## Hashtag Search Posts
 
 Hashtag search finds posts that contain one or more hashtags. Pass hashtag names without the `#` prefix.
 
@@ -25423,7 +25423,7 @@ Use community semantic search when a discovery experience should match a user's 
 
 The current public Flutter SDK source reviewed for this page does not expose a semantic community search repository method.
 
-## Search communities
+## Search Communities
 
 Search communities with a semantic query and optional category, tag, membership, or discoverable-private filters.
 
@@ -25503,7 +25503,7 @@ AmitySocialClient.newCommunityRepository()
 ```
 
 
-## Membership status
+## Membership Status
 
 | Intent | iOS | Android | TypeScript |
 | --- | --- | --- | --- |
@@ -25527,7 +25527,7 @@ The notification tray SDK APIs expose in-app notification tray data for the sign
 
 The current public Flutter SDK source reviewed for this page exposes push-notification registration and notification-settings APIs, but not notification tray item/status APIs.
 
-## SDK surfaces
+## SDK Surfaces
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -25536,7 +25536,7 @@ The current public Flutter SDK source reviewed for this page exposes push-notifi
 | Mark tray seen | `notificationTray.markTraySeen(lastSeenAt)` | `client.notificationTray.markSeen()` | `AmityCoreClient.notificationTray().markTraySeen()` | Not exposed in the current public Flutter SDK source reviewed for this page |
 | Mark item seen | `notificationTray.markItemsSeen([{ id, lastSeenAt }])` | `AmityNotificationTrayItem.markSeen()` | `AmityNotificationTrayItem.markSeen()` | Not exposed in the current public Flutter SDK source reviewed for this page |
 
-## Data model
+## Data Model
 
 Notification tray items are returned with actor, target, reference, action, text, and seen-state data. Property names differ slightly by platform.
 
@@ -25555,7 +25555,7 @@ Notification tray items are returned with actor, target, reference, action, text
 
 Tray seen status is a separate object with the latest tray occurrence timestamp, latest tray seen timestamp, and a derived `isSeen` value.
 
-## Typical flow
+## Typical Flow
 
 1. Observe tray seen status to decide whether to show a notification indicator.
 2. Query tray items when the user opens the notification tray.
@@ -25563,7 +25563,7 @@ Tray seen status is a separate object with the latest tray occurrence timestamp,
 4. Mark individual items as seen when the user views or opens a specific item.
 5. Dispose observers or subscriptions when the owning screen is destroyed.
 
-## Related topics
+## Related Topics
 
     Query tray items and mark individual items as seen
     Observe and update tray-level seen status
@@ -25577,7 +25577,7 @@ Tray seen status is a separate object with the latest tray occurrence timestamp,
 
 Notification tray items are paginated notification records for the signed-in user. Use this API to render an in-app notification tray and then mark individual items as seen when the user opens or views them.
 
-## Query items
+## Query Items
 
 Query notification tray items for the signed-in user, keeping the pagination handle while the tray screen is active.
 
@@ -25635,7 +25635,7 @@ AmityCoreClient.notificationTray()
 ```
 
 
-## Mark an item seen
+## Mark An Item Seen
 
 Mark an individual notification item seen after the user opens or views that item.
 
@@ -25692,7 +25692,7 @@ fun markNotificationItemSeen(item: AmityNotificationTrayItem) {
 - Use the platform-specific item ID field when routing from a tray item to a target screen: TypeScript `_id`, iOS `notificationId`, and Android `getId()`.
 - Dispose live collection subscriptions or notification tokens when the notification tray screen is destroyed.
 
-## Related topics
+## Related Topics
 
     Manage overall notification tray seen status.
     Reference action and category values returned on tray items.
@@ -25705,7 +25705,7 @@ fun markNotificationItemSeen(item: AmityNotificationTrayItem) {
 
 Notification tray status tracks whether the signed-in user's tray has been seen since the latest tray item occurred. Use it for tray badges, unread indicators, and "new notifications" affordances.
 
-## Status fields
+## Status Fields
 
 | Concept | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -25715,7 +25715,7 @@ Notification tray status tracks whether the signed-in user's tray has been seen 
 
 The current public Flutter SDK source reviewed for this page does not expose notification tray seen-status APIs.
 
-## Observe tray seen status
+## Observe Tray Seen Status
 
 Observe tray seen status when your app needs a badge or "new notifications" indicator to stay current.
 
@@ -25763,7 +25763,7 @@ AmityCoreClient.notificationTray()
 ```
 
 
-## Mark tray seen
+## Mark Tray Seen
 
 Mark the tray seen after the user actually views the notification tray.
 
@@ -25802,7 +25802,7 @@ AmityCoreClient.notificationTray()
 - Keep tray-level status separate from item-level status. Marking the tray seen does not replace item-level interaction tracking in your UI.
 - Re-observe or refresh tray status when the app returns to the foreground if your badge must reflect cross-device activity.
 
-## Related topics
+## Related Topics
 
     Query notification items and mark individual items as seen.
     Understand the notification tray SDK surface.
@@ -25817,7 +25817,7 @@ Notification tray items include string fields that identify what happened and wh
 
 Do not hardcode notification message-template behavior from this page. The SDK returns `text` and `templatedText` on each tray item. Render those fields or map action/category values only for UI behavior you own, such as icons and routing.
 
-## Core fields
+## Core Fields
 
 | Field | TypeScript | iOS | Android | Purpose |
 | --- | --- | --- | --- | --- |
@@ -25828,7 +25828,7 @@ Do not hardcode notification message-template behavior from this page. The SDK r
 | Parent | `parentId` | `parentId` | `getParentId()` | Parent object, when present |
 | Rendered text | `text`, `templatedText` | `text`, `templatedText` | `getText()`, `getTemplatedText()` | Text returned by the backend for display |
 
-## Action types
+## Action Types
 
 The TypeScript SDK type surface defines these action values. iOS and Android expose action type as a string on each returned tray item.
 
@@ -25843,7 +25843,7 @@ The TypeScript SDK type surface defines these action values. iOS and Android exp
 | `join_request` | Join-request-related notification |
 | `user` | User-related notification |
 
-## Tray item categories
+## Tray Item Categories
 
 The TypeScript SDK type surface defines these category values. iOS and Android expose the category as a string on each returned tray item.
 
@@ -25864,14 +25864,14 @@ The TypeScript SDK type surface defines these category values. iOS and Android e
 | `room_cohost_invite` | Room co-host invitation |
 | `user_profile_reset` | User profile reset notification |
 
-## Routing guidance
+## Routing Guidance
 
 - Use `targetType` and `targetId` for the primary destination.
 - Use `referenceType` and `referenceId` when your UI needs to highlight a related post, comment, event, or other referenced object.
 - Use `rootId` and `latestCommentId` when they are present and your comment UI needs to open a thread context.
 - Prefer the returned `text` or `templatedText` for display copy instead of rebuilding notification copy in the client.
 
-## Related documentation
+## Related Documentation
 
     Query tray items and inspect returned fields
     Observe and update tray-level seen status

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -18,7 +18,7 @@ Use `AmityFeedRepository` to read feed-style post collections. The SDK exposes u
 TypeScript still exports `queryGlobalFeed()`, but the SDK source marks it deprecated. Use the live collection APIs for new integrations.
 </Note>
 
-## Query global feed
+## Query Global Feed
 
 Global feed returns a paginated collection of posts for the current user's global feed surface. Use data type filters when your UI only needs a subset of post types, such as an image or video feed.
 
@@ -96,7 +96,7 @@ showError(posts.length);
 
 </CodeGroup>
 
-## Query custom-ranking global feed
+## Query Custom-Ranking Global Feed
 
 Use custom-ranking global feed when your app has enabled the backend-ranked global feed experience. The SDK does not expose ranking weights or formulas; it only requests the custom-ranking feed and returns the posts provided by the backend.
 
@@ -171,7 +171,7 @@ showError(posts.length);
 
 </CodeGroup>
 
-## Android cache invalidation
+## Android Cache Invalidation
 
 Android feed builders expose `invalidateCache(true)`. Use it for deliberate refresh flows, such as pull-to-refresh, when the first page should not reuse the existing paging cache.
 
@@ -201,7 +201,7 @@ AmitySocialClient.newFeedRepository()
 - Dispose live collection subscriptions, notification tokens, and stream subscriptions when the screen is destroyed.
 - Treat custom-ranking behavior as backend-owned. Do not hardcode ranking assumptions in client UI logic.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Query Posts" icon="newspaper" href="/social-plus-sdk/social/content-management/posts/retrieval/query-posts">

--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-events-reference.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-events-reference.mdx
@@ -9,7 +9,7 @@ Notification tray items include string fields that identify what happened and wh
 Do not hardcode notification message-template behavior from this page. The SDK returns `text` and `templatedText` on each tray item. Render those fields or map action/category values only for UI behavior you own, such as icons and routing.
 </Warning>
 
-## Core fields
+## Core Fields
 
 | Field | TypeScript | iOS | Android | Purpose |
 | --- | --- | --- | --- | --- |
@@ -20,7 +20,7 @@ Do not hardcode notification message-template behavior from this page. The SDK r
 | Parent | `parentId` | `parentId` | `getParentId()` | Parent object, when present |
 | Rendered text | `text`, `templatedText` | `text`, `templatedText` | `getText()`, `getTemplatedText()` | Text returned by the backend for display |
 
-## Action types
+## Action Types
 
 The TypeScript SDK type surface defines these action values. iOS and Android expose action type as a string on each returned tray item.
 
@@ -35,7 +35,7 @@ The TypeScript SDK type surface defines these action values. iOS and Android exp
 | `join_request` | Join-request-related notification |
 | `user` | User-related notification |
 
-## Tray item categories
+## Tray Item Categories
 
 The TypeScript SDK type surface defines these category values. iOS and Android expose the category as a string on each returned tray item.
 
@@ -56,14 +56,14 @@ The TypeScript SDK type surface defines these category values. iOS and Android e
 | `room_cohost_invite` | Room co-host invitation |
 | `user_profile_reset` | User profile reset notification |
 
-## Routing guidance
+## Routing Guidance
 
 - Use `targetType` and `targetId` for the primary destination.
 - Use `referenceType` and `referenceId` when your UI needs to highlight a related post, comment, event, or other referenced object.
 - Use `rootId` and `latestCommentId` when they are present and your comment UI needs to open a thread context.
 - Prefer the returned `text` or `templatedText` for display copy instead of rebuilding notification copy in the client.
 
-## Related documentation
+## Related Documentation
 
 <CardGroup cols={2}>
   <Card title="Notification Items" href="./notification-items" icon="list">

--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-items.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-items.mdx
@@ -5,7 +5,7 @@ description: "Query notification tray items and mark individual items as seen."
 
 Notification tray items are paginated notification records for the signed-in user. Use this API to render an in-app notification tray and then mark individual items as seen when the user opens or views them.
 
-## Query items
+## Query Items
 
 Query notification tray items for the signed-in user, keeping the pagination handle while the tray screen is active.
 
@@ -65,7 +65,7 @@ AmityCoreClient.notificationTray()
 
 </CodeGroup>
 
-## Mark an item seen
+## Mark An Item Seen
 
 Mark an individual notification item seen after the user opens or views that item.
 
@@ -124,7 +124,7 @@ fun markNotificationItemSeen(item: AmityNotificationTrayItem) {
 - Use the platform-specific item ID field when routing from a tray item to a target screen: TypeScript `_id`, iOS `notificationId`, and Android `getId()`.
 - Dispose live collection subscriptions or notification tokens when the notification tray screen is destroyed.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Notification Tray Status" href="./notification-tray-status" icon="check">

--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-tray-status.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-tray-status.mdx
@@ -5,7 +5,7 @@ description: "Observe and update notification tray seen status for unread indica
 
 Notification tray status tracks whether the signed-in user's tray has been seen since the latest tray item occurred. Use it for tray badges, unread indicators, and "new notifications" affordances.
 
-## Status fields
+## Status Fields
 
 | Concept | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -17,7 +17,7 @@ Notification tray status tracks whether the signed-in user's tray has been seen 
 The current public Flutter SDK source reviewed for this page does not expose notification tray seen-status APIs.
 </Note>
 
-## Observe tray seen status
+## Observe Tray Seen Status
 
 Observe tray seen status when your app needs a badge or "new notifications" indicator to stay current.
 
@@ -67,7 +67,7 @@ AmityCoreClient.notificationTray()
 
 </CodeGroup>
 
-## Mark tray seen
+## Mark Tray Seen
 
 Mark the tray seen after the user actually views the notification tray.
 
@@ -108,7 +108,7 @@ AmityCoreClient.notificationTray()
 - Keep tray-level status separate from item-level status. Marking the tray seen does not replace item-level interaction tracking in your UI.
 - Re-observe or refresh tray status when the app returns to the foreground if your badge must reflect cross-device activity.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Notification Items" href="./notification-items" icon="list">

--- a/social-plus-sdk/social/discovery-engagement/notifications/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/overview.mdx
@@ -9,7 +9,7 @@ The notification tray SDK APIs expose in-app notification tray data for the sign
 The current public Flutter SDK source reviewed for this page exposes push-notification registration and notification-settings APIs, but not notification tray item/status APIs.
 </Note>
 
-## SDK surfaces
+## SDK Surfaces
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -18,7 +18,7 @@ The current public Flutter SDK source reviewed for this page exposes push-notifi
 | Mark tray seen | `notificationTray.markTraySeen(lastSeenAt)` | `client.notificationTray.markSeen()` | `AmityCoreClient.notificationTray().markTraySeen()` | Not exposed in the current public Flutter SDK source reviewed for this page |
 | Mark item seen | `notificationTray.markItemsSeen([{ id, lastSeenAt }])` | `AmityNotificationTrayItem.markSeen()` | `AmityNotificationTrayItem.markSeen()` | Not exposed in the current public Flutter SDK source reviewed for this page |
 
-## Data model
+## Data Model
 
 Notification tray items are returned with actor, target, reference, action, text, and seen-state data. Property names differ slightly by platform.
 
@@ -37,7 +37,7 @@ Notification tray items are returned with actor, target, reference, action, text
 
 Tray seen status is a separate object with the latest tray occurrence timestamp, latest tray seen timestamp, and a derived `isSeen` value.
 
-## Typical flow
+## Typical Flow
 
 1. Observe tray seen status to decide whether to show a notification indicator.
 2. Query tray items when the user opens the notification tray.
@@ -45,7 +45,7 @@ Tray seen status is a separate object with the latest tray occurrence timestamp,
 4. Mark individual items as seen when the user views or opens a specific item.
 5. Dispose observers or subscriptions when the owning screen is destroyed.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Notification Items" href="./notification-items" icon="list">

--- a/social-plus-sdk/social/discovery-engagement/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/overview.mdx
@@ -20,7 +20,7 @@ Discovery and engagement APIs help users find content, communities, and activity
   </Card>
 </CardGroup>
 
-## Choose the right surface
+## Choose The Right Surface
 
 | Goal | Use |
 | --- | --- |
@@ -34,7 +34,7 @@ Discovery and engagement APIs help users find content, communities, and activity
 Platform coverage varies by surface. Each linked page includes the platform-specific SDK availability and code examples for that feature.
 </Info>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Feed Overview" href="./feed/overview" icon="rss">

--- a/social-plus-sdk/social/discovery-engagement/search/intelligent-search-community.mdx
+++ b/social-plus-sdk/social/discovery-engagement/search/intelligent-search-community.mdx
@@ -19,7 +19,7 @@ Use community semantic search when a discovery experience should match a user's 
 The current public Flutter SDK source reviewed for this page does not expose a semantic community search repository method.
 </Note>
 
-## Search communities
+## Search Communities
 
 Search communities with a semantic query and optional category, tag, membership, or discoverable-private filters.
 
@@ -101,7 +101,7 @@ AmitySocialClient.newCommunityRepository()
 
 </CodeGroup>
 
-## Membership status
+## Membership Status
 
 | Intent | iOS | Android | TypeScript |
 | --- | --- | --- | --- |

--- a/social-plus-sdk/social/discovery-engagement/search/intelligent-search-post.mdx
+++ b/social-plus-sdk/social/discovery-engagement/search/intelligent-search-post.mdx
@@ -9,7 +9,7 @@ Use post search when users need to find content across accessible post targets. 
 The current public Flutter SDK source reviewed for this page does not expose semantic post search or hashtag post search repository methods.
 </Note>
 
-## Semantic search filters
+## Semantic Search Filters
 
 | Filter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -19,7 +19,7 @@ The current public Flutter SDK source reviewed for this page does not expose sem
 | Parent-only matching | `matchingOnlyParentPost` | `matchingOnlyParentPost` | `matchingOnlyParentPosts` |
 | Mixed structure | `includeMixedStructure` | `includeMixedStructure` | `includeMixedStructure` |
 
-## Semantic search posts
+## Semantic Search Posts
 
 Use semantic search when a natural-language query should match accessible posts for the requested target and data types.
 
@@ -103,7 +103,7 @@ AmitySocialClient.newPostRepository()
 
 </CodeGroup>
 
-## Hashtag search posts
+## Hashtag Search Posts
 
 Hashtag search finds posts that contain one or more hashtags. Pass hashtag names without the `#` prefix.
 

--- a/social-plus-sdk/social/discovery-engagement/search/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/search/overview.mdx
@@ -9,7 +9,7 @@ The SDK search pages in this section cover the client-side APIs for finding post
 Semantic search availability depends on your network configuration. Confirm that the feature is enabled for your network before building UI that depends on semantic search results.
 </Note>
 
-## Search surfaces
+## Search Surfaces
 
 | Surface | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -29,7 +29,7 @@ Semantic search availability depends on your network configuration. Confirm that
 | Post data types | Not applicable | Supported for semantic post search; hashtag search support differs by platform |
 | Mixed structure | Not applicable | Supported by TypeScript, iOS, and Android post search APIs |
 
-## Implementation guides
+## Implementation Guides
 
 <CardGroup cols={2}>
   <Card title="Search Communities" icon="users" href="./intelligent-search-community">


### PR DESCRIPTION
## Summary
- normalized heading style across Social discovery, feed, intelligent search, and notification tray SDK pages
- verified discovery/engagement SDK code fences are already inside `CodeGroup` blocks
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Notes
- structure-only slice; no SDK snippets, parameters, or API semantics changed
- kept table labels and descriptive copy unchanged unless they were section headings

## Validation
- `awk ... social-plus-sdk/social/discovery-engagement` check for SDK code fences outside `CodeGroup` returned no results
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/social/discovery-engagement`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/social/discovery-engagement`
- `python3 tools/check_internal_links.py social-plus-sdk/social/discovery-engagement`
- `cd llmstxt && go test ./...`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `git diff --check`