### PR TITLE
Normalize discovery and event SDK pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17813,11 +17813,7 @@ Community categories are read through the SDK and managed in the social.plus Con
 
 Categories can only be created and updated from the social.plus Console. SDK access is limited to reading existing categories.
 
-## Query Categories
-
-Use `getCategories()` to retrieve community categories. The SDK returns paginated/live collection results depending on the platform.
-
-### Parameters
+## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -17825,7 +17821,7 @@ Use `getCategories()` to retrieve community categories. The SDK returns paginate
 | `includeDeleted` | No | Include deleted categories in the result. |
 | `limit` / pagination token | No | Page-size and pagination controls where supported by the platform. |
 
-### Sort Options
+## Sort Options
 
 | Platform | Sort values |
 |----------|-------------|
@@ -17833,6 +17829,10 @@ Use `getCategories()` to retrieve community categories. The SDK returns paginate
 | iOS | `.displayName`, `.firstCreated`, `.lastCreated` |
 | Android | `AmityCommunityCategorySortOption.NAME`, `FIRST_CREATED`, `LAST_CREATED` |
 | Flutter | `AmityCommunityCategorySortOption.NAME`, `FIRST_CREATED`, `LAST_CREATED` |
+
+## Query Categories
+
+Use `getCategories()` to retrieve community categories. The SDK returns paginated/live collection results depending on the platform.
 
 ```swift iOS
 let liveCollection = communityRepository.getCategories(
@@ -25240,6 +25240,16 @@ Use `AmityFeedRepository` to read feed-style post collections. The SDK exposes u
 
 TypeScript still exports `queryGlobalFeed()`, but the SDK source marks it deprecated. Use the live collection APIs for new integrations.
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Query global feed | `dataTypes` | No | Filter the global feed to specific post content types where supported. |
+| Query global feed | `includeMixedStructure` | No | Include mixed-structure posts alongside the requested data type filters. |
+| Query custom-ranking global feed | `includeMixedStructure` | No | Include mixed-structure posts in the backend-ranked global feed response. |
+| TypeScript pagination | `limit`, `onNextPage`, `hasNextPage` | No | Control page size and load additional pages from the live collection callback. |
+| Android refresh | `invalidateCache` | No | Skip cached paging data for deliberate refresh flows. |
+
 ## Query Global Feed
 
 Global feed returns a paginated collection of posts for the current user's global feed surface. Use data type filters when your UI only needs a subset of post types, such as an image or video feed.
@@ -25472,9 +25482,9 @@ Use post search when users need to find content across accessible post targets. 
 
 The current public Flutter SDK source reviewed for this page does not expose semantic post search or hashtag post search repository methods.
 
-## Semantic Search Filters
+## Parameters
 
-| Filter | TypeScript | iOS | Android |
+| Parameter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
 | Query | `query` | `query` | `query` |
 | Target | `targetType`, `targetId` | `targetType`, `targetId` | `targetType`, `targetId` |
@@ -25564,6 +25574,16 @@ AmitySocialClient.newPostRepository()
 ```
 
 
+## Hashtag Search Filters
+
+| Parameter | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Hashtags | `hashtags` | `hashtags` | `hashtags` |
+| Target | `targetType` | Not exposed | Not exposed |
+| Data types | `dataTypes` | `dataTypes` | `dataTypes` |
+| Parent-only matching | `matchingOnlyParentPost` | `matchingOnlyParentPost` | Not exposed in the snippet surface |
+| Mixed structure | `includeMixedStructure` | `includeMixedStructure` | `includeMixedStructure` |
+
 ## Hashtag Search Posts
 
 Hashtag search finds posts that contain one or more hashtags. Pass hashtag names without the `#` prefix.
@@ -25647,6 +25667,12 @@ AmitySocialClient.newPostRepository()
 - For hashtag search, TypeScript requires a `targetType`; iOS and Android expose hashtag search without a target type parameter.
 - Search results are permission-aware from the backend response, but your UI should still handle empty results and authorization errors.
 
+## Related Topics
+
+    Query live post collections by target, type, review state, tags, and pagination options.
+    Query feed-style post collections for global, custom-ranking, user, and community feeds.
+    Review SDK search surfaces for community and post discovery.
+
 ---
 
 ### [Communities](https://learn.social.plus/social-plus-sdk/social/discovery-engagement/search/intelligent-search-community)
@@ -25655,9 +25681,9 @@ AmitySocialClient.newPostRepository()
 
 Use community semantic search when a discovery experience should match a user's intent instead of only exact community names. The client SDK sends a query and optional filters, then observes or receives a paginated set of `AmityCommunity` results.
 
-## Filters
+## Parameters
 
-| Filter | TypeScript | iOS | Android |
+| Parameter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
 | Query | `query` | `query` | `query` |
 | Category IDs | `categoryIds` | `categoryIds` | `categoryIds` |
@@ -25761,6 +25787,12 @@ AmitySocialClient.newCommunityRepository()
 - Use `includeDiscoverablePrivateCommunity` only when your product intentionally exposes discoverable private communities in search results.
 - Search results are returned as live or paginated collections depending on platform, so keep pagination and disposal logic close to the screen that owns the search.
 
+## Related Topics
+
+    Query and search communities by membership, category, tags, keyword, and sort order.
+    Retrieve categories used to organize community discovery.
+    Review SDK search surfaces for community and post discovery.
+
 ## Social — Notifications
 
 ### [Notification Tray Overview](https://learn.social.plus/social-plus-sdk/social/discovery-engagement/notifications/overview)
@@ -25821,6 +25853,15 @@ Tray seen status is a separate object with the latest tray occurrence timestamp,
 
 Notification tray items are paginated notification records for the signed-in user. Use this API to render an in-app notification tray and then mark individual items as seen when the user opens or views them.
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Query items | `limit` / pagination handle | No | TypeScript, iOS, Android | Page-size and pagination controls where supported by the platform. |
+| Mark item seen | Item ID | Yes | TypeScript | Notification item ID to pass into `markItemsSeen`. |
+| Mark item seen | `lastSeenAt` | Yes | TypeScript | ISO timestamp for when the item was seen. |
+| Mark item seen | Notification tray item object | Yes | iOS, Android | Item returned by the tray item query; call `markSeen()` on the object. |
+
 ## Query Items
 
 Query notification tray items for the signed-in user, keeping the pagination handle while the tray screen is active.
@@ -25879,7 +25920,7 @@ AmityCoreClient.notificationTray()
 ```
 
 
-## Mark An Item Seen
+## Mark an Item Seen
 
 Mark an individual notification item seen after the user opens or views that item.
 
@@ -25958,6 +25999,14 @@ Notification tray status tracks whether the signed-in user's tray has been seen 
 | Last tray seen timestamp | `lastTraySeenAt` | `lastTraySeenAt` | `getLastSeenAt()` |
 
 The current public Flutter SDK source reviewed for this page does not expose notification tray seen-status APIs.
+
+## Parameters
+
+| Operation | Input | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Observe tray seen status | Signed-in user session | Yes | TypeScript, iOS, Android | The SDK returns status for the current user; no explicit user ID is passed. |
+| Mark tray seen | Seen timestamp | Platform-dependent | TypeScript | Timestamp to store as the tray seen time. |
+| Mark tray seen | Current tray context | Yes | iOS, Android | Marks the signed-in user's tray seen without an explicit timestamp parameter. |
 
 ## Observe Tray Seen Status
 
@@ -26130,7 +26179,7 @@ Events are scheduled social objects with a title, description, type, start and e
 
 The SDK event surface is currently exposed in TypeScript, iOS, and Android. The public Flutter SDK source reviewed for this page does not expose scheduled event creation, query, management, or RSVP APIs.
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -26142,7 +26191,7 @@ The SDK event surface is currently exposed in TypeScript, iOS, and Android. The 
 | Delete event | `EventRepository.deleteEvent(eventId)` | `AmityEventRepository().deleteEvent(id:)` | `AmitySocialClient.newEventRepository().deleteEvent(eventId)` | Not exposed |
 | RSVP | `event.createRSVP(...)`, `event.updateRSVP(...)`, `event.getMyRSVP()`, `event.getRSVPs(...)` | Same methods on `AmityEvent` | Same methods on `AmityEvent` | Not exposed |
 
-## Event fields
+## Event Fields
 
 Core fields returned by the SDK include:
 
@@ -26159,7 +26208,7 @@ Core fields returned by the SDK include:
 | `rsvpCount`, `interestedCount` | Count fields returned with the event. |
 | `creator`, `targetCommunity`, `coverImage`, `post`, `room` | Linked objects are present when returned by the SDK payload/cache. Availability depends on platform and response payload. |
 
-## RSVP statuses
+## RSVP Statuses
 
 | Status | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -26167,7 +26216,7 @@ Core fields returned by the SDK include:
 | Interested | Not exposed by the current TypeScript enum reviewed for this page | `.interested` | `AmityEventResponseStatus.INTERESTED` |
 | Not going | `AmityEventResponseStatus.NotGoing` | `.notGoing` | `AmityEventResponseStatus.NOT_GOING` |
 
-## Common flow
+## Common Flow
 
 1. Create an event with a title, description, type, start time, end time, origin type, and origin ID.
 2. Query events by origin, status, type, user ID, attendee filter, sort option, and order option.
@@ -26177,7 +26226,7 @@ Core fields returned by the SDK include:
 
 This page documents SDK method names and data surfaces only. Product policy such as who can create, edit, RSVP, or view an event is enforced by backend permissions and should be handled by your app UI and error handling.
 
-## Event guides
+## Event Guides
 
     Create scheduled virtual or in-person events.
     Get, query, update, and delete event objects.
@@ -26208,7 +26257,7 @@ Flutter does not currently expose a public scheduled-event creation API in the S
 | `tags` | No | TypeScript, iOS, Android | Tags used for app-owned grouping or filtering. |
 | `metadata` / `timezone` | No | TypeScript, iOS, Android | Custom metadata. Android exposes timezone through `.timezone(...)`. |
 
-## Create an event
+## Create an Event
 
 Use the create method when your app has collected the required event fields and knows the target origin. The examples below create a virtual community event and return the created event object.
 
@@ -26277,14 +26326,14 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Platform notes
+## Platform Notes
 
 - TypeScript uses `AmityEventType.Virtual` and `AmityEventType.InPerson`.
 - iOS uses `.virtual` and `.inPerson`.
 - Android uses `AmityEventType.VIRTUAL` and `AmityEventType.IN_PERSON`.
 - Android requires `endTime(...)` before calling `build()`.
 
-## Related topics
+## Related Topics
 
     Get, query, update, and delete events.
     Create, update, read, and query RSVP responses.
@@ -26300,7 +26349,7 @@ Use event repository APIs to observe a single event, query event collections, up
 
 Flutter does not currently expose public scheduled-event management APIs in the SDK source reviewed for this page.
 
-## Method inputs
+## Parameters
 
 | Input | Methods | Platforms | Description |
 | --- | --- | --- | --- |
@@ -26312,7 +26361,7 @@ Flutter does not currently expose public scheduled-event management APIs in the 
 | `sortBy`, `orderBy` | Query | TypeScript, iOS, Android | Sort event lists by start time or creation time. |
 | Event fields | Update | TypeScript, iOS, Android | Mutable fields such as title, external URL, description, location, tags, and metadata. |
 
-## Get an event
+## Get an Event
 
 Use this method for event detail screens or any flow that needs the latest state of one event. TypeScript and iOS expose observable objects; Android returns the requested event through the repository.
 
@@ -26359,7 +26408,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Query events
+## Query Events
 
 Use event queries to build calendar lists, community event lists, and upcoming-event surfaces. Pass origin, status, type, sort, and order filters that match the list your UI needs.
 
@@ -26434,7 +26483,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Query my RSVP events
+## Query My RSVP Events
 
 Use this flow when the current screen should show events connected to a user's RSVP or attendance state. The SDKs expose this through event query filters rather than a separate event object method.
 
@@ -26490,7 +26539,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Update an event
+## Update an Event
 
 Use update when the current user can edit the event and your app has collected the changed fields. The examples update the title and virtual-event URL.
 
@@ -26529,7 +26578,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Delete an event
+## Delete an Event
 
 Use delete for event owner or moderator flows where removing the event is allowed by backend permissions. Handle errors in your UI because permission and lifecycle rules are enforced server-side.
 
@@ -26554,7 +26603,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Query filters
+## Query Filters
 
 | Filter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -26567,7 +26616,7 @@ AmitySocialClient.newEventRepository()
 
 TypeScript `deleteEvent` returns `void`. Android returns a `Completable`; iOS returns from an async throwing function when deletion completes.
 
-## Related topics
+## Related Topics
 
     Create scheduled virtual or in-person events.
     Work with RSVP responses on event objects.
@@ -26583,7 +26632,7 @@ RSVP methods are exposed on the `AmityEvent` object returned by the event reposi
 
 Flutter does not currently expose public scheduled-event RSVP APIs in the SDK source reviewed for this page.
 
-## Status values
+## Status Values
 
 | Meaning | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -26714,7 +26763,7 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Get my RSVP
+## Get My RSVP
 
 Get the active user's RSVP for an event when the UI needs to show the current response before offering update actions.
 
@@ -26841,11 +26890,11 @@ AmitySocialClient.newEventRepository()
     )
 ```
 
-## Response fields
+## Response Fields
 
 `AmityEventResponse` includes the event ID, user ID, status, linked user when available, creation time, update time, and the time the user responded. Android also exposes an RSVP ID through `getRsvpId()`.
 
-## Related topics
+## Related Topics
 
     Create the event before collecting RSVP responses.
     Get and query event objects before calling RSVP methods.

--- a/social-plus-sdk/social/communities-spaces/organization/community-categories.mdx
+++ b/social-plus-sdk/social/communities-spaces/organization/community-categories.mdx
@@ -9,11 +9,7 @@ Community categories are read through the SDK and managed in the social.plus Con
 Categories can only be created and updated from the social.plus Console. SDK access is limited to reading existing categories.
 </Callout>
 
-## Query Categories
-
-Use `getCategories()` to retrieve community categories. The SDK returns paginated/live collection results depending on the platform.
-
-### Parameters
+## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -21,7 +17,7 @@ Use `getCategories()` to retrieve community categories. The SDK returns paginate
 | `includeDeleted` | No | Include deleted categories in the result. |
 | `limit` / pagination token | No | Page-size and pagination controls where supported by the platform. |
 
-### Sort Options
+## Sort Options
 
 | Platform | Sort values |
 |----------|-------------|
@@ -29,6 +25,10 @@ Use `getCategories()` to retrieve community categories. The SDK returns paginate
 | iOS | `.displayName`, `.firstCreated`, `.lastCreated` |
 | Android | `AmityCommunityCategorySortOption.NAME`, `FIRST_CREATED`, `LAST_CREATED` |
 | Flutter | `AmityCommunityCategorySortOption.NAME`, `FIRST_CREATED`, `LAST_CREATED` |
+
+## Query Categories
+
+Use `getCategories()` to retrieve community categories. The SDK returns paginated/live collection results depending on the platform.
 
 <CodeGroup>
 ```swift iOS

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -18,6 +18,16 @@ Use `AmityFeedRepository` to read feed-style post collections. The SDK exposes u
 TypeScript still exports `queryGlobalFeed()`, but the SDK source marks it deprecated. Use the live collection APIs for new integrations.
 </Note>
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Query global feed | `dataTypes` | No | Filter the global feed to specific post content types where supported. |
+| Query global feed | `includeMixedStructure` | No | Include mixed-structure posts alongside the requested data type filters. |
+| Query custom-ranking global feed | `includeMixedStructure` | No | Include mixed-structure posts in the backend-ranked global feed response. |
+| TypeScript pagination | `limit`, `onNextPage`, `hasNextPage` | No | Control page size and load additional pages from the live collection callback. |
+| Android refresh | `invalidateCache` | No | Skip cached paging data for deliberate refresh flows. |
+
 ## Query Global Feed
 
 Global feed returns a paginated collection of posts for the current user's global feed surface. Use data type filters when your UI only needs a subset of post types, such as an image or video feed.

--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-items.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-items.mdx
@@ -5,6 +5,15 @@ description: "Query notification tray items and mark individual items as seen."
 
 Notification tray items are paginated notification records for the signed-in user. Use this API to render an in-app notification tray and then mark individual items as seen when the user opens or views them.
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Query items | `limit` / pagination handle | No | TypeScript, iOS, Android | Page-size and pagination controls where supported by the platform. |
+| Mark item seen | Item ID | Yes | TypeScript | Notification item ID to pass into `markItemsSeen`. |
+| Mark item seen | `lastSeenAt` | Yes | TypeScript | ISO timestamp for when the item was seen. |
+| Mark item seen | Notification tray item object | Yes | iOS, Android | Item returned by the tray item query; call `markSeen()` on the object. |
+
 ## Query Items
 
 Query notification tray items for the signed-in user, keeping the pagination handle while the tray screen is active.
@@ -65,7 +74,7 @@ AmityCoreClient.notificationTray()
 
 </CodeGroup>
 
-## Mark An Item Seen
+## Mark an Item Seen
 
 Mark an individual notification item seen after the user opens or views that item.
 

--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-tray-status.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-tray-status.mdx
@@ -17,6 +17,14 @@ Notification tray status tracks whether the signed-in user's tray has been seen 
 The current public Flutter SDK source reviewed for this page does not expose notification tray seen-status APIs.
 </Note>
 
+## Parameters
+
+| Operation | Input | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Observe tray seen status | Signed-in user session | Yes | TypeScript, iOS, Android | The SDK returns status for the current user; no explicit user ID is passed. |
+| Mark tray seen | Seen timestamp | Platform-dependent | TypeScript | Timestamp to store as the tray seen time. |
+| Mark tray seen | Current tray context | Yes | iOS, Android | Marks the signed-in user's tray seen without an explicit timestamp parameter. |
+
 ## Observe Tray Seen Status
 
 Observe tray seen status when your app needs a badge or "new notifications" indicator to stay current.

--- a/social-plus-sdk/social/discovery-engagement/search/intelligent-search-community.mdx
+++ b/social-plus-sdk/social/discovery-engagement/search/intelligent-search-community.mdx
@@ -5,9 +5,9 @@ description: "Search communities semantically with category, tag, membership, an
 
 Use community semantic search when a discovery experience should match a user's intent instead of only exact community names. The client SDK sends a query and optional filters, then observes or receives a paginated set of `AmityCommunity` results.
 
-## Filters
+## Parameters
 
-| Filter | TypeScript | iOS | Android |
+| Parameter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
 | Query | `query` | `query` | `query` |
 | Category IDs | `categoryIds` | `categoryIds` | `categoryIds` |
@@ -114,3 +114,17 @@ AmitySocialClient.newCommunityRepository()
 - Use category and tag filters when your discovery UI already knows the user's topic area.
 - Use `includeDiscoverablePrivateCommunity` only when your product intentionally exposes discoverable private communities in search results.
 - Search results are returned as live or paginated collections depending on platform, so keep pagination and disposal logic close to the screen that owns the search.
+
+## Related Topics
+
+<CardGroup cols={3}>
+  <Card title="Query Communities" href="../../communities-spaces/discovery/query-communities" icon="magnifying-glass">
+    Query and search communities by membership, category, tags, keyword, and sort order.
+  </Card>
+  <Card title="Community Categories" href="../../communities-spaces/organization/community-categories" icon="folder">
+    Retrieve categories used to organize community discovery.
+  </Card>
+  <Card title="Search Overview" href="./overview" icon="sparkles">
+    Review SDK search surfaces for community and post discovery.
+  </Card>
+</CardGroup>

--- a/social-plus-sdk/social/discovery-engagement/search/intelligent-search-post.mdx
+++ b/social-plus-sdk/social/discovery-engagement/search/intelligent-search-post.mdx
@@ -9,9 +9,9 @@ Use post search when users need to find content across accessible post targets. 
 The current public Flutter SDK source reviewed for this page does not expose semantic post search or hashtag post search repository methods.
 </Note>
 
-## Semantic Search Filters
+## Parameters
 
-| Filter | TypeScript | iOS | Android |
+| Parameter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
 | Query | `query` | `query` | `query` |
 | Target | `targetType`, `targetId` | `targetType`, `targetId` | `targetType`, `targetId` |
@@ -103,6 +103,16 @@ AmitySocialClient.newPostRepository()
 
 </CodeGroup>
 
+## Hashtag Search Filters
+
+| Parameter | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Hashtags | `hashtags` | `hashtags` | `hashtags` |
+| Target | `targetType` | Not exposed | Not exposed |
+| Data types | `dataTypes` | `dataTypes` | `dataTypes` |
+| Parent-only matching | `matchingOnlyParentPost` | `matchingOnlyParentPost` | Not exposed in the snippet surface |
+| Mixed structure | `includeMixedStructure` | `includeMixedStructure` | `includeMixedStructure` |
+
 ## Hashtag Search Posts
 
 Hashtag search finds posts that contain one or more hashtags. Pass hashtag names without the `#` prefix.
@@ -187,3 +197,17 @@ AmitySocialClient.newPostRepository()
 - Use parent-only matching when the UI should show top-level posts instead of child posts from mixed or threaded structures.
 - For hashtag search, TypeScript requires a `targetType`; iOS and Android expose hashtag search without a target type parameter.
 - Search results are permission-aware from the backend response, but your UI should still handle empty results and authorization errors.
+
+## Related Topics
+
+<CardGroup cols={3}>
+  <Card title="Query Posts" href="../../content-management/posts/retrieval/query-posts" icon="newspaper">
+    Query live post collections by target, type, review state, tags, and pagination options.
+  </Card>
+  <Card title="Feeds and Timelines" href="../feed/overview" icon="rss">
+    Query feed-style post collections for global, custom-ranking, user, and community feeds.
+  </Card>
+  <Card title="Search Overview" href="./overview" icon="sparkles">
+    Review SDK search surfaces for community and post discovery.
+  </Card>
+</CardGroup>

--- a/social-plus-sdk/social/events/create-event.mdx
+++ b/social-plus-sdk/social/events/create-event.mdx
@@ -24,7 +24,7 @@ Flutter does not currently expose a public scheduled-event creation API in the S
 | `tags` | No | TypeScript, iOS, Android | Tags used for app-owned grouping or filtering. |
 | `metadata` / `timezone` | No | TypeScript, iOS, Android | Custom metadata. Android exposes timezone through `.timezone(...)`. |
 
-## Create an event
+## Create an Event
 
 Use the create method when your app has collected the required event fields and knows the target origin. The examples below create a virtual community event and return the created event object.
 
@@ -95,14 +95,14 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Platform notes
+## Platform Notes
 
 - TypeScript uses `AmityEventType.Virtual` and `AmityEventType.InPerson`.
 - iOS uses `.virtual` and `.inPerson`.
 - Android uses `AmityEventType.VIRTUAL` and `AmityEventType.IN_PERSON`.
 - Android requires `endTime(...)` before calling `build()`.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Manage Events" href="./manage-events" icon="calendar-days">

--- a/social-plus-sdk/social/events/event-rsvp.mdx
+++ b/social-plus-sdk/social/events/event-rsvp.mdx
@@ -9,7 +9,7 @@ RSVP methods are exposed on the `AmityEvent` object returned by the event reposi
 Flutter does not currently expose public scheduled-event RSVP APIs in the SDK source reviewed for this page.
 </Info>
 
-## Status values
+## Status Values
 
 | Meaning | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -144,7 +144,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Get my RSVP
+## Get My RSVP
 
 Get the active user's RSVP for an event when the UI needs to show the current response before offering update actions.
 
@@ -275,11 +275,11 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Response fields
+## Response Fields
 
 `AmityEventResponse` includes the event ID, user ID, status, linked user when available, creation time, update time, and the time the user responded. Android also exposes an RSVP ID through `getRsvpId()`.
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Create Event" href="./create-event" icon="calendar-plus">

--- a/social-plus-sdk/social/events/manage-events.mdx
+++ b/social-plus-sdk/social/events/manage-events.mdx
@@ -9,7 +9,7 @@ Use event repository APIs to observe a single event, query event collections, up
 Flutter does not currently expose public scheduled-event management APIs in the SDK source reviewed for this page.
 </Info>
 
-## Method inputs
+## Parameters
 
 | Input | Methods | Platforms | Description |
 | --- | --- | --- | --- |
@@ -21,7 +21,7 @@ Flutter does not currently expose public scheduled-event management APIs in the 
 | `sortBy`, `orderBy` | Query | TypeScript, iOS, Android | Sort event lists by start time or creation time. |
 | Event fields | Update | TypeScript, iOS, Android | Mutable fields such as title, external URL, description, location, tags, and metadata. |
 
-## Get an event
+## Get an Event
 
 Use this method for event detail screens or any flow that needs the latest state of one event. TypeScript and iOS expose observable objects; Android returns the requested event through the repository.
 
@@ -70,7 +70,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Query events
+## Query Events
 
 Use event queries to build calendar lists, community event lists, and upcoming-event surfaces. Pass origin, status, type, sort, and order filters that match the list your UI needs.
 
@@ -147,7 +147,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Query my RSVP events
+## Query My RSVP Events
 
 Use this flow when the current screen should show events connected to a user's RSVP or attendance state. The SDKs expose this through event query filters rather than a separate event object method.
 
@@ -205,7 +205,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Update an event
+## Update an Event
 
 Use update when the current user can edit the event and your app has collected the changed fields. The examples update the title and virtual-event URL.
 
@@ -246,7 +246,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Delete an event
+## Delete an Event
 
 Use delete for event owner or moderator flows where removing the event is allowed by backend permissions. Handle errors in your UI because permission and lifecycle rules are enforced server-side.
 
@@ -273,7 +273,7 @@ AmitySocialClient.newEventRepository()
 ```
 </CodeGroup>
 
-## Query filters
+## Query Filters
 
 | Filter | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -288,7 +288,7 @@ AmitySocialClient.newEventRepository()
 TypeScript `deleteEvent` returns `void`. Android returns a `Completable`; iOS returns from an async throwing function when deletion completes.
 </Note>
 
-## Related topics
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Create Event" href="./create-event" icon="calendar-plus">

--- a/social-plus-sdk/social/events/overview.mdx
+++ b/social-plus-sdk/social/events/overview.mdx
@@ -7,7 +7,7 @@ Events are scheduled social objects with a title, description, type, start and e
 
 The SDK event surface is currently exposed in TypeScript, iOS, and Android. The public Flutter SDK source reviewed for this page does not expose scheduled event creation, query, management, or RSVP APIs.
 
-## Platform coverage
+## Platform Coverage
 
 | Capability | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -19,7 +19,7 @@ The SDK event surface is currently exposed in TypeScript, iOS, and Android. The 
 | Delete event | `EventRepository.deleteEvent(eventId)` | `AmityEventRepository().deleteEvent(id:)` | `AmitySocialClient.newEventRepository().deleteEvent(eventId)` | Not exposed |
 | RSVP | `event.createRSVP(...)`, `event.updateRSVP(...)`, `event.getMyRSVP()`, `event.getRSVPs(...)` | Same methods on `AmityEvent` | Same methods on `AmityEvent` | Not exposed |
 
-## Event fields
+## Event Fields
 
 Core fields returned by the SDK include:
 
@@ -36,7 +36,7 @@ Core fields returned by the SDK include:
 | `rsvpCount`, `interestedCount` | Count fields returned with the event. |
 | `creator`, `targetCommunity`, `coverImage`, `post`, `room` | Linked objects are present when returned by the SDK payload/cache. Availability depends on platform and response payload. |
 
-## RSVP statuses
+## RSVP Statuses
 
 | Status | TypeScript | iOS | Android |
 | --- | --- | --- | --- |
@@ -44,7 +44,7 @@ Core fields returned by the SDK include:
 | Interested | Not exposed by the current TypeScript enum reviewed for this page | `.interested` | `AmityEventResponseStatus.INTERESTED` |
 | Not going | `AmityEventResponseStatus.NotGoing` | `.notGoing` | `AmityEventResponseStatus.NOT_GOING` |
 
-## Common flow
+## Common Flow
 
 1. Create an event with a title, description, type, start time, end time, origin type, and origin ID.
 2. Query events by origin, status, type, user ID, attendee filter, sort option, and order option.
@@ -56,7 +56,7 @@ Core fields returned by the SDK include:
 This page documents SDK method names and data surfaces only. Product policy such as who can create, edit, RSVP, or view an event is enforced by backend permissions and should be handled by your app UI and error handling.
 </Note>
 
-## Event guides
+## Event Guides
 
 <CardGroup cols={3}>
   <Card title="Create Event" href="./create-event" icon="calendar-plus">


### PR DESCRIPTION
## Summary
- Move discovery/event SDK pages toward the shared structure with page-level Parameters sections where snippets need them
- Normalize event page heading casing across overview, create, manage, and RSVP pages
- Add related-topic card groups to intelligent search pages and refresh llms-full.txt

## Validation
- python3 .docs-ops/ci/check-mdx.py social-plus-sdk
- python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk
- python3 tools/check_internal_links.py social-plus-sdk
- go test ./... (in llmstxt)
- git diff --check