### PR TITLE
Normalize social relationship pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19370,7 +19370,7 @@ User relationship APIs let a signed-in user build and manage their social graph.
 
 For an end-to-end product walkthrough, see [User Profiles & Social Graph](/use-cases/social/user-profiles-and-social-graph). This section focuses on SDK calls and return shapes.
 
-## Relationship systems
+## Relationship Systems
 
 | System | What it manages | Main SDK surface |
 | --- | --- | --- |
@@ -19388,7 +19388,7 @@ Follow status values are platform-specific enum or string values, but the shared
 
 Whether a follow becomes `accepted` immediately or starts as `pending` is determined by your network's follow configuration. The same SDK follow call is used in both cases.
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -19401,7 +19401,7 @@ Whether a follow becomes `accepted` immediately or starts as `pending` is determ
 | Query paginated blocked users | Yes | Yes | Yes | Yes |
 | Get all blocked users as a one-shot list | Yes | Yes | Yes | Not available in the Flutter public repository |
 
-## Use the right read API
+## Use The Right Read API
 
 Use the live or paginated APIs for user-facing screens:
 
@@ -19413,7 +19413,7 @@ Use `getAllBlockedUsers()` only when you need a one-shot block list for local de
 
 Do not rely on this overview for feed visibility, search visibility, comment permissions, or other product policy details. Those behaviors can depend on backend configuration and feature area. Handle SDK errors from the affected feature API and keep the UI state in sync with relationship status.
 
-## Related guides
+## Related Guides
 
     Create or remove a follow relationship.
     Approve or reject incoming follow requests.
@@ -26619,7 +26619,14 @@ Use the unfollow API to cancel a pending request or remove an accepted follow re
 
 If the relationship is blocked, follow and unfollow calls can fail or return a blocked status. Read the connection status before rendering a follow button when the UI needs to distinguish blocked users.
 
-## Follow user
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Follow user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to follow. |
+| Unfollow user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to unfollow or whose pending request should be canceled. |
+
+## Follow User
 
 Follow a user when the current user starts a relationship that may become accepted immediately or remain pending.
 
@@ -26663,7 +26670,7 @@ final statusValue = status.value;
 ```
 
 
-## Unfollow user
+## Unfollow User
 
 Unfollow a user to remove an accepted relationship or cancel a pending follow request.
 
@@ -26707,7 +26714,7 @@ final statusValue = status.value;
 ```
 
 
-## Related topics
+## Related Topics
 
     Handle incoming follow requests.
     Read status and counters.
@@ -26723,7 +26730,14 @@ When follow approval is enabled, a follow call creates a pending request. The ta
 
 Accept and decline methods operate on requests received by the current user. If the request has already been withdrawn, accepted, or declined, handle the SDK error and refresh the request list or follow info.
 
-## Accept follow request
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Accept follow request | `userId` / `targetUserId` | Yes | ID of the requester whose incoming follow request should be accepted. |
+| Decline follow request | `userId` / `targetUserId` | Yes | ID of the requester whose incoming follow request should be declined. |
+
+## Accept Follow Request
 
 Accept an incoming follow request when the current user approves the requester.
 
@@ -26767,7 +26781,7 @@ final statusValue = status.value;
 ```
 
 
-## Decline follow request
+## Decline Follow Request
 
 Decline an incoming follow request when the current user does not want to approve the requester.
 
@@ -26811,7 +26825,7 @@ final statusValue = status.value;
 ```
 
 
-## Related topics
+## Related Topics
 
     Create or remove follow relationships.
     Read status and counters.
@@ -26832,7 +26846,16 @@ Use follower and following list APIs when you need to show people lists, pending
 
 Status filters use `accepted`, `pending`, or `all` where the platform exposes them. TypeScript and Flutter support status filters on target-user follower/following builders. iOS and Android support status filters on the current user's follower/following builders; use their target-user builders when you need another user's accepted social graph without a status filter.
 
-## Get followers
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get followers | `userId` / `targetUserId` | Platform-dependent | Target user whose followers should be queried. iOS and Android status-filter snippets use current-user builders. |
+| Get following | `userId` / `targetUserId` | Platform-dependent | Target user whose following list should be queried. iOS status-filter snippet uses the current-user builder. |
+| Both lists | `status` / status filter | No | Relationship status filter such as accepted, pending, or all where exposed. |
+| Both lists | `limit` / page size | No | Page size for paginated follower or following lists. |
+
+## Get Followers
 
 Query followers when your UI needs a paginated people list for a user. The iOS and Android snippets use the current-user builders because those SDKs expose status filters there.
 
@@ -26904,7 +26927,7 @@ final relationships = page.data;
 ```
 
 
-## Get following
+## Get Following
 
 Query following relationships when your UI needs the users a profile follows. The iOS snippet uses the current-user builder to show status filtering; the Android snippet uses the target-user builder for another user's following list.
 
@@ -26975,7 +26998,7 @@ final relationships = page.data;
 ```
 
 
-## Follow relationship fields
+## Follow Relationship Fields
 
 | Platform | Common fields |
 | --- | --- |
@@ -26984,7 +27007,7 @@ final relationships = page.data;
 | Android | `getSourceUser()`, `getTargetUser()`, `getStatus()` |
 | Flutter | `sourceUserId`, `targetUserId`, `sourceUser`, `targetUser`, `status`, `createdAt` |
 
-## Related topics
+## Related Topics
 
     Change a relationship.
     Read counts and status.
@@ -27007,7 +27030,15 @@ The current user's follow info returns counts only. Another user's follow info r
 | Pending count for current user | `pendingCount` | `pendingCount` | `getPendingRequestCount()` | `pendingRequestCount` |
 | Status for another user | `status` | `status` | `getStatus()` | `status` |
 
-## Get my follow info
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get my follow info | None | No | Reads the current user's follow counts and pending-request count. |
+| Get another user's follow info | `userId` / `targetUserId` | Yes | ID of the user whose counts and relationship status should be read. |
+| Live observation | Callback / observer / subscription | Platform-dependent | TypeScript, iOS, and Android examples observe live data. Retain and dispose the returned handle where applicable. |
+
+## Get My Follow Info
 
 Read the current user's follow counts and pending-request count for profile or account surfaces.
 
@@ -27075,7 +27106,7 @@ final pendingCount = info.pendingRequestCount;
 ```
 
 
-## Get another user's follow info
+## Get Another User's Follow Info
 
 Read another user's follow info when rendering a profile header or follow button state.
 
@@ -27144,7 +27175,7 @@ final followingCount = info.followingCount;
 ```
 
 
-## Related topics
+## Related Topics
 
     Change the relationship state.
     Process pending requests.
@@ -27162,7 +27193,14 @@ The SDK updates relationship data after block and unblock calls. TypeScript retu
 
 Blocking affects relationship state, but downstream visibility and interaction behavior can vary by feature area and backend configuration. Keep feed, comment, search, and profile screens resilient by handling errors from those feature APIs and refreshing relationship status after block or unblock actions.
 
-## Block user
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Block user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to block. |
+| Unblock user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to unblock. |
+
+## Block User
 
 Block a user when the current user wants to prevent or limit relationship-based interactions with that account.
 
@@ -27202,7 +27240,7 @@ await AmityCoreClient.newUserRepository()
 ```
 
 
-## Unblock user
+## Unblock User
 
 Unblock a user when the current user removes a previously created block.
 
@@ -27242,7 +27280,7 @@ await AmityCoreClient.newUserRepository()
 ```
 
 
-## After block or unblock
+## After Block Or Unblock
 
 After a successful block or unblock action:
 
@@ -27251,7 +27289,7 @@ After a successful block or unblock action:
 - Refresh blocked-user lists if the current screen lets users manage blocked accounts.
 - Handle errors from other feature APIs instead of assuming all product surfaces update in the same way.
 
-## Related topics
+## Related Topics
 
     Query the blocked-user list.
     Read status and counters.
@@ -27274,7 +27312,15 @@ There are two read patterns:
 
 You can query users blocked by the current user. These APIs do not reveal which users have blocked the current user.
 
-## Get blocked users
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get blocked users | `limit` / page size | No | Page size for the paginated blocked-user list where the platform exposes it. |
+| Get blocked users | Pagination handle | No | Use each platform's live collection, paging, or callback pagination to load more blocked users. |
+| Get all blocked users | None | No | Returns a one-shot list on TypeScript, iOS, and Android. Not exposed in the current public Flutter repository. |
+
+## Get Blocked Users
 
 Query blocked users for a paginated account-management screen.
 
@@ -27340,7 +27386,7 @@ final blockedUsers = page.data;
 ```
 
 
-## Get all blocked users
+## Get All Blocked Users
 
 Use `getAllBlockedUsers()` when your app needs a one-shot list instead of a paginated collection. TypeScript, iOS, and Android return up to 100 blocked users and use a short SDK-side cache. Call the method again when you need a fresh snapshot.
 
@@ -27376,7 +27422,7 @@ const blockedUserIds = new Set(blockedUsers.map((user) => user.userId));
 
 The one-shot API is not available in the Flutter public repository. For Flutter, use `getBlockedUsers().getPagingData(...)` and page through the result.
 
-## Related topics
+## Related Topics
 
     Change blocked status.
     Read follow status.

--- a/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
@@ -11,7 +11,14 @@ The SDK updates relationship data after block and unblock calls. TypeScript retu
 Blocking affects relationship state, but downstream visibility and interaction behavior can vary by feature area and backend configuration. Keep feed, comment, search, and profile screens resilient by handling errors from those feature APIs and refreshing relationship status after block or unblock actions.
 </Warning>
 
-## Block user
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Block user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to block. |
+| Unblock user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to unblock. |
+
+## Block User
 
 Block a user when the current user wants to prevent or limit relationship-based interactions with that account.
 
@@ -53,7 +60,7 @@ await AmityCoreClient.newUserRepository()
 
 </CodeGroup>
 
-## Unblock user
+## Unblock User
 
 Unblock a user when the current user removes a previously created block.
 
@@ -95,7 +102,7 @@ await AmityCoreClient.newUserRepository()
 
 </CodeGroup>
 
-## After block or unblock
+## After Block Or Unblock
 
 After a successful block or unblock action:
 
@@ -104,7 +111,7 @@ After a successful block or unblock action:
 - Refresh blocked-user lists if the current screen lets users manage blocked accounts.
 - Handle errors from other feature APIs instead of assuming all product surfaces update in the same way.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Manage Blocked Users" href="./manage-blocked-users" icon="list">

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users.mdx
@@ -16,7 +16,15 @@ There are two read patterns:
 You can query users blocked by the current user. These APIs do not reveal which users have blocked the current user.
 </Info>
 
-## Get blocked users
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get blocked users | `limit` / page size | No | Page size for the paginated blocked-user list where the platform exposes it. |
+| Get blocked users | Pagination handle | No | Use each platform's live collection, paging, or callback pagination to load more blocked users. |
+| Get all blocked users | None | No | Returns a one-shot list on TypeScript, iOS, and Android. Not exposed in the current public Flutter repository. |
+
+## Get Blocked Users
 
 Query blocked users for a paginated account-management screen.
 
@@ -84,7 +92,7 @@ final blockedUsers = page.data;
 
 </CodeGroup>
 
-## Get all blocked users
+## Get All Blocked Users
 
 Use `getAllBlockedUsers()` when your app needs a one-shot list instead of a paginated collection. TypeScript, iOS, and Android return up to 100 blocked users and use a short SDK-side cache. Call the method again when you need a fresh snapshot.
 
@@ -124,7 +132,7 @@ const blockedUserIds = new Set(blockedUsers.map((user) => user.userId));
 The one-shot API is not available in the Flutter public repository. For Flutter, use `getBlockedUsers().getPagingData(...)` and page through the result.
 </Warning>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Block & Unblock User" href="./block-unblock-user" icon="ban">

--- a/social-plus-sdk/social/user-relationship/following/accept-decline-follow-request.mdx
+++ b/social-plus-sdk/social/user-relationship/following/accept-decline-follow-request.mdx
@@ -9,7 +9,14 @@ When follow approval is enabled, a follow call creates a pending request. The ta
 Accept and decline methods operate on requests received by the current user. If the request has already been withdrawn, accepted, or declined, handle the SDK error and refresh the request list or follow info.
 </Info>
 
-## Accept follow request
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Accept follow request | `userId` / `targetUserId` | Yes | ID of the requester whose incoming follow request should be accepted. |
+| Decline follow request | `userId` / `targetUserId` | Yes | ID of the requester whose incoming follow request should be declined. |
+
+## Accept Follow Request
 
 Accept an incoming follow request when the current user approves the requester.
 
@@ -55,7 +62,7 @@ final statusValue = status.value;
 
 </CodeGroup>
 
-## Decline follow request
+## Decline Follow Request
 
 Decline an incoming follow request when the current user does not want to approve the requester.
 
@@ -101,7 +108,7 @@ final statusValue = status.value;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Follow/Unfollow User" href="./follow-unfollow-user" icon="user-plus">

--- a/social-plus-sdk/social/user-relationship/following/follow-unfollow-user.mdx
+++ b/social-plus-sdk/social/user-relationship/following/follow-unfollow-user.mdx
@@ -11,7 +11,14 @@ Use the unfollow API to cancel a pending request or remove an accepted follow re
 If the relationship is blocked, follow and unfollow calls can fail or return a blocked status. Read the connection status before rendering a follow button when the UI needs to distinguish blocked users.
 </Info>
 
-## Follow user
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Follow user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to follow. |
+| Unfollow user | `userId` / `targetUserId` | Yes | ID of the user the current user wants to unfollow or whose pending request should be canceled. |
+
+## Follow User
 
 Follow a user when the current user starts a relationship that may become accepted immediately or remain pending.
 
@@ -57,7 +64,7 @@ final statusValue = status.value;
 
 </CodeGroup>
 
-## Unfollow user
+## Unfollow User
 
 Unfollow a user to remove an accepted relationship or cancel a pending follow request.
 
@@ -103,7 +110,7 @@ final statusValue = status.value;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Accept/Decline Requests" href="./accept-decline-follow-request" icon="handshake">

--- a/social-plus-sdk/social/user-relationship/following/get-connection-status.mdx
+++ b/social-plus-sdk/social/user-relationship/following/get-connection-status.mdx
@@ -14,7 +14,15 @@ The current user's follow info returns counts only. Another user's follow info r
 | Pending count for current user | `pendingCount` | `pendingCount` | `getPendingRequestCount()` | `pendingRequestCount` |
 | Status for another user | `status` | `status` | `getStatus()` | `status` |
 
-## Get my follow info
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get my follow info | None | No | Reads the current user's follow counts and pending-request count. |
+| Get another user's follow info | `userId` / `targetUserId` | Yes | ID of the user whose counts and relationship status should be read. |
+| Live observation | Callback / observer / subscription | Platform-dependent | TypeScript, iOS, and Android examples observe live data. Retain and dispose the returned handle where applicable. |
+
+## Get My Follow Info
 
 Read the current user's follow counts and pending-request count for profile or account surfaces.
 
@@ -84,7 +92,7 @@ final pendingCount = info.pendingRequestCount;
 
 </CodeGroup>
 
-## Get another user's follow info
+## Get Another User's Follow Info
 
 Read another user's follow info when rendering a profile header or follow button state.
 
@@ -155,7 +163,7 @@ final followingCount = info.followingCount;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Follow/Unfollow User" href="./follow-unfollow-user" icon="user-plus">

--- a/social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx
+++ b/social-plus-sdk/social/user-relationship/following/get-follower-following-list.mdx
@@ -14,7 +14,16 @@ Use follower and following list APIs when you need to show people lists, pending
 Status filters use `accepted`, `pending`, or `all` where the platform exposes them. TypeScript and Flutter support status filters on target-user follower/following builders. iOS and Android support status filters on the current user's follower/following builders; use their target-user builders when you need another user's accepted social graph without a status filter.
 </Info>
 
-## Get followers
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get followers | `userId` / `targetUserId` | Platform-dependent | Target user whose followers should be queried. iOS and Android status-filter snippets use current-user builders. |
+| Get following | `userId` / `targetUserId` | Platform-dependent | Target user whose following list should be queried. iOS status-filter snippet uses the current-user builder. |
+| Both lists | `status` / status filter | No | Relationship status filter such as accepted, pending, or all where exposed. |
+| Both lists | `limit` / page size | No | Page size for paginated follower or following lists. |
+
+## Get Followers
 
 Query followers when your UI needs a paginated people list for a user. The iOS and Android snippets use the current-user builders because those SDKs expose status filters there.
 
@@ -88,7 +97,7 @@ final relationships = page.data;
 
 </CodeGroup>
 
-## Get following
+## Get Following
 
 Query following relationships when your UI needs the users a profile follows. The iOS snippet uses the current-user builder to show status filtering; the Android snippet uses the target-user builder for another user's following list.
 
@@ -161,7 +170,7 @@ final relationships = page.data;
 
 </CodeGroup>
 
-## Follow relationship fields
+## Follow Relationship Fields
 
 | Platform | Common fields |
 | --- | --- |
@@ -170,7 +179,7 @@ final relationships = page.data;
 | Android | `getSourceUser()`, `getTargetUser()`, `getStatus()` |
 | Flutter | `sourceUserId`, `targetUserId`, `sourceUser`, `targetUser`, `status`, `createdAt` |
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Follow/Unfollow User" href="./follow-unfollow-user" icon="user-plus">

--- a/social-plus-sdk/social/user-relationship/overview.mdx
+++ b/social-plus-sdk/social/user-relationship/overview.mdx
@@ -9,7 +9,7 @@ User relationship APIs let a signed-in user build and manage their social graph.
 For an end-to-end product walkthrough, see [User Profiles & Social Graph](/use-cases/social/user-profiles-and-social-graph). This section focuses on SDK calls and return shapes.
 </Tip>
 
-## Relationship systems
+## Relationship Systems
 
 | System | What it manages | Main SDK surface |
 | --- | --- | --- |
@@ -29,7 +29,7 @@ Follow status values are platform-specific enum or string values, but the shared
 Whether a follow becomes `accepted` immediately or starts as `pending` is determined by your network's follow configuration. The same SDK follow call is used in both cases.
 </Info>
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -42,7 +42,7 @@ Whether a follow becomes `accepted` immediately or starts as `pending` is determ
 | Query paginated blocked users | Yes | Yes | Yes | Yes |
 | Get all blocked users as a one-shot list | Yes | Yes | Yes | Not available in the Flutter public repository |
 
-## Use the right read API
+## Use The Right Read API
 
 Use the live or paginated APIs for user-facing screens:
 
@@ -56,7 +56,7 @@ Use `getAllBlockedUsers()` only when you need a one-shot block list for local de
 Do not rely on this overview for feed visibility, search visibility, comment permissions, or other product policy details. Those behaviors can depend on backend configuration and feature area. Handle SDK errors from the affected feature API and keep the UI state in sync with relationship status.
 </Warning>
 
-## Related guides
+## Related Guides
 
 <CardGroup cols={2}>
   <Card title="Follow/Unfollow User" href="./following/follow-unfollow-user" icon="user-plus">


### PR DESCRIPTION
## Summary
- added compact parameter tables to Social SDK relationship operation pages
- normalized heading style across follow, block, connection status, list, and relationship overview pages
- verified relationship SDK code fences are already inside `CodeGroup` blocks
- regenerated `llms-full.txt` so AI-facing docs match the MDX changes

## Notes
- no SDK snippets or API semantics changed
- parameter tables summarize existing snippet inputs and platform-specific pagination/observation handles

## Validation
- `awk ... social-plus-sdk/social/user-relationship` check for SDK code fences outside `CodeGroup` returned no results
- `python3 .docs-ops/ci/check-mdx.py social-plus-sdk/social/user-relationship`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/social/user-relationship`
- `python3 tools/check_internal_links.py social-plus-sdk/social/user-relationship`
- `cd llmstxt && go test ./...`
- `python3 .docs-ops/ci/check-mdx.py`
- `python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk`
- `git diff --check`