### PR TITLE
Normalize comments and post creation pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -20029,7 +20029,7 @@ Text posts publish written content to a user feed, a community feed, or the curr
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 | `links` | No | Structured link metadata supported by TypeScript, Android, and iOS. |
 
-## Create a text post
+## Create a Text Post
 
 The examples below create a text post in a community. Use the equivalent user target method or target type when posting to a user feed.
 
@@ -20082,7 +20082,7 @@ final post = await AmitySocialClient.newPostRepository()
 ```
 
 
-## Add structured links
+## Add Structured Links
 
 TypeScript, Android, and iOS expose a `links` field when creating a text post. Fetch preview metadata first if the post should render a preview card.
 
@@ -20168,13 +20168,13 @@ const { data: post } = await PostRepository.createPost({
 ```
 
 
-## Query text posts
+## Query Text Posts
 
 Post query APIs are SDK-specific. For TypeScript, `PostRepository.getPosts` returns a live collection through a callback instead of a promise, so do not call it with `await`.
 
 For structure type values and filtering behavior, see [Posts Overview](../overview) and [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
     Review post concepts, retrieval, and moderation flows.
     Load text posts back into feed and detail screens.
@@ -20204,7 +20204,7 @@ This page focuses on the SDK call that creates the post. See [Image Handling](/s
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create an image post
+## Create an Image Post
 
 The examples below create an image post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -20287,7 +20287,7 @@ Future<AmityPost> createImagePost(List<AmityImage> uploadedImages) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
     Upload images before creating image posts.
     Combine images with other supported media attachments.
@@ -20317,7 +20317,7 @@ This page focuses on the SDK call that creates the post. See [Video Handling](/s
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a video post
+## Create a Video Post
 
 The examples below create a video post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -20400,7 +20400,7 @@ Future<AmityPost> createVideoPost(List<AmityVideo> uploadedVideos) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
     Upload videos before creating video posts.
     Create short-form clip posts where supported.
@@ -20430,7 +20430,7 @@ TypeScript, Android, and iOS expose audio post creation APIs. Flutter can upload
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create an audio post
+## Create an Audio Post
 
 The examples below create an audio post in a community on SDKs that support audio post creation.
 
@@ -20493,7 +20493,7 @@ const { data: post } = await PostRepository.createAudioPost({
 ```
 
 
-## Flutter support
+## Flutter Support
 
 Flutter's public file repository supports audio upload, but the public post creation builder currently exposes text, image, video, file, poll, live stream, and custom post creation paths. It does not expose `.audio(...)` or a dedicated audio post creator.
 
@@ -20506,7 +20506,7 @@ Use a supported Flutter post type, or create audio posts from a platform/backend
 - iOS accepts `[AmityAudioData]`.
 - Do not set `structureType` manually; the service derives post structure from the created post data.
 
-## Related topics
+## Related Topics
 
     Upload files before creating attachment-based posts.
     Combine multiple supported media attachment types.
@@ -20536,7 +20536,7 @@ This page focuses on the SDK call that creates the post. See [File Handling](/so
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a file post
+## Create a File Post
 
 The examples below create a file post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -20619,7 +20619,7 @@ Future<AmityPost> createFilePost(List<AmityFile> uploadedFiles) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
     Upload files before creating file posts.
     Combine files with other supported media attachments.
@@ -20649,7 +20649,7 @@ Use a stable, application-owned data type such as `post.product` or `event.sessi
 | `metadata` | No | Auxiliary custom metadata that should not define the post type. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a custom post
+## Create a Custom Post
 
 The examples below create a custom product-style post in a community. Replace the data type and payload with your app's schema.
 
@@ -20727,7 +20727,7 @@ final post = await AmitySocialClient.newPostRepository()
 - Use one stable data type per custom schema so feeds can route rendering predictably.
 - Keep custom post data focused on renderable content. Use `metadata` for auxiliary app data that should not define the post type.
 
-## Related topics
+## Related Topics
 
     Review post concepts, retrieval, and moderation flows.
     Load custom posts back into feed and detail screens.
@@ -20757,7 +20757,7 @@ Create the poll before creating the post. See [Poll Creation Guidelines](/social
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a poll post
+## Create a Poll Post
 
 The examples below create a poll post in a community from an existing `pollId`.
 
@@ -20826,7 +20826,7 @@ final post = await AmitySocialClient.newPostRepository()
 - Keep the poll question, answers, answer type, and close time in the poll creation flow.
 - Use the post text for feed context or a short prompt; the poll object remains the source of truth for answer options and voting behavior.
 
-## Related topics
+## Related Topics
 
     Create the poll object before publishing a poll post.
     Create a simple feed post without a poll attachment.
@@ -20842,7 +20842,7 @@ Live stream posts are the legacy feed representation for an existing live stream
 
   For new live and co-host room experiences, create a room and publish a room post instead. The iOS live stream post API is deprecated in favor of `createRoomPost`.
 
-## When to use
+## When to Use
 
 | Use case | Recommended post type |
 | --- | --- |
@@ -20860,7 +20860,7 @@ Live stream posts are the legacy feed representation for an existing live stream
 | `targetId` | Yes | Community ID or user ID for the target feed |
 | `metadata` | No | Custom metadata stored with the post where supported |
 
-## Create a live stream post
+## Create a Live Stream Post
 
 Create a legacy live stream post only when your product still has an existing stream ID from the older live-stream flow.
 
@@ -20930,14 +20930,14 @@ Future<AmityPost> createLegacyLiveStreamPost(
 ```
 
 
-## Platform notes
+## Platform Notes
 
 - TypeScript creates a legacy live stream post through `PostRepository.createPost()` with `dataType: "liveStream"`.
 - Android exposes `AmityPostRepository.createLiveStreamPost()`.
 - iOS exposes `AmityPostRepository.createLiveStreamPost()`, but the method is deprecated in favor of `createRoomPost()`.
 - Flutter exposes `.liveStream(streamId)` on the public post creation builder.
 
-## Related topics
+## Related Topics
 
     Use room posts for new live and co-host experiences.
     Create posts from uploaded video files.
@@ -20964,7 +20964,7 @@ Clip posts publish an uploaded clip into a user or community feed. Upload the cl
 | `targetType` | Yes | Feed target, usually `community` or `user` |
 | `targetId` | Yes | Community ID or user ID for the target feed |
 
-## Create a clip post
+## Create a Clip Post
 
 Create a clip post from an uploaded clip file or clip data, and include optional display settings where supported.
 
@@ -21031,14 +21031,14 @@ func createClipPost(
 
   The current Flutter public post creation builder does not expose a clip post creator. It supports text, image, video, file, poll, live stream, and custom post creation.
 
-## Platform notes
+## Platform Notes
 
 - TypeScript exposes `PostRepository.createClipPost()` with `attachments: [{ type: "clip", fileId }]`.
 - Android exposes `AmityPostRepository.createClipPost()` with an uploaded `AmityClip`.
 - iOS exposes `AmityPostRepository.createClipPost()` with `AmityClipPostBuilder` and uploaded `AmityClipData`.
 - Flutter does not currently expose a public clip post creation method.
 
-## Related topics
+## Related Topics
 
     Upload video files before creating video-based posts.
     Create standard uploaded-video posts.
@@ -21068,7 +21068,7 @@ TypeScript, Android, and iOS expose mixed media post creation APIs. The current 
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a mixed media post
+## Create a Mixed Media Post
 
 The examples below combine image and video attachments in a community post. Add audio or file attachments on SDKs that expose those uploaded media object types.
 
@@ -21142,7 +21142,7 @@ const { data: post } = await PostRepository.createPost({
 ```
 
 
-## Flutter support
+## Flutter Support
 
 Flutter's current public post creation builder exposes `.image(...)`, `.video(...)`, and `.file(...)` for single attachment-type posts. It does not expose a public mixed media builder that accepts multiple attachment types in one post creation call.
 
@@ -21155,7 +21155,7 @@ Create a single supported post type from Flutter, or create mixed media posts fr
 - iOS accepts uploaded media through `AmityMixedMediaPostBuilder`.
 - Do not pass `structureType` in the create request. The service derives it from the attachment composition.
 
-## Related topics
+## Related Topics
 
     Create image-only posts from uploaded images.
     Create video-only posts from uploaded videos.
@@ -21182,7 +21182,7 @@ Room posts publish an existing room into a user or community feed. Create the ro
 | `targetId` | Yes | Community ID or user ID for the target feed |
 | `metadata` | No | Custom metadata stored with the post where supported |
 
-## Create a room post
+## Create a Room Post
 
 Create a room post after the room already exists, then use the returned post in the target user or community feed.
 
@@ -21239,14 +21239,14 @@ func createRoomPost(roomId: String, communityId: String) async throws -> AmityPo
 
   The current Flutter public post creation builder does not expose a room post creator. Use another supported SDK or backend flow when your product needs to publish room posts from Flutter.
 
-## Platform notes
+## Platform Notes
 
 - TypeScript exposes `PostRepository.createRoomPost()`.
 - Android exposes `AmityPostRepository.createRoomPost()`.
 - iOS exposes `AmityPostRepository.createRoomPost()` with `AmityRoomPostBuilder`.
 - Flutter does not currently expose a public room post creation method.
 
-## Related topics
+## Related Topics
 
     Review the deprecated legacy live stream post path.
     Create posts from uploaded video files.
@@ -22577,7 +22577,7 @@ Use comment creation APIs to add comments to posts, stories, or your own custom 
 | `metadata` | No | App-defined metadata stored with the comment, where supported by the platform-specific builder. |
 | `mentionees` / mention builders | No | Mention targets for text comments, where supported by the platform-specific builder. |
 
-## Basic text comment
+## Basic Text Comment
 
 Create a top-level text comment by passing the reference target and text body to the comment repository.
 
@@ -22633,7 +22633,7 @@ final commentId = comment.commentId;
 ```
 
 
-## Reply to a comment
+## Reply to a Comment
 
 Create a reply with the same reference target and the `parentId` of the comment being replied to.
 
@@ -22693,7 +22693,7 @@ final replyId = reply.commentId;
 ```
 
 
-## Related topics
+## Related Topics
 
     See full text-comment parameters and notes.
     Create comments with uploaded image attachments.
@@ -22722,7 +22722,7 @@ Create a text comment by passing a reference target and text body to the comment
 
   The current Flutter public comment creation builder exposes `metadata(...)` and `mentionUsers(...)`, but it does not expose a `links(...)` method.
 
-## Create a text comment
+## Create a Text Comment
 
 Create a top-level text comment with the reference target and text body.
 
@@ -22778,7 +22778,7 @@ final commentId = comment.commentId;
 ```
 
 
-## Reply to a comment
+## Reply to a Comment
 
 Replies use the same creation API with `parentId` set to the comment being replied to.
 
@@ -22845,7 +22845,7 @@ final replyId = reply.commentId;
 - Validate your product's text limits and moderation rules before calling the SDK.
 - Build mention payloads from the user IDs your mention picker returns.
 
-## Related topics
+## Related Topics
 
     Create comments with uploaded image attachments.
     Query top-level comments and reply threads.
@@ -22860,7 +22860,17 @@ Image comments are comments with image attachment file IDs. Upload each image fi
 
   Comment creation accepts uploaded image file IDs. Use the file or image upload APIs before creating the comment.
 
-## Create an image comment
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Create an image comment | `referenceId` | Yes | Target content ID for the comment, such as a post ID. |
+| Create an image comment | `referenceType` | Yes | Target content type, such as `post`. |
+| Create an image comment | Uploaded image file ID | Yes | File ID returned by the image upload API. |
+| Create an image comment | `text` | No | Optional text body included with the image attachment. |
+| Reply with an image | `parentId` | Yes | Parent comment ID when creating an image reply. |
+
+## Create an Image Comment
 
 Create an image comment from an uploaded image file ID, with optional text where supported.
 
@@ -22934,7 +22944,7 @@ final commentId = comment.commentId;
 ```
 
 
-## Reply with an image
+## Reply with an Image
 
 Set `parentId` before the platform-specific create step.
 
@@ -23013,7 +23023,7 @@ final replyId = reply.commentId;
 - If your product needs image moderation or file-size limits, apply those rules before upload.
 - Query the resulting comment if you need composed file metadata such as rendered image information.
 
-## Related topics
+## Related Topics
 
     Create text comments and replies.
     Upload image files before attaching them to comments.
@@ -23026,7 +23036,7 @@ final replyId = reply.commentId;
 
 Use a comment ID when your app needs to open a thread, refresh a detail view, or inspect a comment after creation. TypeScript, iOS, Android, and Flutter all expose single-comment retrieval; the live update shape differs by platform.
 
-## Comment fields
+## Comment Fields
 
 The comment model names vary by SDK, but these are the fields most apps read after retrieval.
 
@@ -23041,7 +23051,15 @@ The comment model names vary by SDK, but these are the fields most apps read aft
 | Reactions | `reactionCount`, `myReactions` | `reactionsCount`, `myReactions` | `getReactionCount()`, `getMyReactions()` | `reactionCount`, `myReactions` |
 | Deleted state | `isDeleted` | `isDeleted` | `isDeleted()` | `isDeleted` |
 
-## Observe a comment
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Observe a comment | `commentId` | Yes | Comment ID to observe as a live object or stream. |
+| Fetch one comment | `commentId` | Yes | Comment ID to fetch once on Flutter. |
+| Fetch multiple comments by ID | `commentIds` | Yes | Comment IDs to fetch on TypeScript and Android. |
+
+## Observe a Comment
 
 Observe a single comment when a detail view or thread preview should stay current after edits, deletes, or reactions.
 
@@ -23113,7 +23131,7 @@ await subscription.cancel();
 ```
 
 
-## Fetch one comment
+## Fetch One Comment
 
 Flutter also exposes a direct one-shot fetch for comment detail screens.
 
@@ -23126,7 +23144,7 @@ final fetchedCommentId = comment.commentId;
 ```
 
 
-## Fetch multiple comments by ID
+## Fetch Multiple Comments by ID
 
 Batch lookup is available in TypeScript and Android. Use query APIs when you need a paged collection for a post, story, or custom content item.
 
@@ -23158,7 +23176,7 @@ AmitySocialClient.newCommentRepository()
 - Android `getComment(...)` is annotated with `ExperimentalAmityApi`; opt in at the call site or enclosing scope.
 - If the user needs a list of comments under a reference, use [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments) instead of repeated single-comment calls.
 
-## Related topics
+## Related Topics
 
     Query top-level comments and reply threads.
     Fetch or derive the newest comment for a reference.
@@ -23171,7 +23189,7 @@ AmitySocialClient.newCommentRepository()
 
 Use the latest-comment pattern when you need a compact preview, such as showing the newest comment below a post card. iOS and Android expose dedicated latest-comment helpers. TypeScript and Flutter use the normal comment query API sorted newest-first with a page size of one.
 
-## Platform availability
+## Platform Availability
 
 | Platform | Dedicated latest helper | Reference targets |
 | --- | --- | --- |
@@ -23180,7 +23198,17 @@ Use the latest-comment pattern when you need a compact preview, such as showing 
 | TypeScript | Use `getComments(...)` with `sortBy: "lastCreated"` and `pageSize: 1` | `post`, `content`, `story` |
 | Flutter | Use `getComments().post(...)`, `.content(...)`, or `.story(...)` with newest-first sort and limit `1` | `post`, `content`, `story` |
 
-## Dedicated helpers
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Dedicated helpers | `referenceId` | Yes | Target content ID whose latest comment should be fetched. |
+| Dedicated helpers | `referenceType` | Yes | Target content type, such as `post`. |
+| Dedicated helpers | `includeReplies` | No | Whether replies can be returned as the latest comment on iOS and Android. |
+| Query the latest comment | `sortBy` | Yes | Newest-first sort order, such as `lastCreated`. |
+| Query the latest comment | `pageSize` / `limit` | Yes | Set to `1` to retrieve only the newest comment. |
+
+## Dedicated Helpers
 
 Use the dedicated iOS and Android helpers when you want the latest comment without building a manual one-item query.
 
@@ -23209,7 +23237,7 @@ AmitySocialClient.newCommentRepository()
 ```
 
 
-## Query the latest comment
+## Query the Latest Comment
 
 Use this pattern on TypeScript and Flutter, or when you want the same query-based behavior across platforms.
 
@@ -23252,7 +23280,7 @@ final latestComment = comments.isNotEmpty ? comments.first : null;
 ```
 
 
-## Include replies
+## Include Replies
 
 For iOS and Android dedicated helpers, `includeReplies` controls whether replies can be returned as the latest comment.
 
@@ -23273,7 +23301,7 @@ For query-based implementations, use the `parentId` filter:
 - Use [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments) when you need pagination, filtering, or a full thread.
 - Handle the empty state in query-based implementations because a reference may not have comments yet.
 
-## Related topics
+## Related Topics
 
     Query comments with parent filters, deleted-state filters, and pagination.
     Retrieve a specific comment by ID.
@@ -23288,7 +23316,19 @@ Use comment queries when your app needs a paged list for a post, story, or custo
 
   Query APIs return paged/live collection results on TypeScript, iOS, Android, and Flutter. For a single known comment ID, use [Get Comment](/social-plus-sdk/social/content-management/comments/retrieval/get-comment).
 
-## Query options
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Query comments | `referenceId` | Yes | ID of the post, story, or custom content item. |
+| Query comments | `referenceType` | Yes | Target content type, such as `post`, `story`, or `content`. |
+| Query comments | `parentId` | No | `null` / `nil` for top-level comments, a comment ID for replies, or omitted where supported. |
+| Query comments | `includeDeleted` | No | Include soft-deleted comments for moderation or audit views. |
+| Query comments | `dataTypes` | No | Filter comments by content type, such as text or image. |
+| Query comments | `sortBy` / `orderBy` | No | Newest-first or oldest-first comment order. |
+| Query comments | `pageSize` / `limit` | No | Number of comments to load per page. |
+
+## Query Options
 
 | Option | Description |
 | --- | --- |
@@ -23300,7 +23340,7 @@ Use comment queries when your app needs a paged list for a post, story, or custo
 | `sortBy` / `orderBy` | Newest-first or oldest-first comment order |
 | `pageSize` / `limit` | Number of comments to load per page |
 
-## Query top-level comments
+## Query Top-Level Comments
 
 Set the parent filter to `null` / `nil` when you only want root comments.
 
@@ -23393,7 +23433,7 @@ await subscription.cancel();
 ```
 
 
-## Query replies
+## Query Replies
 
 Set `parentId` to an existing comment ID to load replies for that comment.
 
@@ -23476,7 +23516,7 @@ final replyCount = replies.length;
 ```
 
 
-## Filter by data type
+## Filter by Data Type
 
 Use data type filters when your UI needs a specific type of comment, such as image-only comments.
 
@@ -23566,7 +23606,7 @@ final imageCommentCount = imageComments.length;
 ```
 
 
-## Reference targets
+## Reference Targets
 
 | Target | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -23581,7 +23621,7 @@ final imageCommentCount = imageComments.length;
 - `includeDeleted: true` is mainly for moderation, audit, or admin-style views; most end-user views should exclude deleted comments.
 - Dispose of observers, subscriptions, or live collections when the screen is no longer active.
 
-## Related topics
+## Related Topics
 
     Retrieve a specific comment by ID
     Create top-level comments and replies
@@ -23594,7 +23634,7 @@ final imageCommentCount = imageComments.length;
 
 Use comment update APIs when a user edits a comment or replaces its image attachments. The SDK sends the update to the server; permission, ownership, and moderation rules are enforced by the backend and surfaced as SDK errors.
 
-## Update fields
+## Update Fields
 
 | Field | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -23606,7 +23646,17 @@ Use comment update APIs when a user edits a comment or replaces its image attach
 
   Upload image files first, then pass the uploaded file IDs to the update API. Passing local file paths to comment update is not supported.
 
-## Update text
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Update text | `commentId` | Yes | Comment ID to update. |
+| Update text | `text` | Yes | Replacement text body for the comment. |
+| Update image attachments | `commentId` | Yes | Comment ID to update. |
+| Update image attachments | Uploaded image file ID | Yes | Uploaded image file ID to keep on the comment. |
+| Update optional fields | `metadata`, mentions, links | No | Optional editable fields where the target SDK exposes them. |
+
+## Update Text
 
 Update text and other editable fields by loading the comment ID and applying the platform-specific update call.
 
@@ -23660,7 +23710,7 @@ await AmitySocialClient.newCommentRepository()
 ```
 
 
-## Update image attachments
+## Update Image Attachments
 
 Set the attachment list to the full list you want the comment to keep. To preserve an existing image, include its uploaded file ID in the update payload.
 
@@ -23736,7 +23786,7 @@ await AmitySocialClient.newCommentRepository()
 ```
 
 
-## Clear optional fields
+## Clear Optional Fields
 
 Different SDKs distinguish between "leave this field unchanged" and "replace this field with an empty value."
 
@@ -23756,7 +23806,7 @@ Different SDKs distinguish between "leave this field unchanged" and "replace thi
 - Rebuild mention and link payloads from the edited text before updating a comment.
 - Handle permission, not-found, and moderation errors from the SDK call rather than relying only on client-side checks.
 
-## Related topics
+## Related Topics
 
     Soft delete or permanently delete comments where supported.
     Query comments and include deleted comments when needed.
@@ -23771,7 +23821,7 @@ Different SDKs distinguish between "leave this field unchanged" and "replace thi
 
 Use comment deletion when a user removes their own comment or a moderation flow removes a comment. Soft delete marks the comment as deleted while preserving enough state for collections and audit-style views. Hard delete permanently removes the comment where the SDK exposes that operation.
 
-## Platform support
+## Platform Support
 
 | Platform | Soft delete | Hard delete |
 | --- | --- | --- |
@@ -23782,7 +23832,17 @@ Use comment deletion when a user removes their own comment or a moderation flow 
 
   Hard delete is permanent. Confirm the action in your UI before calling a hard-delete API.
 
-## Soft delete
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Soft delete | `commentId` | Yes | Comment ID to soft delete. |
+| Hard delete | `commentId` | Yes | Comment ID to hard delete where supported. |
+| Query deleted comments | `referenceId` | Yes | Target content ID whose comments should be queried. |
+| Query deleted comments | `referenceType` | Yes | Target content type, such as `post`. |
+| Query deleted comments | `includeDeleted` | Yes | Include soft-deleted comments in query results. |
+
+## Soft Delete
 
 Soft delete a comment when the UI should preserve deleted-state semantics in comment collections.
 
@@ -23817,7 +23877,7 @@ await comment.delete();
 ```
 
 
-## Hard delete
+## Hard Delete
 
 Hard delete is available in TypeScript, iOS, and Android.
 
@@ -23845,7 +23905,7 @@ AmitySocialClient.newCommentRepository()
 ```
 
 
-## Query deleted comments
+## Query Deleted Comments
 
 Use the query API with deleted comments included when you need moderation or audit views.
 
@@ -23924,7 +23984,7 @@ final resultCount = comments.length;
 - Use soft delete for reversible moderation workflows; reserve hard delete for cases where permanent removal is intended and supported on that platform.
 - The Flutter public comment extension exposes `delete()` for the comment instance; do not rely on a separate Flutter hard-delete path unless your SDK version documents one.
 
-## Related topics
+## Related Topics
 
     Update text, metadata, mentions, links, and image attachments.
     Query comments with deleted-state filtering.

--- a/social-plus-sdk/social/content-management/comments/actions/delete-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/actions/delete-comment.mdx
@@ -5,7 +5,7 @@ description: "Delete comments with the platform-supported soft delete and hard d
 
 Use comment deletion when a user removes their own comment or a moderation flow removes a comment. Soft delete marks the comment as deleted while preserving enough state for collections and audit-style views. Hard delete permanently removes the comment where the SDK exposes that operation.
 
-## Platform support
+## Platform Support
 
 | Platform | Soft delete | Hard delete |
 | --- | --- | --- |
@@ -18,7 +18,17 @@ Use comment deletion when a user removes their own comment or a moderation flow 
   Hard delete is permanent. Confirm the action in your UI before calling a hard-delete API.
 </Warning>
 
-## Soft delete
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Soft delete | `commentId` | Yes | Comment ID to soft delete. |
+| Hard delete | `commentId` | Yes | Comment ID to hard delete where supported. |
+| Query deleted comments | `referenceId` | Yes | Target content ID whose comments should be queried. |
+| Query deleted comments | `referenceType` | Yes | Target content type, such as `post`. |
+| Query deleted comments | `includeDeleted` | Yes | Include soft-deleted comments in query results. |
+
+## Soft Delete
 
 Soft delete a comment when the UI should preserve deleted-state semantics in comment collections.
 
@@ -55,7 +65,7 @@ await comment.delete();
 
 </CodeGroup>
 
-## Hard delete
+## Hard Delete
 
 Hard delete is available in TypeScript, iOS, and Android.
 
@@ -85,7 +95,7 @@ AmitySocialClient.newCommentRepository()
 
 </CodeGroup>
 
-## Query deleted comments
+## Query Deleted Comments
 
 Use the query API with deleted comments included when you need moderation or audit views.
 
@@ -166,7 +176,7 @@ final resultCount = comments.length;
 - Use soft delete for reversible moderation workflows; reserve hard delete for cases where permanent removal is intended and supported on that platform.
 - The Flutter public comment extension exposes `delete()` for the comment instance; do not rely on a separate Flutter hard-delete path unless your SDK version documents one.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Edit Comment" href="/social-plus-sdk/social/content-management/comments/actions/edit-comment" icon="pen">

--- a/social-plus-sdk/social/content-management/comments/actions/edit-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/actions/edit-comment.mdx
@@ -5,7 +5,7 @@ description: "Update comment text, metadata, mentions, links, and image attachme
 
 Use comment update APIs when a user edits a comment or replaces its image attachments. The SDK sends the update to the server; permission, ownership, and moderation rules are enforced by the backend and surfaced as SDK errors.
 
-## Update fields
+## Update Fields
 
 | Field | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -19,7 +19,17 @@ Use comment update APIs when a user edits a comment or replaces its image attach
   Upload image files first, then pass the uploaded file IDs to the update API. Passing local file paths to comment update is not supported.
 </Info>
 
-## Update text
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Update text | `commentId` | Yes | Comment ID to update. |
+| Update text | `text` | Yes | Replacement text body for the comment. |
+| Update image attachments | `commentId` | Yes | Comment ID to update. |
+| Update image attachments | Uploaded image file ID | Yes | Uploaded image file ID to keep on the comment. |
+| Update optional fields | `metadata`, mentions, links | No | Optional editable fields where the target SDK exposes them. |
+
+## Update Text
 
 Update text and other editable fields by loading the comment ID and applying the platform-specific update call.
 
@@ -75,7 +85,7 @@ await AmitySocialClient.newCommentRepository()
 
 </CodeGroup>
 
-## Update image attachments
+## Update Image Attachments
 
 Set the attachment list to the full list you want the comment to keep. To preserve an existing image, include its uploaded file ID in the update payload.
 
@@ -153,7 +163,7 @@ await AmitySocialClient.newCommentRepository()
 
 </CodeGroup>
 
-## Clear optional fields
+## Clear Optional Fields
 
 Different SDKs distinguish between "leave this field unchanged" and "replace this field with an empty value."
 
@@ -173,7 +183,7 @@ Different SDKs distinguish between "leave this field unchanged" and "replace thi
 - Rebuild mention and link payloads from the edited text before updating a comment.
 - Handle permission, not-found, and moderation errors from the SDK call rather than relying only on client-side checks.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Delete Comment" href="/social-plus-sdk/social/content-management/comments/actions/delete-comment" icon="trash">

--- a/social-plus-sdk/social/content-management/comments/creation/create-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/creation/create-comment.mdx
@@ -25,7 +25,7 @@ Use comment creation APIs to add comments to posts, stories, or your own custom 
 | `metadata` | No | App-defined metadata stored with the comment, where supported by the platform-specific builder. |
 | `mentionees` / mention builders | No | Mention targets for text comments, where supported by the platform-specific builder. |
 
-## Basic text comment
+## Basic Text Comment
 
 Create a top-level text comment by passing the reference target and text body to the comment repository.
 
@@ -83,7 +83,7 @@ final commentId = comment.commentId;
 
 </CodeGroup>
 
-## Reply to a comment
+## Reply to a Comment
 
 Create a reply with the same reference target and the `parentId` of the comment being replied to.
 
@@ -145,7 +145,7 @@ final replyId = reply.commentId;
 
 </CodeGroup>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Text Comment" href="./text-comment" icon="message-square">

--- a/social-plus-sdk/social/content-management/comments/creation/image-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/creation/image-comment.mdx
@@ -9,7 +9,17 @@ Image comments are comments with image attachment file IDs. Upload each image fi
   Comment creation accepts uploaded image file IDs. Use the file or image upload APIs before creating the comment.
 </Info>
 
-## Create an image comment
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Create an image comment | `referenceId` | Yes | Target content ID for the comment, such as a post ID. |
+| Create an image comment | `referenceType` | Yes | Target content type, such as `post`. |
+| Create an image comment | Uploaded image file ID | Yes | File ID returned by the image upload API. |
+| Create an image comment | `text` | No | Optional text body included with the image attachment. |
+| Reply with an image | `parentId` | Yes | Parent comment ID when creating an image reply. |
+
+## Create an Image Comment
 
 Create an image comment from an uploaded image file ID, with optional text where supported.
 
@@ -85,7 +95,7 @@ final commentId = comment.commentId;
 
 </CodeGroup>
 
-## Reply with an image
+## Reply with an Image
 
 Set `parentId` before the platform-specific create step.
 
@@ -166,7 +176,7 @@ final replyId = reply.commentId;
 - If your product needs image moderation or file-size limits, apply those rules before upload.
 - Query the resulting comment if you need composed file metadata such as rendered image information.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Text Comment" icon="message-square" href="./text-comment">

--- a/social-plus-sdk/social/content-management/comments/creation/text-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/creation/text-comment.mdx
@@ -21,7 +21,7 @@ Create a text comment by passing a reference target and text body to the comment
   The current Flutter public comment creation builder exposes `metadata(...)` and `mentionUsers(...)`, but it does not expose a `links(...)` method.
 </Info>
 
-## Create a text comment
+## Create a Text Comment
 
 Create a top-level text comment with the reference target and text body.
 
@@ -79,7 +79,7 @@ final commentId = comment.commentId;
 
 </CodeGroup>
 
-## Reply to a comment
+## Reply to a Comment
 
 Replies use the same creation API with `parentId` set to the comment being replied to.
 
@@ -148,7 +148,7 @@ final replyId = reply.commentId;
 - Validate your product's text limits and moderation rules before calling the SDK.
 - Build mention payloads from the user IDs your mention picker returns.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Image Comment" icon="image" href="./image-comment">

--- a/social-plus-sdk/social/content-management/comments/retrieval/get-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/retrieval/get-comment.mdx
@@ -5,7 +5,7 @@ description: "Retrieve a comment by ID and observe updates where the SDK exposes
 
 Use a comment ID when your app needs to open a thread, refresh a detail view, or inspect a comment after creation. TypeScript, iOS, Android, and Flutter all expose single-comment retrieval; the live update shape differs by platform.
 
-## Comment fields
+## Comment Fields
 
 The comment model names vary by SDK, but these are the fields most apps read after retrieval.
 
@@ -20,7 +20,15 @@ The comment model names vary by SDK, but these are the fields most apps read aft
 | Reactions | `reactionCount`, `myReactions` | `reactionsCount`, `myReactions` | `getReactionCount()`, `getMyReactions()` | `reactionCount`, `myReactions` |
 | Deleted state | `isDeleted` | `isDeleted` | `isDeleted()` | `isDeleted` |
 
-## Observe a comment
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Observe a comment | `commentId` | Yes | Comment ID to observe as a live object or stream. |
+| Fetch one comment | `commentId` | Yes | Comment ID to fetch once on Flutter. |
+| Fetch multiple comments by ID | `commentIds` | Yes | Comment IDs to fetch on TypeScript and Android. |
+
+## Observe a Comment
 
 Observe a single comment when a detail view or thread preview should stay current after edits, deletes, or reactions.
 
@@ -94,7 +102,7 @@ await subscription.cancel();
 
 </CodeGroup>
 
-## Fetch one comment
+## Fetch One Comment
 
 Flutter also exposes a direct one-shot fetch for comment detail screens.
 
@@ -109,7 +117,7 @@ final fetchedCommentId = comment.commentId;
 
 </CodeGroup>
 
-## Fetch multiple comments by ID
+## Fetch Multiple Comments by ID
 
 Batch lookup is available in TypeScript and Android. Use query APIs when you need a paged collection for a post, story, or custom content item.
 
@@ -143,7 +151,7 @@ AmitySocialClient.newCommentRepository()
 - Android `getComment(...)` is annotated with `ExperimentalAmityApi`; opt in at the call site or enclosing scope.
 - If the user needs a list of comments under a reference, use [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments) instead of repeated single-comment calls.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Query Comments" href="/social-plus-sdk/social/content-management/comments/retrieval/query-comments" icon="search">

--- a/social-plus-sdk/social/content-management/comments/retrieval/get-latest-comment.mdx
+++ b/social-plus-sdk/social/content-management/comments/retrieval/get-latest-comment.mdx
@@ -5,7 +5,7 @@ description: "Fetch the newest comment for a post or content item, with platform
 
 Use the latest-comment pattern when you need a compact preview, such as showing the newest comment below a post card. iOS and Android expose dedicated latest-comment helpers. TypeScript and Flutter use the normal comment query API sorted newest-first with a page size of one.
 
-## Platform availability
+## Platform Availability
 
 | Platform | Dedicated latest helper | Reference targets |
 | --- | --- | --- |
@@ -14,7 +14,17 @@ Use the latest-comment pattern when you need a compact preview, such as showing 
 | TypeScript | Use `getComments(...)` with `sortBy: "lastCreated"` and `pageSize: 1` | `post`, `content`, `story` |
 | Flutter | Use `getComments().post(...)`, `.content(...)`, or `.story(...)` with newest-first sort and limit `1` | `post`, `content`, `story` |
 
-## Dedicated helpers
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Dedicated helpers | `referenceId` | Yes | Target content ID whose latest comment should be fetched. |
+| Dedicated helpers | `referenceType` | Yes | Target content type, such as `post`. |
+| Dedicated helpers | `includeReplies` | No | Whether replies can be returned as the latest comment on iOS and Android. |
+| Query the latest comment | `sortBy` | Yes | Newest-first sort order, such as `lastCreated`. |
+| Query the latest comment | `pageSize` / `limit` | Yes | Set to `1` to retrieve only the newest comment. |
+
+## Dedicated Helpers
 
 Use the dedicated iOS and Android helpers when you want the latest comment without building a manual one-item query.
 
@@ -45,7 +55,7 @@ AmitySocialClient.newCommentRepository()
 
 </CodeGroup>
 
-## Query the latest comment
+## Query the Latest Comment
 
 Use this pattern on TypeScript and Flutter, or when you want the same query-based behavior across platforms.
 
@@ -90,7 +100,7 @@ final latestComment = comments.isNotEmpty ? comments.first : null;
 
 </CodeGroup>
 
-## Include replies
+## Include Replies
 
 For iOS and Android dedicated helpers, `includeReplies` controls whether replies can be returned as the latest comment.
 
@@ -111,7 +121,7 @@ For query-based implementations, use the `parentId` filter:
 - Use [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments) when you need pagination, filtering, or a full thread.
 - Handle the empty state in query-based implementations because a reference may not have comments yet.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Query Comments" href="/social-plus-sdk/social/content-management/comments/retrieval/query-comments" icon="search">

--- a/social-plus-sdk/social/content-management/comments/retrieval/query-comments.mdx
+++ b/social-plus-sdk/social/content-management/comments/retrieval/query-comments.mdx
@@ -9,7 +9,19 @@ Use comment queries when your app needs a paged list for a post, story, or custo
   Query APIs return paged/live collection results on TypeScript, iOS, Android, and Flutter. For a single known comment ID, use [Get Comment](/social-plus-sdk/social/content-management/comments/retrieval/get-comment).
 </Info>
 
-## Query options
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Query comments | `referenceId` | Yes | ID of the post, story, or custom content item. |
+| Query comments | `referenceType` | Yes | Target content type, such as `post`, `story`, or `content`. |
+| Query comments | `parentId` | No | `null` / `nil` for top-level comments, a comment ID for replies, or omitted where supported. |
+| Query comments | `includeDeleted` | No | Include soft-deleted comments for moderation or audit views. |
+| Query comments | `dataTypes` | No | Filter comments by content type, such as text or image. |
+| Query comments | `sortBy` / `orderBy` | No | Newest-first or oldest-first comment order. |
+| Query comments | `pageSize` / `limit` | No | Number of comments to load per page. |
+
+## Query Options
 
 | Option | Description |
 | --- | --- |
@@ -21,7 +33,7 @@ Use comment queries when your app needs a paged list for a post, story, or custo
 | `sortBy` / `orderBy` | Newest-first or oldest-first comment order |
 | `pageSize` / `limit` | Number of comments to load per page |
 
-## Query top-level comments
+## Query Top-Level Comments
 
 Set the parent filter to `null` / `nil` when you only want root comments.
 
@@ -116,7 +128,7 @@ await subscription.cancel();
 
 </CodeGroup>
 
-## Query replies
+## Query Replies
 
 Set `parentId` to an existing comment ID to load replies for that comment.
 
@@ -201,7 +213,7 @@ final replyCount = replies.length;
 
 </CodeGroup>
 
-## Filter by data type
+## Filter by Data Type
 
 Use data type filters when your UI needs a specific type of comment, such as image-only comments.
 
@@ -293,7 +305,7 @@ final imageCommentCount = imageComments.length;
 
 </CodeGroup>
 
-## Reference targets
+## Reference Targets
 
 | Target | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -308,7 +320,7 @@ final imageCommentCount = imageComments.length;
 - `includeDeleted: true` is mainly for moderation, audit, or admin-style views; most end-user views should exclude deleted comments.
 - Dispose of observers, subscriptions, or live collections when the screen is no longer active.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Get Comment" href="/social-plus-sdk/social/content-management/comments/retrieval/get-comment" icon="message">

--- a/social-plus-sdk/social/content-management/posts/creation/audio-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/audio-post.mdx
@@ -29,7 +29,7 @@ TypeScript, Android, and iOS expose audio post creation APIs. Flutter can upload
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create an audio post
+## Create an Audio Post
 
 The examples below create an audio post in a community on SDKs that support audio post creation.
 
@@ -94,7 +94,7 @@ const { data: post } = await PostRepository.createAudioPost({
 
 </CodeGroup>
 
-## Flutter support
+## Flutter Support
 
 Flutter's public file repository supports audio upload, but the public post creation builder currently exposes text, image, video, file, poll, live stream, and custom post creation paths. It does not expose `.audio(...)` or a dedicated audio post creator.
 
@@ -107,7 +107,7 @@ Use a supported Flutter post type, or create audio posts from a platform/backend
 - iOS accepts `[AmityAudioData]`.
 - Do not set `structureType` manually; the service derives post structure from the created post data.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="File Handling" icon="upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file">

--- a/social-plus-sdk/social/content-management/posts/creation/clip-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/clip-post.mdx
@@ -20,7 +20,7 @@ Clip posts publish an uploaded clip into a user or community feed. Upload the cl
 | `targetType` | Yes | Feed target, usually `community` or `user` |
 | `targetId` | Yes | Community ID or user ID for the target feed |
 
-## Create a clip post
+## Create a Clip Post
 
 Create a clip post from an uploaded clip file or clip data, and include optional display settings where supported.
 
@@ -91,14 +91,14 @@ func createClipPost(
   The current Flutter public post creation builder does not expose a clip post creator. It supports text, image, video, file, poll, live stream, and custom post creation.
 </Info>
 
-## Platform notes
+## Platform Notes
 
 - TypeScript exposes `PostRepository.createClipPost()` with `attachments: [{ type: "clip", fileId }]`.
 - Android exposes `AmityPostRepository.createClipPost()` with an uploaded `AmityClip`.
 - iOS exposes `AmityPostRepository.createClipPost()` with `AmityClipPostBuilder` and uploaded `AmityClipData`.
 - Flutter does not currently expose a public clip post creation method.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Video Handling" icon="upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling">

--- a/social-plus-sdk/social/content-management/posts/creation/custom-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/custom-post.mdx
@@ -27,7 +27,7 @@ Use a stable, application-owned data type such as `post.product` or `event.sessi
 | `metadata` | No | Auxiliary custom metadata that should not define the post type. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a custom post
+## Create a Custom Post
 
 The examples below create a custom product-style post in a community. Replace the data type and payload with your app's schema.
 
@@ -107,7 +107,7 @@ final post = await AmitySocialClient.newPostRepository()
 - Use one stable data type per custom schema so feeds can route rendering predictably.
 - Keep custom post data focused on renderable content. Use `metadata` for auxiliary app data that should not define the post type.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Posts Overview" icon="newspaper" href="../overview">

--- a/social-plus-sdk/social/content-management/posts/creation/file-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/file-post.mdx
@@ -29,7 +29,7 @@ This page focuses on the SDK call that creates the post. See [File Handling](/so
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a file post
+## Create a File Post
 
 The examples below create a file post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -114,7 +114,7 @@ Future<AmityPost> createFilePost(List<AmityFile> uploadedFiles) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="File Handling" icon="upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file">

--- a/social-plus-sdk/social/content-management/posts/creation/image-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/image-post.mdx
@@ -29,7 +29,7 @@ This page focuses on the SDK call that creates the post. See [Image Handling](/s
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create an image post
+## Create an Image Post
 
 The examples below create an image post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -114,7 +114,7 @@ Future<AmityPost> createImagePost(List<AmityImage> uploadedImages) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Image Handling" icon="upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling">

--- a/social-plus-sdk/social/content-management/posts/creation/live-stream-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/live-stream-post.mdx
@@ -9,7 +9,7 @@ Live stream posts are the legacy feed representation for an existing live stream
   For new live and co-host room experiences, create a room and publish a room post instead. The iOS live stream post API is deprecated in favor of `createRoomPost`.
 </Warning>
 
-## When to use
+## When to Use
 
 | Use case | Recommended post type |
 | --- | --- |
@@ -27,7 +27,7 @@ Live stream posts are the legacy feed representation for an existing live stream
 | `targetId` | Yes | Community ID or user ID for the target feed |
 | `metadata` | No | Custom metadata stored with the post where supported |
 
-## Create a live stream post
+## Create a Live Stream Post
 
 Create a legacy live stream post only when your product still has an existing stream ID from the older live-stream flow.
 
@@ -99,14 +99,14 @@ Future<AmityPost> createLegacyLiveStreamPost(
 
 </CodeGroup>
 
-## Platform notes
+## Platform Notes
 
 - TypeScript creates a legacy live stream post through `PostRepository.createPost()` with `dataType: "liveStream"`.
 - Android exposes `AmityPostRepository.createLiveStreamPost()`.
 - iOS exposes `AmityPostRepository.createLiveStreamPost()`, but the method is deprecated in favor of `createRoomPost()`.
 - Flutter exposes `.liveStream(streamId)` on the public post creation builder.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Room Posts" icon="users-viewfinder" href="./room-post">

--- a/social-plus-sdk/social/content-management/posts/creation/mixed-media-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/mixed-media-post.mdx
@@ -29,7 +29,7 @@ TypeScript, Android, and iOS expose mixed media post creation APIs. The current 
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a mixed media post
+## Create a Mixed Media Post
 
 The examples below combine image and video attachments in a community post. Add audio or file attachments on SDKs that expose those uploaded media object types.
 
@@ -105,7 +105,7 @@ const { data: post } = await PostRepository.createPost({
 
 </CodeGroup>
 
-## Flutter support
+## Flutter Support
 
 Flutter's current public post creation builder exposes `.image(...)`, `.video(...)`, and `.file(...)` for single attachment-type posts. It does not expose a public mixed media builder that accepts multiple attachment types in one post creation call.
 
@@ -118,7 +118,7 @@ Create a single supported post type from Flutter, or create mixed media posts fr
 - iOS accepts uploaded media through `AmityMixedMediaPostBuilder`.
 - Do not pass `structureType` in the create request. The service derives it from the attachment composition.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Image Posts" icon="image" href="./image-post">

--- a/social-plus-sdk/social/content-management/posts/creation/poll-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/poll-post.mdx
@@ -29,7 +29,7 @@ Create the poll before creating the post. See [Poll Creation Guidelines](/social
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a poll post
+## Create a Poll Post
 
 The examples below create a poll post in a community from an existing `pollId`.
 
@@ -100,7 +100,7 @@ final post = await AmitySocialClient.newPostRepository()
 - Keep the poll question, answers, answer type, and close time in the poll creation flow.
 - Use the post text for feed context or a short prompt; the poll object remains the source of truth for answer options and voting behavior.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Poll Creation" icon="square-poll-vertical" href="/social-plus-sdk/core-concepts/content-handling/poll#create-a-poll">

--- a/social-plus-sdk/social/content-management/posts/creation/room-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/room-post.mdx
@@ -20,7 +20,7 @@ Room posts publish an existing room into a user or community feed. Create the ro
 | `targetId` | Yes | Community ID or user ID for the target feed |
 | `metadata` | No | Custom metadata stored with the post where supported |
 
-## Create a room post
+## Create a Room Post
 
 Create a room post after the room already exists, then use the returned post in the target user or community feed.
 
@@ -81,14 +81,14 @@ func createRoomPost(roomId: String, communityId: String) async throws -> AmityPo
   The current Flutter public post creation builder does not expose a room post creator. Use another supported SDK or backend flow when your product needs to publish room posts from Flutter.
 </Info>
 
-## Platform notes
+## Platform Notes
 
 - TypeScript exposes `PostRepository.createRoomPost()`.
 - Android exposes `AmityPostRepository.createRoomPost()`.
 - iOS exposes `AmityPostRepository.createRoomPost()` with `AmityRoomPostBuilder`.
 - Flutter does not currently expose a public room post creation method.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Live Stream Posts" icon="circle-video" href="./live-stream-post">

--- a/social-plus-sdk/social/content-management/posts/creation/text-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/text-post.mdx
@@ -25,7 +25,7 @@ Text posts publish written content to a user feed, a community feed, or the curr
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 | `links` | No | Structured link metadata supported by TypeScript, Android, and iOS. |
 
-## Create a text post
+## Create a Text Post
 
 The examples below create a text post in a community. Use the equivalent user target method or target type when posting to a user feed.
 
@@ -80,7 +80,7 @@ final post = await AmitySocialClient.newPostRepository()
 
 </CodeGroup>
 
-## Add structured links
+## Add Structured Links
 
 TypeScript, Android, and iOS expose a `links` field when creating a text post. Fetch preview metadata first if the post should render a preview card.
 
@@ -170,13 +170,13 @@ const { data: post } = await PostRepository.createPost({
 
 </CodeGroup>
 
-## Query text posts
+## Query Text Posts
 
 Post query APIs are SDK-specific. For TypeScript, `PostRepository.getPosts` returns a live collection through a callback instead of a promise, so do not call it with `await`.
 
 For structure type values and filtering behavior, see [Posts Overview](../overview) and [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Posts Overview" icon="newspaper" href="../overview">

--- a/social-plus-sdk/social/content-management/posts/creation/video-post.mdx
+++ b/social-plus-sdk/social/content-management/posts/creation/video-post.mdx
@@ -29,7 +29,7 @@ This page focuses on the SDK call that creates the post. See [Video Handling](/s
 | `metadata` | No | Custom metadata stored with the post where supported. |
 | `mentionees` | No | User mention payload where supported by the platform builder. |
 
-## Create a video post
+## Create a Video Post
 
 The examples below create a video post in a community. Replace the target with the SDK's user-feed target when posting to a user.
 
@@ -114,7 +114,7 @@ Future<AmityPost> createVideoPost(List<AmityVideo> uploadedVideos) {
 
 For mixed attachment types, use [Mixed Media Posts](./mixed-media-post).
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Video Handling" icon="upload" href="/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling">


### PR DESCRIPTION
## Summary
- Added top-level parameter tables to comment operation pages that had SDK snippets but no parameters section.
- Normalized section heading style across comment pages and remaining post creation pages.
- Kept SDK snippets inside CodeGroup and preserved existing code examples.
- Regenerated llms-full.txt for the updated SDK docs content.

## Validation
- python3 .docs-ops/ci/check-mdx.py social-plus-sdk/social/content-management/comments social-plus-sdk/social/content-management/posts/creation
- python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk/social/content-management/comments social-plus-sdk/social/content-management/posts/creation
- python3 tools/check_internal_links.py social-plus-sdk/social/content-management/comments social-plus-sdk/social/content-management/posts/creation
- python3 .docs-ops/ci/check-mdx.py
- python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk
- go test ./... from llmstxt
- git diff --check