### PR TITLE
Normalize core and video SDK pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2777,11 +2777,11 @@ This architecture gives you the flexibility to build social features while maint
 
 social.plus SDK does not replace your identity system or require personal identifiers such as email addresses. Each user is represented by a `userId` (a string you supply from your own system) that remains immutable for the lifetime of the account. The SDK does store the social profile fields you send to it, such as display name, description, avatar, metadata, roles, and moderation state, so avoid putting sensitive personal data in those fields.
 
-## Core principles
+## Core Principles
 
 **You Own Identity Data**: Keep your source-of-truth user account, login credentials, email address, and private profile data in your own system. Send social.plus only the stable `userId` and optional social profile fields needed by social features.
 
-### Key benefits
+### Key Benefits
 
 Your users' data stays in your systems, ensuring privacy and compliance
 
@@ -2789,11 +2789,11 @@ Integrate social.plus without migrating your primary user accounts
 
 Handle authentication and private user data with your existing application logic and systems
 
-## User identification
+## User Identification
 
 Every user in social.plus is represented by a unique `userId` - a string that uniquely identifies the user and remains immutable throughout their lifetime.
 
-### Choosing the right user ID
+### Choosing the Right User ID
 
 **Database Primary Keys**
 ```
@@ -2828,11 +2828,11 @@ userId: "john_doe"              // Display name can change
 
 **Important**: Once a user is created in social.plus, their `userId` cannot be changed. Choose your user identification strategy carefully.
 
-## User data structure
+## User Data Structure
 
 While social.plus doesn't store personal data, it maintains essential information for social features:
 
-### User attributes
+### User Attributes
 
 <div className="overflow-x-auto">
 <table>
@@ -2903,13 +2903,13 @@ While social.plus doesn't store personal data, it maintains essential informatio
 </table>
 </div>
 
-## User roles & permissions
+## User Roles and Permissions
 
 Enhance user capabilities by assigning roles with specific permissions defined in your admin panel.
 
 **Role-Based Access Control**: social.plus uses a comprehensive permission system that allows you to create hierarchical moderation structures and fine-grained access control.
 
-### Quick overview
+### Quick Overview
 
 **Built-in Role Hierarchy**
 Member → Channel Moderator → Community Moderator → Super Moderator → Global Admin
@@ -2917,11 +2917,11 @@ Member → Channel Moderator → Community Moderator → Super Moderator → Glo
 **Flexible Permissions**
 Create custom roles with specific permissions in the social.plus Console
 
-## User repository
+## User Repository
 
 While social.plus doesn't store user profiles, it provides tools for querying and searching users within your social features.
 
-### Initializing user repository
+### Initializing the User Repository
 
 Initialize the user repository before querying or searching users from SDK-powered social surfaces.
 
@@ -2945,7 +2945,7 @@ void initUserRepository() {
 }
 ```
 
-## Best practices
+## Best Practices
 
 **Do:**
 - Use database primary keys
@@ -3015,6 +3015,16 @@ Specific actions users can perform (edit, delete, ban, etc.)
 
 **Structured Access**
 Roles have different levels of access and moderation privileges
+
+## Parameters
+
+| Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- |
+| Permission constant | Yes | TypeScript, iOS, Android, Flutter | Permission value to check, such as delete-message, ban-user, or edit-community-post permissions. |
+| Scope selector | Context-dependent | TypeScript, iOS, Android, Flutter | Channel, community, or other supported scope where the permission should be evaluated. |
+| `channelId` | For channel-scoped permissions | TypeScript, iOS, Android, Flutter | Channel ID used when checking channel moderation permissions. |
+| `communityId` | For community-scoped permissions | TypeScript, iOS, Android | Community ID used when checking community moderation permissions. |
+| Result | Yes | TypeScript, iOS, Android, Flutter | Boolean-style result that tells the UI whether to show or hide the protected action. |
 
 ## Permission Checking
 
@@ -3921,15 +3931,17 @@ Retrieve user information using the UserRepository to display profiles, user car
 
 **Live Objects**: User data is returned as Live Objects that automatically update when the underlying data changes, keeping your UI synchronized.
 
-## Common Inputs
+## Parameters
 
-| Input | Description |
-| --- | --- |
-| `userId` | Unique identifier of the user to retrieve. |
-| User repository | Platform-specific user repository or client method used to query user data. |
-| Observer or callback | Receives live object or live collection updates where supported. |
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get a single user | `userId` | Yes | Unique identifier of the user to retrieve. |
+| Get multiple users by ID | `userIds` | Yes | User IDs to retrieve in one batch where the platform exposes a batch API. |
+| Query users | Sort option | No | Sort order for user collections, such as display name or creation time where supported. |
+| Query users | Pagination handle | No | Platform-specific live collection, paging data, or callback controls used to load additional users. |
+| All operations | Observer or callback | Platform-dependent | Receives live object or live collection updates where supported. |
 
-## Get A Single User
+## Get a Single User
 
 Retrieve a specific user by their unique ID:
 
@@ -4379,14 +4391,16 @@ Use the user repository to find users by display name, or query the full user li
 
 Deleted users are automatically excluded from all search and query results to maintain data integrity.
 
-## Search And Query Options
+## Parameters
 
-| Operation | Use when | SDK notes |
-| --- | --- | --- |
-| Search users | You need to find users by display name keyword. | iOS and Android use `searchUsers`; TypeScript and Flutter use `searchUserByDisplayName`. |
-| Query users | You need to retrieve a user collection with sorting and pagination. | Sort options vary by SDK. |
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Search users | Display-name keyword | Yes | TypeScript, iOS, Android, Flutter | Search term for user display names. Search keywords must be at least 3 characters long. |
+| Search users | Sort option | No | TypeScript, iOS | Display-name sorting for search results where supported. |
+| Query users | Sort option | No | TypeScript, iOS, Android, Flutter | Sort user collections by display name or creation time where supported. |
+| Search or query users | Pagination handle | No | TypeScript, iOS, Android, Flutter | Platform-specific live collection, paging data, or callback controls used to load more users. |
 
-## Search Users By Display Name
+## Search Users by Display Name
 
 Query for users by their display name, receiving a collection of AmityUser matching your search. It requires two parameters: the display name you're searching for, and a 'sort option' from the AmityUserSortOption enum.
 
@@ -4622,7 +4636,17 @@ Flagging a user helps moderators identify potential issues without immediately t
 | Unflag user | Remove the current user's flag from a user. |
 | Check flag status | Check whether the current user has flagged a specific user. |
 
-## Flag A User
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Flag user | `userId` | Yes | TypeScript, iOS, Android | User ID to flag. |
+| Flag user | `AmityUser` object | Yes | Flutter | User object whose `report().flag()` method is called. |
+| Unflag user | `userId` | Yes | TypeScript, iOS, Android | User ID whose flag should be removed for the current user. |
+| Unflag user | `AmityUser` object | Yes | Flutter | User object whose `report().unflag()` method is called. |
+| Check flag status | `userId` / `AmityUser` | Yes | TypeScript, iOS, Android, Flutter | User to check against the current user's flag state. |
+
+## Flag a User
 
 To flag a user, call the following method:
 
@@ -4665,7 +4689,7 @@ void flagUser(AmityUser user) {
 }
 ```
 
-## Unflag A User
+## Unflag a User
 
 To unflag a user, call the following method:
 
@@ -4708,7 +4732,7 @@ void unflagUser(AmityUser user) {
 }
 ```
 
-## Check Whether The Current User Flagged A User
+## Check Whether the Current User Flagged a User
 
 To check whether a user has been flagged by the current user:
 
@@ -6612,7 +6636,7 @@ flowchart LR
     D --> E["Unsubscribe when no longer needed"]
 ```
 
-## When To Subscribe
+## When to Subscribe
 
 | UI need | Recommended topic |
 | --- | --- |
@@ -7908,6 +7932,15 @@ Use SDK logging and error surfaces while you build and debug an integration. Kee
 
 Use the network observer as a development diagnostic tool. It can expose request metadata, response metadata, and payloads depending on platform, so avoid storing raw logs that may contain user content or credentials.
 
+## Parameters
+
+| Platform | Callback or stream value | Notes |
+| --- | --- | --- |
+| TypeScript | `request`, `response` | `response` includes `data`, `status`, `statusText`, and `headers`. The API returns an unsubscriber. |
+| iOS | `URLRequest?`, `HTTPURLResponse?`, `Data?` | Pass `nil` to `observeNetworkActivities` when logging should stop. |
+| Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
+| Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
+
 ## Network Activity
 
 Observe network activity only while debugging an integration, then unsubscribe or dispose the observer when the debug session ends.
@@ -7958,15 +7991,6 @@ val disposable = AmityCoreClient.observeNetworkActivities()
 // Stop observing when the debug session ends.
 disposable.dispose()
 ```
-
-### Observer Parameters
-
-| Platform | Callback or stream value | Notes |
-| --- | --- | --- |
-| TypeScript | `request`, `response` | `response` includes `data`, `status`, `statusText`, and `headers`. The API returns an unsubscriber. |
-| iOS | `URLRequest?`, `HTTPURLResponse?`, `Data?` | Pass `nil` to `observeNetworkActivities` when logging should stop. |
-| Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
-| Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
 
 ## Error Handling
 
@@ -8024,7 +8048,7 @@ if (error is AmityException) {
 }
 ```
 
-### Common SDK Error Constants
+## Common SDK Error Constants
 
 | Meaning | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |
@@ -8090,7 +8114,14 @@ The current native SDK helpers define dedicated categories for these values.
 
 Handle unknown categories deliberately. The server can introduce category strings before every client UI has a named enum case.
 
-## Read And Redact
+## Parameters
+
+| Parameter | iOS type | Android type | Default | Behavior |
+| --- | --- | --- | --- | --- |
+| `piiCategories` | `[AmityPIICategory]` | `List<AmityPII.Category>` | Empty list | Empty means redact every detected category. Provide categories to redact only selected types. |
+| `replaceChar` | `Character` | `Char` | `*` | Character used to replace each redacted character. |
+
+## Read and Redact
 
 Use `getPIIData()` when you need entity metadata for moderation UI, highlighting, or audit views. Use `redactedText(...)` when the app should display masked text.
 
@@ -8161,13 +8192,6 @@ val redactedMessage = (message?.getData() as? AmityMessage.Data.TEXT)
 
 print(redactedText + redactedComment + redactedMessage)
 ```
-
-### Redaction Parameters
-
-| Parameter | iOS type | Android type | Default | Behavior |
-| --- | --- | --- | --- | --- |
-| `piiCategories` | `[AmityPIICategory]` | `List<AmityPII.Category>` | Empty list | Empty means redact every detected category. Provide categories to redact only selected types. |
-| `replaceChar` | `Character` | `Char` | `*` | Character used to replace each redacted character. |
 
 ## Behavior Notes
 
@@ -9266,6 +9290,16 @@ Use room APIs for new livestream and co-host experiences. Legacy Stream APIs sti
 | Stream watcher URL / recordings | Room live and recorded playback fields | Pass SDK-returned room playback URLs to your app-owned player. |
 | Stream session analytics | Room watch-session analytics | Use `room.analytics()` for new room watch sessions. |
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Observe room content | `roomId` | Yes | TypeScript, iOS, Android | Room ID used when replacing new Stream observation flows with room observation. |
+| Create room | Room options | Yes | TypeScript, iOS, Android | Room title and configuration passed to the room repository. |
+| Publish room post | `communityId` or target ID | Yes | TypeScript, iOS, Android | Feed target where the room post should be published. |
+| Publish room post | `roomId` | Yes | TypeScript, iOS, Android | Room ID returned by room creation and embedded in the room post. |
+| Publish room post | Text or title fields | No | TypeScript, iOS, Android | Display text used by the feed post that references the room. |
+
 ## Observe Room Content
 
 Replace new Stream observation flows with room observation for new room-based screens. Each snippet below is standalone and uses the current room repository surface.
@@ -9607,7 +9641,7 @@ Create a room before you publish it to a feed or connect a broadcaster. Room cre
 | `participants` | No | iOS, Android | Initial participant user IDs. TypeScript room creation does not expose this field. |
 | `type` | No | TypeScript, iOS | Room type such as `coHosts` / `.coHosts` or `directStreaming` / `.directStreaming`. Android creation does not expose a type argument. |
 
-## Create a room
+## Create a Room
 
 Create a room with the title and configuration your product needs before publishing it or connecting a broadcaster.
 
@@ -9665,7 +9699,7 @@ showSuccessMessage(room.roomId)
 ```
 
 
-## Create with thumbnail or parent room
+## Create with Thumbnail or Parent Room
 
 Use `thumbnailFileId` after uploading an image through the file APIs. Use `parentRoomId` only when your product intentionally creates a room hierarchy.
 
@@ -9712,7 +9746,7 @@ showSuccessMessage(childRoom.roomId)
 ```
 
 
-## Get broadcaster data
+## Get Broadcaster Data
 
 After creating the room, request broadcaster credentials before connecting the media layer. TypeScript and Android expose broadcaster-data APIs. iOS exposes room token generation.
 
@@ -9800,6 +9834,25 @@ Starting a broadcast has two parts: the social.plus SDK returns room broadcaster
 | iOS | `AmityRoomRepository().generateRoomToken(withId:)` | `AmityRoomRepository().getRoom(withId:)` live object | `AmityRoomRepository().stopRoom(withId:)` | Token response is a dictionary from `/api/v1/rooms/{roomId}/token`; read known keys defensively. |
 | Android | `AmityVideoClient.newRoomRepository().getBroadcasterData(roomId)` | `getRoom(roomId)` plus room topic subscription when real-time updates are needed | `stopRoom(roomId)` | Returns `AmityRoomBroadcastData.CoHosts` or `AmityRoomBroadcastData.DirectStreaming`. |
 | Flutter | No current public room broadcaster API found in this audit | Not available | Not available | The Flutter SDK source exposes older stream read APIs, not the room broadcasting repository. |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android | Notes |
+| --- | --- | --- | --- | --- |
+| Fetch credentials | `getBroadcasterData(roomId)` | `generateRoomToken(withId:)` | `getBroadcasterData(roomId)` | Requires an existing room ID. |
+| Co-host URL | `coHostUrl?: string` | `tokenPayload["coHostUrl"]` | `AmityRoomBroadcastData.CoHosts.getCoHostUrl()` | Use as the media connection URL for co-host rooms. |
+| Co-host token | `coHostToken?: string` | `tokenPayload["coHostToken"]` | `AmityRoomBroadcastData.CoHosts.getCoHostToken()` | Use as the media access token for co-host rooms. |
+| Direct stream URL | `directStreamUrl?: string` | `tokenPayload["directStreamUrl"]` | `AmityRoomBroadcastData.DirectStreaming.getDirectStreamUrl()` | Use only for direct-streaming publisher flows. |
+| Flutter room broadcasting | Not applicable | Not applicable | Not applicable | No current public Flutter room broadcaster API found in this audit. |
+
+### Lifecycle Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Start event | `onRoomStartBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
+| End event | `onRoomEndBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
+| Stop room | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
+| Cleanup | Call returned `Amity.Unsubscriber` functions | Retain and release the `AmityNotificationToken` with the screen lifecycle | Dispose Rx subscriptions and unsubscribe room topics when no longer needed |
 
 ## Get Broadcaster Data
 
@@ -10061,25 +10114,6 @@ showSuccessMessage(stoppedRoom.status.rawValue)
 
   Stopping a room ends the current broadcast session. Do not build a "restart the same room" flow unless your product and backend contract explicitly support it.
 
-## Credential Parameters
-
-| Concept | TypeScript | iOS | Android | Notes |
-| --- | --- | --- | --- | --- |
-| Fetch credentials | `getBroadcasterData(roomId)` | `generateRoomToken(withId:)` | `getBroadcasterData(roomId)` | Requires an existing room ID. |
-| Co-host URL | `coHostUrl?: string` | `tokenPayload["coHostUrl"]` | `AmityRoomBroadcastData.CoHosts.getCoHostUrl()` | Use as the media connection URL for co-host rooms. |
-| Co-host token | `coHostToken?: string` | `tokenPayload["coHostToken"]` | `AmityRoomBroadcastData.CoHosts.getCoHostToken()` | Use as the media access token for co-host rooms. |
-| Direct stream URL | `directStreamUrl?: string` | `tokenPayload["directStreamUrl"]` | `AmityRoomBroadcastData.DirectStreaming.getDirectStreamUrl()` | Use only for direct-streaming publisher flows. |
-| Flutter room broadcasting | Not applicable | Not applicable | Not applicable | No current public Flutter room broadcaster API found in this audit. |
-
-## Lifecycle Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Start event | `onRoomStartBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
-| End event | `onRoomEndBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
-| Stop room | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
-| Cleanup | Call returned `Amity.Unsubscriber` functions | Retain and release the `AmityNotificationToken` with the screen lifecycle | Dispose Rx subscriptions and unsubscribe room topics when no longer needed |
-
 ## Media Boundary
 
 | Area | Owned by social.plus SDK | Owned by your app/media stack |
@@ -10113,6 +10147,17 @@ Live room viewing starts from a room ID or a room post. The social.plus SDK owns
 | iOS | `AmityPostRepository().getLiveRoomPosts()`, `getCommunityLiveRoomPosts(withIds:)` | `AmityRoomRepository().getRoom(withId:)` | `room.livePlaybackUrl` | `room.recordedData[]` |
 | Android | `AmityPostRepository.getLiveRoomPosts()`, `getCommunityLiveRoomPosts(...)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `room.getLivePlaybackUrl()` | `room.getRecordedPlaybackInfos()` |
 | Flutter | No current public room viewing API found in this audit | Not available | Not available | Not available |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Live room post collection | `getLiveRoomPosts(callback)` | `getLiveRoomPosts()` | `getLiveRoomPosts()` |
+| Community live room posts | `getCommunityLiveRoomPosts({ communityIds })` | `getCommunityLiveRoomPosts(withIds:)` | `getCommunityLiveRoomPosts(communityIds)` |
+| Room ID in post data | `post.data.roomId` when `dataType === "room"` | `post.data?["roomId"]` when `dataType == "room"` | `AmityPost.Data.ROOM.getRoomId()` |
+| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
+| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
+| Recorded URL | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
 
 ## Find Live Room Posts
 
@@ -10316,17 +10361,6 @@ func playbackSource(for room: AmityRoom) -> String? {
 ```
 
 
-## Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Live room post collection | `getLiveRoomPosts(callback)` | `getLiveRoomPosts()` | `getLiveRoomPosts()` |
-| Community live room posts | `getCommunityLiveRoomPosts({ communityIds })` | `getCommunityLiveRoomPosts(withIds:)` | `getCommunityLiveRoomPosts(communityIds)` |
-| Room ID in post data | `post.data.roomId` when `dataType === "room"` | `post.data?["roomId"]` when `dataType == "room"` | `AmityPost.Data.ROOM.getRoomId()` |
-| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
-| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
-| Recorded URL | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
-
 ## Status Handling
 
 | Status | Viewer behavior |
@@ -10373,6 +10407,33 @@ Manage rooms after creation by observing a single room, querying room lists, upd
 | iOS | `AmityRoomRepository().getRoom(withId:)` | `AmityRoomRepository().getRooms(with:)` | `updateRoom(withId:options:)`, `stopRoom(withId:)`, `deleteRoom(withId:)` | Retain the returned `AmityNotificationToken` while observing. |
 | Android | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `AmityVideoClient.newRoomRepository().getRooms().build().query()` | `updateRoom()`, `stopRoom()`, `deleteRoom()` | Single rooms are `Flowable<AmityRoom>`; room lists are `Flowable<PagingData<AmityRoom>>`. |
 | Flutter | No current public room repository found in this audit | Not available | Not available | The Flutter SDK source exposes older stream APIs, not the room broadcasting repository. |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Status filter | `statuses?: Amity.RoomStatus[]` | `statuses: [AmityRoomStatus]?` | `setStatuses(Array<AmityRoomStatus>)` |
+| Room type filter | `type?: Amity.RoomType` | `type: AmityRoomType?` | `setTypes(Array<AmityRoomType>)` |
+| Deleted rooms | `includeDeleted?: boolean` | `isDeleted: Bool` | `setIsDeleted(Boolean?)` |
+| Sort order | `sortBy?: "firstCreated"` or `"lastCreated"` | `sortBy: AmityRoomSortOption` | `setSortBy(AmityRoomSortOption?)` |
+| Page size | `limit?: number` | Not exposed on `AmityRoomQueryOptions` | Paging 3 controls consumption after `PagingData` emission |
+
+### Mutation Parameters
+
+| Operation | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Update | `updateRoom(roomId, bundle)` | `updateRoom(withId:options:)` | `updateRoom(roomId, ...)` |
+| Stop | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
+| Delete | `deleteRoom(roomId)` | `deleteRoom(withId:)` | `deleteRoom(roomId)` |
+
+| Update field | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Title | `title` | `title` | `title` |
+| Description | `description` | `description` | `description` |
+| Thumbnail | `thumbnailFileId` | `thumbnailFileId` | `thumbnailFileId` |
+| Metadata | `metadata` | `metadata` | `metadata` |
+| Live chat flag | `liveChatEnabled` | `channelEnabled` | `liveChatEnabled` |
+| Parent room | `parentRoomId` | Not exposed by update options | Not exposed by update API |
 
 ## Get a Room
 
@@ -10503,16 +10564,6 @@ roomCollectionToken = rooms.observe { collection, error in
 ```
 
 
-## Query Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Status filter | `statuses?: Amity.RoomStatus[]` | `statuses: [AmityRoomStatus]?` | `setStatuses(Array<AmityRoomStatus>)` |
-| Room type filter | `type?: Amity.RoomType` | `type: AmityRoomType?` | `setTypes(Array<AmityRoomType>)` |
-| Deleted rooms | `includeDeleted?: boolean` | `isDeleted: Bool` | `setIsDeleted(Boolean?)` |
-| Sort order | `sortBy?: "firstCreated"` or `"lastCreated"` | `sortBy: AmityRoomSortOption` | `setSortBy(AmityRoomSortOption?)` |
-| Page size | `limit?: number` | Not exposed on `AmityRoomQueryOptions` | Paging 3 controls consumption after `PagingData` emission |
-
   TypeScript filters by a single `type` value. Android's builder accepts `setTypes(...)` because the Android query model supports an array of room types.
 
 ## Update a Room
@@ -10616,23 +10667,6 @@ showSuccessMessage(roomId)
 
   Stopping a room ends the current broadcast session. Do not document or build a "restart same room" flow unless your product and backend contract explicitly support it.
 
-## Mutation Parameters
-
-| Operation | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Update | `updateRoom(roomId, bundle)` | `updateRoom(withId:options:)` | `updateRoom(roomId, ...)` |
-| Stop | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
-| Delete | `deleteRoom(roomId)` | `deleteRoom(withId:)` | `deleteRoom(roomId)` |
-
-| Update field | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Title | `title` | `title` | `title` |
-| Description | `description` | `description` | `description` |
-| Thumbnail | `thumbnailFileId` | `thumbnailFileId` | `thumbnailFileId` |
-| Metadata | `metadata` | `metadata` | `metadata` |
-| Live chat flag | `liveChatEnabled` | `channelEnabled` | `liveChatEnabled` |
-| Parent room | `parentRoomId` | Not exposed by update options | Not exposed by update API |
-
 ## Recorded Playback Boundary
 
 Recorded playback is intentionally separate from room lifecycle management:
@@ -10667,6 +10701,31 @@ Co-host management is built on room invitations, room participant events, and ro
 | iOS | `AmityRoom.createInvitation(_:)` | `room.getInvitation()`, `invitation.accept()`, `invitation.reject()`, `room.cancelInvitation(_:)` | `AmityRoomRepository().getCoHostEvent(roomId:)` | `updateCohostPermissions(...)`, `removeParticipant(withId:userId:)`, `leaveRoom(withId:)` |
 | Android | `AmityRoom.createInvitation(userId)` | `room.getInvitation()`, `invitation.accept()`, `invitation.reject()`, `invitation.cancel()` | `AmityVideoClient.newRoomRepository().getCoHostEvent(roomId)` | `updateCohostPermission(...)`, `removeRoomParticipant(...)`, `leaveRoom(...)` |
 | Flutter | No current public room repository found in this audit | Not available | Not available | Not available |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Invite one user | `room.createInvitation(userId)` | `room.createInvitation(userId)` | `room.createInvitation(userId)` |
+| Current user's pending room invitation | `room.getInvitations()` | `room.getInvitation()` | `room.getInvitation()` |
+| Accept | `invitation.accept()` | `invitation.accept()` | `invitation.accept()` |
+| Reject | `invitation.reject()` | `invitation.reject()` | `invitation.reject()` |
+| Cancel | `InvitationRepository.cancelInvitation(invitationId)` | `room.cancelInvitation(invitationId)` | `invitation.cancel()` |
+| Invitation type value | `livestreamCohostInvite` | `.livestreamCoHostInvite` | `AmityInvitationType.LIVESTREAM_COHOST` |
+| Pending status | `"pending"` | `.pending` | `AmityInvitationStatus.PENDING` |
+
+### Event and Participant Control
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room invitation events | `InvitationRepository.getInvitations({ targetId, targetType: "room" }, callback)` | `AmityInvitationRepository().getInvitations(targetId:targetType:)` or `AmityRoomRepository().getCoHostEvent(roomId:)` | `AmityCoreClient.newInvitationRepository().getInvitations(targetId, AmityInvitation.TargetType.ROOM.value)` or `getCoHostEvent(roomId)` |
+| Co-host joined | `RoomRepository.onRoomParticipantJoined(callback)` | `AmityCoHostEventType.coHostJoined` | `AmityCoHostEvent.CoHostJoined` |
+| Co-host left | `RoomRepository.onRoomParticipantLeft(callback)` | `AmityCoHostEventType.coHostLeft` | `AmityCoHostEvent.CoHostLeft` |
+| Co-host removed | `RoomRepository.onRoomParticipantRemoved(callback)` | `AmityCoHostEventType.coHostRemoved` | `AmityCoHostEvent.CoHostRemoved` |
+| Stage left | `RoomRepository.onRoomParticipantStageLeft(callback)` | `AmityCoHostEventType.coHostStageLeft` | No separate public sealed event in audited model |
+| Product-tag permission | `updateCohostPermission(roomId, cohostId, canManageProductTags)` | `updateCohostPermissions(roomId:cohostId:canManageProductTags:)` | `updateCohostPermission(roomId, cohostId, canManageProductTags)` |
+| Remove participant | `removeParticipant(roomId, participantUserId)` | `removeParticipant(withId:userId:)` | `removeRoomParticipant(roomId, userId)` |
+| Leave room | `leaveRoom(roomId)` | `leaveRoom(withId:)` | `leaveRoom(roomId)` |
 
 ## Invite a Co-Host
 
@@ -10927,31 +10986,6 @@ showSuccessMessage(roomId)
 ```
 
 
-## Invitation Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Invite one user | `room.createInvitation(userId)` | `room.createInvitation(userId)` | `room.createInvitation(userId)` |
-| Current user's pending room invitation | `room.getInvitations()` | `room.getInvitation()` | `room.getInvitation()` |
-| Accept | `invitation.accept()` | `invitation.accept()` | `invitation.accept()` |
-| Reject | `invitation.reject()` | `invitation.reject()` | `invitation.reject()` |
-| Cancel | `InvitationRepository.cancelInvitation(invitationId)` | `room.cancelInvitation(invitationId)` | `invitation.cancel()` |
-| Invitation type value | `livestreamCohostInvite` | `.livestreamCoHostInvite` | `AmityInvitationType.LIVESTREAM_COHOST` |
-| Pending status | `"pending"` | `.pending` | `AmityInvitationStatus.PENDING` |
-
-## Event and Participant Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Room invitation events | `InvitationRepository.getInvitations({ targetId, targetType: "room" }, callback)` | `AmityInvitationRepository().getInvitations(targetId:targetType:)` or `AmityRoomRepository().getCoHostEvent(roomId:)` | `AmityCoreClient.newInvitationRepository().getInvitations(targetId, AmityInvitation.TargetType.ROOM.value)` or `getCoHostEvent(roomId)` |
-| Co-host joined | `RoomRepository.onRoomParticipantJoined(callback)` | `AmityCoHostEventType.coHostJoined` | `AmityCoHostEvent.CoHostJoined` |
-| Co-host left | `RoomRepository.onRoomParticipantLeft(callback)` | `AmityCoHostEventType.coHostLeft` | `AmityCoHostEvent.CoHostLeft` |
-| Co-host removed | `RoomRepository.onRoomParticipantRemoved(callback)` | `AmityCoHostEventType.coHostRemoved` | `AmityCoHostEvent.CoHostRemoved` |
-| Stage left | `RoomRepository.onRoomParticipantStageLeft(callback)` | `AmityCoHostEventType.coHostStageLeft` | No separate public sealed event in audited model |
-| Product-tag permission | `updateCohostPermission(roomId, cohostId, canManageProductTags)` | `updateCohostPermissions(roomId:cohostId:canManageProductTags:)` | `updateCohostPermission(roomId, cohostId, canManageProductTags)` |
-| Remove participant | `removeParticipant(roomId, participantUserId)` | `removeParticipant(withId:userId:)` | `removeRoomParticipant(roomId, userId)` |
-| Leave room | `leaveRoom(roomId)` | `leaveRoom(withId:)` | `leaveRoom(roomId)` |
-
   TypeScript exposes room participant events as global room event subscribers, so filter by `event.room.roomId` when a screen only cares about one room. Android and iOS expose room-filtered co-host event streams from the room repository.
 
 ## Broadcaster Data Boundary
@@ -10991,6 +11025,18 @@ Recorded playback becomes available after a room finishes broadcasting and the b
 | iOS | `AmityRoomRepository().getRoom(withId:)` | `room.recordedData[]`, `room.recordedResolution` | Re-observe or fetch the room object | Retain the returned `AmityNotificationToken` while observing. |
 | Android | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `room.getRecordedPlaybackInfos()`, `room.getRecordedResolution()` | `getRecordedUrls(roomId)` | `getRecordedUrls()` returns URL strings only. |
 | Flutter | No current public room recorded playback API found in this audit | Not available | Not available | The Flutter SDK source exposes older stream APIs, not the room broadcasting repository. |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
+| Recorded status | `room.status === "recorded"` | `room.status == .recorded` | `room.getStatus() == AmityRoomStatus.RECORDED` |
+| Processing status | `room.status === "ended"` | `room.status == .ended` | `room.getStatus() == AmityRoomStatus.ENDED` |
+| Playback URL metadata | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
+| Thumbnail metadata | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
+| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
+| Fresh URL helper | `RoomRepository.getRecordedUrl(roomId)` | Re-observe `AmityRoom` | `getRecordedUrls(roomId)` |
 
 ## Wait for Recorded Status
 
@@ -11190,18 +11236,6 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 ```
 
 
-## Recorded Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
-| Recorded status | `room.status === "recorded"` | `room.status == .recorded` | `room.getStatus() == AmityRoomStatus.RECORDED` |
-| Processing status | `room.status === "ended"` | `room.status == .ended` | `room.getStatus() == AmityRoomStatus.ENDED` |
-| Playback URL metadata | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
-| Thumbnail metadata | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
-| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
-| Fresh URL helper | `RoomRepository.getRecordedUrl(roomId)` | Re-observe `AmityRoom` | `getRecordedUrls(roomId)` |
-
 ## Status Handling
 
 | Room status | Recorded playback behavior |
@@ -11257,6 +11291,19 @@ Playback in the social.plus SDK is a room-data workflow. The SDK gives your app 
     Use the live URL only when the room is `live` or `waitingReconnect`. Use recorded metadata only when the room is `recorded`.
     Pass the selected URL to your app-owned player. Do not call player APIs that are not part of the social.plus SDK.
     Create and update a room watch session from `room.analytics()` when your product considers the viewer actively watching.
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
+| Room status | `room.status` | `room.status` | `room.getStatus()` |
+| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
+| Recorded URL list | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
+| Recorded thumbnail list | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
+| Live resolution | `room.liveResolution` | `room.liveResolution` | `room.getLiveResolution()` |
+| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
+| Watch analytics | `room.analytics()` | `room.analytics()` | `room.analytics()` |
 
 ## Choose a Playback Source
 
@@ -11441,19 +11488,6 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 ```
 
 
-## Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
-| Room status | `room.status` | `room.status` | `room.getStatus()` |
-| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
-| Recorded URL list | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
-| Recorded thumbnail list | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
-| Live resolution | `room.liveResolution` | `room.liveResolution` | `room.getLiveResolution()` |
-| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
-| Watch analytics | `room.analytics()` | `room.analytics()` | `room.analytics()` |
-
 ## Status Handling
 
 | Room status | Playback behavior |
@@ -11477,6 +11511,8 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 | Freshness | Platform refresh or re-observation helpers | Retry timing, expired URL recovery, and player reload |
 | Analytics | Room watch-session APIs | Deciding which player states count as active watch time |
 
+## Related Topics
+
     Observe live room state and hand the live URL to your player.
     Wait for recorded status, read recorded metadata, and refresh URLs.
     Track room watch sessions after playback starts.
@@ -11499,6 +11535,18 @@ Livestream analytics track a viewer's watch session for a room. The social.plus 
 | iOS | `room.analytics()` | `createWatchSession(startedAt:)` | `updateWatchSession(sessionId:duration:endedAt:)` | `syncPendingWatchSessions()` |
 | Android | `room.analytics()` | `createWatchSession(startedAt)` | `updateWatchSession(sessionId, duration, endedAt)` | `syncPendingWatchSessions()` |
 | Flutter | No current public room analytics API found in this audit | Not available | Not available | Not available |
+
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Entry point | `room.analytics()` | `room.analytics()` | `room.analytics()` |
+| Watchable statuses | `"live"`, `"recorded"` | `.live`, `.recorded` | `AmityRoomStatus.LIVE`, `AmityRoomStatus.RECORDED` |
+| Start timestamp | `Date` | `Date` | `DateTime` |
+| Session ID | `string` | `String` | `String` |
+| Duration | `number` seconds | `Int` seconds | `Long` seconds |
+| End timestamp | `Date` | `Date` | `DateTime` |
+| Sync return | `void` | `Void` | `Unit` |
 
 ## Create a Watch Session
 
@@ -11645,18 +11693,6 @@ func syncRoomWatchSessions(for room: AmityRoom) {
 }
 ```
 
-
-## Analytics Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Entry point | `room.analytics()` | `room.analytics()` | `room.analytics()` |
-| Watchable statuses | `"live"`, `"recorded"` | `.live`, `.recorded` | `AmityRoomStatus.LIVE`, `AmityRoomStatus.RECORDED` |
-| Start timestamp | `Date` | `Date` | `DateTime` |
-| Session ID | `string` | `String` | `String` |
-| Duration | `number` seconds | `Int` seconds | `Long` seconds |
-| End timestamp | `Date` | `Date` | `DateTime` |
-| Sync return | `void` | `Void` | `Unit` |
 
 ## Tracking Boundaries
 

--- a/social-plus-sdk/core-concepts/foundation/logging.mdx
+++ b/social-plus-sdk/core-concepts/foundation/logging.mdx
@@ -17,6 +17,15 @@ Use SDK logging and error surfaces while you build and debug an integration. Kee
 Use the network observer as a development diagnostic tool. It can expose request metadata, response metadata, and payloads depending on platform, so avoid storing raw logs that may contain user content or credentials.
 </Info>
 
+## Parameters
+
+| Platform | Callback or stream value | Notes |
+| --- | --- | --- |
+| TypeScript | `request`, `response` | `response` includes `data`, `status`, `statusText`, and `headers`. The API returns an unsubscriber. |
+| iOS | `URLRequest?`, `HTTPURLResponse?`, `Data?` | Pass `nil` to `observeNetworkActivities` when logging should stop. |
+| Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
+| Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
+
 ## Network Activity
 
 Observe network activity only while debugging an integration, then unsubscribe or dispose the observer when the debug session ends.
@@ -69,15 +78,6 @@ val disposable = AmityCoreClient.observeNetworkActivities()
 disposable.dispose()
 ```
 </CodeGroup>
-
-### Observer Parameters
-
-| Platform | Callback or stream value | Notes |
-| --- | --- | --- |
-| TypeScript | `request`, `response` | `response` includes `data`, `status`, `statusText`, and `headers`. The API returns an unsubscriber. |
-| iOS | `URLRequest?`, `HTTPURLResponse?`, `Data?` | Pass `nil` to `observeNetworkActivities` when logging should stop. |
-| Android | `Flowable<AmityNetworkActivity>` | Subscribe while debugging and dispose the subscription when finished. Avoid depending on internal activity subtypes in app code. |
-| Flutter | Not available | Use normal request-level error handling and your app's HTTP tooling for Flutter-specific network diagnostics. |
 
 ## Error Handling
 
@@ -137,7 +137,7 @@ if (error is AmityException) {
 ```
 </CodeGroup>
 
-### Common SDK Error Constants
+## Common SDK Error Constants
 
 | Meaning | TypeScript | iOS | Android | Flutter |
 | --- | --- | --- | --- | --- |

--- a/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
+++ b/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview.mdx
@@ -27,7 +27,7 @@ flowchart LR
     D --> E["Unsubscribe when no longer needed"]
 ```
 
-## When To Subscribe
+## When to Subscribe
 
 | UI need | Recommended topic |
 | --- | --- |

--- a/social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx
+++ b/social-plus-sdk/core-concepts/safety-privacy/pii-detection.mdx
@@ -46,7 +46,14 @@ The current native SDK helpers define dedicated categories for these values.
 Handle unknown categories deliberately. The server can introduce category strings before every client UI has a named enum case.
 </Tip>
 
-## Read And Redact
+## Parameters
+
+| Parameter | iOS type | Android type | Default | Behavior |
+| --- | --- | --- | --- | --- |
+| `piiCategories` | `[AmityPIICategory]` | `List<AmityPII.Category>` | Empty list | Empty means redact every detected category. Provide categories to redact only selected types. |
+| `replaceChar` | `Character` | `Char` | `*` | Character used to replace each redacted character. |
+
+## Read and Redact
 
 Use `getPIIData()` when you need entity metadata for moderation UI, highlighting, or audit views. Use `redactedText(...)` when the app should display masked text.
 
@@ -119,13 +126,6 @@ val redactedMessage = (message?.getData() as? AmityMessage.Data.TEXT)
 print(redactedText + redactedComment + redactedMessage)
 ```
 </CodeGroup>
-
-### Redaction Parameters
-
-| Parameter | iOS type | Android type | Default | Behavior |
-| --- | --- | --- | --- | --- |
-| `piiCategories` | `[AmityPIICategory]` | `List<AmityPII.Category>` | Empty list | Empty means redact every detected category. Provide categories to redact only selected types. |
-| `replaceChar` | `Character` | `Char` | `*` | Character used to replace each redacted character. |
 
 ## Behavior Notes
 

--- a/social-plus-sdk/core-concepts/user-management/roles-permissions.mdx
+++ b/social-plus-sdk/core-concepts/user-management/roles-permissions.mdx
@@ -30,6 +30,16 @@ Roles have different levels of access and moderation privileges
 </Card>
 </CardGroup>
 
+## Parameters
+
+| Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- |
+| Permission constant | Yes | TypeScript, iOS, Android, Flutter | Permission value to check, such as delete-message, ban-user, or edit-community-post permissions. |
+| Scope selector | Context-dependent | TypeScript, iOS, Android, Flutter | Channel, community, or other supported scope where the permission should be evaluated. |
+| `channelId` | For channel-scoped permissions | TypeScript, iOS, Android, Flutter | Channel ID used when checking channel moderation permissions. |
+| `communityId` | For community-scoped permissions | TypeScript, iOS, Android | Community ID used when checking community moderation permissions. |
+| Result | Yes | TypeScript, iOS, Android, Flutter | Boolean-style result that tells the UI whether to show or hide the protected action. |
+
 ## Permission Checking
 
 Use the `hasPermission` method to check if the current user can perform specific actions:

--- a/social-plus-sdk/core-concepts/user-management/user-identity.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-identity.mdx
@@ -5,13 +5,13 @@ description: "Understand how social.plus SDK handles user identity and data mana
 
 social.plus SDK does not replace your identity system or require personal identifiers such as email addresses. Each user is represented by a `userId` (a string you supply from your own system) that remains immutable for the lifetime of the account. The SDK does store the social profile fields you send to it, such as display name, description, avatar, metadata, roles, and moderation state, so avoid putting sensitive personal data in those fields.
 
-## Core principles
+## Core Principles
 
 <Info>
 **You Own Identity Data**: Keep your source-of-truth user account, login credentials, email address, and private profile data in your own system. Send social.plus only the stable `userId` and optional social profile fields needed by social features.
 </Info>
 
-### Key benefits
+### Key Benefits
 
 <CardGroup cols={3}>
 <Card title="Privacy First" icon="shield-check">
@@ -27,11 +27,11 @@ Handle authentication and private user data with your existing application logic
 </Card>
 </CardGroup>
 
-## User identification
+## User Identification
 
 Every user in social.plus is represented by a unique `userId` - a string that uniquely identifies the user and remains immutable throughout their lifetime.
 
-### Choosing the right user ID
+### Choosing the Right User ID
 
 <Tabs>
 <Tab title="✅ Recommended">
@@ -74,11 +74,11 @@ userId: "john_doe"              // Display name can change
 **Important**: Once a user is created in social.plus, their `userId` cannot be changed. Choose your user identification strategy carefully.
 </Warning>
 
-## User data structure
+## User Data Structure
 
 While social.plus doesn't store personal data, it maintains essential information for social features:
 
-### User attributes
+### User Attributes
 
 <div className="overflow-x-auto">
 <table>
@@ -149,7 +149,7 @@ While social.plus doesn't store personal data, it maintains essential informatio
 </table>
 </div>
 
-## User roles & permissions
+## User Roles and Permissions
 
 Enhance user capabilities by assigning roles with specific permissions defined in your admin panel.
 
@@ -157,7 +157,7 @@ Enhance user capabilities by assigning roles with specific permissions defined i
 **Role-Based Access Control**: social.plus uses a comprehensive permission system that allows you to create hierarchical moderation structures and fine-grained access control.
 </Info>
 
-### Quick overview
+### Quick Overview
 
 <CardGroup cols={2}>
 <Card title="Default Roles" icon="users">
@@ -171,11 +171,11 @@ Create custom roles with specific permissions in the social.plus Console
 </Card>
 </CardGroup>
 
-## User repository
+## User Repository
 
 While social.plus doesn't store user profiles, it provides tools for querying and searching users within your social features.
 
-### Initializing user repository
+### Initializing the User Repository
 
 Initialize the user repository before querying or searching users from SDK-powered social surfaces.
 
@@ -201,7 +201,7 @@ void initUserRepository() {
 ```
 </CodeGroup>
 
-## Best practices
+## Best Practices
 
 <CardGroup cols={2}>
 <Card title="User ID Strategy" icon="key">

--- a/social-plus-sdk/core-concepts/user-management/user-operations/flag-unflag-user.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/flag-unflag-user.mdx
@@ -17,7 +17,17 @@ Flagging a user helps moderators identify potential issues without immediately t
 | Unflag user | Remove the current user's flag from a user. |
 | Check flag status | Check whether the current user has flagged a specific user. |
 
-## Flag A User
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Flag user | `userId` | Yes | TypeScript, iOS, Android | User ID to flag. |
+| Flag user | `AmityUser` object | Yes | Flutter | User object whose `report().flag()` method is called. |
+| Unflag user | `userId` | Yes | TypeScript, iOS, Android | User ID whose flag should be removed for the current user. |
+| Unflag user | `AmityUser` object | Yes | Flutter | User object whose `report().unflag()` method is called. |
+| Check flag status | `userId` / `AmityUser` | Yes | TypeScript, iOS, Android, Flutter | User to check against the current user's flag state. |
+
+## Flag a User
 
 To flag a user, call the following method:
 
@@ -62,7 +72,7 @@ void flagUser(AmityUser user) {
 ```
 </CodeGroup>
 
-## Unflag A User
+## Unflag a User
 
 To unflag a user, call the following method:
 
@@ -107,7 +117,7 @@ void unflagUser(AmityUser user) {
 ```
 </CodeGroup>
 
-## Check Whether The Current User Flagged A User
+## Check Whether the Current User Flagged a User
 
 To check whether a user has been flagged by the current user:
 

--- a/social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/get-user-information.mdx
@@ -9,15 +9,17 @@ Retrieve user information using the UserRepository to display profiles, user car
 **Live Objects**: User data is returned as Live Objects that automatically update when the underlying data changes, keeping your UI synchronized.
 </Info>
 
-## Common Inputs
+## Parameters
 
-| Input | Description |
-| --- | --- |
-| `userId` | Unique identifier of the user to retrieve. |
-| User repository | Platform-specific user repository or client method used to query user data. |
-| Observer or callback | Receives live object or live collection updates where supported. |
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Get a single user | `userId` | Yes | Unique identifier of the user to retrieve. |
+| Get multiple users by ID | `userIds` | Yes | User IDs to retrieve in one batch where the platform exposes a batch API. |
+| Query users | Sort option | No | Sort order for user collections, such as display name or creation time where supported. |
+| Query users | Pagination handle | No | Platform-specific live collection, paging data, or callback controls used to load additional users. |
+| All operations | Observer or callback | Platform-dependent | Receives live object or live collection updates where supported. |
 
-## Get A Single User
+## Get a Single User
 
 Retrieve a specific user by their unique ID:
 

--- a/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users.mdx
@@ -9,14 +9,16 @@ Use the user repository to find users by display name, or query the full user li
 Deleted users are automatically excluded from all search and query results to maintain data integrity.
 </Info>
 
-## Search And Query Options
+## Parameters
 
-| Operation | Use when | SDK notes |
-| --- | --- | --- |
-| Search users | You need to find users by display name keyword. | iOS and Android use `searchUsers`; TypeScript and Flutter use `searchUserByDisplayName`. |
-| Query users | You need to retrieve a user collection with sorting and pagination. | Sort options vary by SDK. |
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Search users | Display-name keyword | Yes | TypeScript, iOS, Android, Flutter | Search term for user display names. Search keywords must be at least 3 characters long. |
+| Search users | Sort option | No | TypeScript, iOS | Display-name sorting for search results where supported. |
+| Query users | Sort option | No | TypeScript, iOS, Android, Flutter | Sort user collections by display name or creation time where supported. |
+| Search or query users | Pagination handle | No | TypeScript, iOS, Android, Flutter | Platform-specific live collection, paging data, or callback controls used to load more users. |
 
-## Search Users By Display Name
+## Search Users by Display Name
 
 Query for users by their display name, receiving a collection of AmityUser matching your search. It requires two parameters: the display name you're searching for, and a 'sort option' from the AmityUserSortOption enum.
 

--- a/social-plus-sdk/video-new/analytics/overview.mdx
+++ b/social-plus-sdk/video-new/analytics/overview.mdx
@@ -18,6 +18,18 @@ Livestream analytics track a viewer's watch session for a room. The social.plus 
 | Android | `room.analytics()` | `createWatchSession(startedAt)` | `updateWatchSession(sessionId, duration, endedAt)` | `syncPendingWatchSessions()` |
 | Flutter | No current public room analytics API found in this audit | Not available | Not available | Not available |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Entry point | `room.analytics()` | `room.analytics()` | `room.analytics()` |
+| Watchable statuses | `"live"`, `"recorded"` | `.live`, `.recorded` | `AmityRoomStatus.LIVE`, `AmityRoomStatus.RECORDED` |
+| Start timestamp | `Date` | `Date` | `DateTime` |
+| Session ID | `string` | `String` | `String` |
+| Duration | `number` seconds | `Int` seconds | `Long` seconds |
+| End timestamp | `Date` | `Date` | `DateTime` |
+| Sync return | `void` | `Void` | `Unit` |
+
 ## Create a Watch Session
 
 Create a watch session when the current user starts viewing a room as a viewer. The SDK accepts watch sessions only for rooms in watchable states: `live` or `recorded`.
@@ -169,18 +181,6 @@ func syncRoomWatchSessions(for room: AmityRoom) {
 ```
 
 </CodeGroup>
-
-## Analytics Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Entry point | `room.analytics()` | `room.analytics()` | `room.analytics()` |
-| Watchable statuses | `"live"`, `"recorded"` | `.live`, `.recorded` | `AmityRoomStatus.LIVE`, `AmityRoomStatus.RECORDED` |
-| Start timestamp | `Date` | `Date` | `DateTime` |
-| Session ID | `string` | `String` | `String` |
-| Duration | `number` seconds | `Int` seconds | `Long` seconds |
-| End timestamp | `Date` | `Date` | `DateTime` |
-| Sync return | `void` | `Void` | `Unit` |
 
 ## Tracking Boundaries
 

--- a/social-plus-sdk/video-new/broadcasting/co-host-management.mdx
+++ b/social-plus-sdk/video-new/broadcasting/co-host-management.mdx
@@ -18,6 +18,31 @@ Co-host management is built on room invitations, room participant events, and ro
 | Android | `AmityRoom.createInvitation(userId)` | `room.getInvitation()`, `invitation.accept()`, `invitation.reject()`, `invitation.cancel()` | `AmityVideoClient.newRoomRepository().getCoHostEvent(roomId)` | `updateCohostPermission(...)`, `removeRoomParticipant(...)`, `leaveRoom(...)` |
 | Flutter | No current public room repository found in this audit | Not available | Not available | Not available |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Invite one user | `room.createInvitation(userId)` | `room.createInvitation(userId)` | `room.createInvitation(userId)` |
+| Current user's pending room invitation | `room.getInvitations()` | `room.getInvitation()` | `room.getInvitation()` |
+| Accept | `invitation.accept()` | `invitation.accept()` | `invitation.accept()` |
+| Reject | `invitation.reject()` | `invitation.reject()` | `invitation.reject()` |
+| Cancel | `InvitationRepository.cancelInvitation(invitationId)` | `room.cancelInvitation(invitationId)` | `invitation.cancel()` |
+| Invitation type value | `livestreamCohostInvite` | `.livestreamCoHostInvite` | `AmityInvitationType.LIVESTREAM_COHOST` |
+| Pending status | `"pending"` | `.pending` | `AmityInvitationStatus.PENDING` |
+
+### Event and Participant Control
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room invitation events | `InvitationRepository.getInvitations({ targetId, targetType: "room" }, callback)` | `AmityInvitationRepository().getInvitations(targetId:targetType:)` or `AmityRoomRepository().getCoHostEvent(roomId:)` | `AmityCoreClient.newInvitationRepository().getInvitations(targetId, AmityInvitation.TargetType.ROOM.value)` or `getCoHostEvent(roomId)` |
+| Co-host joined | `RoomRepository.onRoomParticipantJoined(callback)` | `AmityCoHostEventType.coHostJoined` | `AmityCoHostEvent.CoHostJoined` |
+| Co-host left | `RoomRepository.onRoomParticipantLeft(callback)` | `AmityCoHostEventType.coHostLeft` | `AmityCoHostEvent.CoHostLeft` |
+| Co-host removed | `RoomRepository.onRoomParticipantRemoved(callback)` | `AmityCoHostEventType.coHostRemoved` | `AmityCoHostEvent.CoHostRemoved` |
+| Stage left | `RoomRepository.onRoomParticipantStageLeft(callback)` | `AmityCoHostEventType.coHostStageLeft` | No separate public sealed event in audited model |
+| Product-tag permission | `updateCohostPermission(roomId, cohostId, canManageProductTags)` | `updateCohostPermissions(roomId:cohostId:canManageProductTags:)` | `updateCohostPermission(roomId, cohostId, canManageProductTags)` |
+| Remove participant | `removeParticipant(roomId, participantUserId)` | `removeParticipant(withId:userId:)` | `removeRoomParticipant(roomId, userId)` |
+| Leave room | `leaveRoom(roomId)` | `leaveRoom(withId:)` | `leaveRoom(roomId)` |
+
 ## Invite a Co-Host
 
 Invite one user at a time. The invitation type is the room co-host invitation type under the hood.
@@ -284,31 +309,6 @@ showSuccessMessage(roomId)
 ```
 
 </CodeGroup>
-
-## Invitation Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Invite one user | `room.createInvitation(userId)` | `room.createInvitation(userId)` | `room.createInvitation(userId)` |
-| Current user's pending room invitation | `room.getInvitations()` | `room.getInvitation()` | `room.getInvitation()` |
-| Accept | `invitation.accept()` | `invitation.accept()` | `invitation.accept()` |
-| Reject | `invitation.reject()` | `invitation.reject()` | `invitation.reject()` |
-| Cancel | `InvitationRepository.cancelInvitation(invitationId)` | `room.cancelInvitation(invitationId)` | `invitation.cancel()` |
-| Invitation type value | `livestreamCohostInvite` | `.livestreamCoHostInvite` | `AmityInvitationType.LIVESTREAM_COHOST` |
-| Pending status | `"pending"` | `.pending` | `AmityInvitationStatus.PENDING` |
-
-## Event and Participant Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Room invitation events | `InvitationRepository.getInvitations({ targetId, targetType: "room" }, callback)` | `AmityInvitationRepository().getInvitations(targetId:targetType:)` or `AmityRoomRepository().getCoHostEvent(roomId:)` | `AmityCoreClient.newInvitationRepository().getInvitations(targetId, AmityInvitation.TargetType.ROOM.value)` or `getCoHostEvent(roomId)` |
-| Co-host joined | `RoomRepository.onRoomParticipantJoined(callback)` | `AmityCoHostEventType.coHostJoined` | `AmityCoHostEvent.CoHostJoined` |
-| Co-host left | `RoomRepository.onRoomParticipantLeft(callback)` | `AmityCoHostEventType.coHostLeft` | `AmityCoHostEvent.CoHostLeft` |
-| Co-host removed | `RoomRepository.onRoomParticipantRemoved(callback)` | `AmityCoHostEventType.coHostRemoved` | `AmityCoHostEvent.CoHostRemoved` |
-| Stage left | `RoomRepository.onRoomParticipantStageLeft(callback)` | `AmityCoHostEventType.coHostStageLeft` | No separate public sealed event in audited model |
-| Product-tag permission | `updateCohostPermission(roomId, cohostId, canManageProductTags)` | `updateCohostPermissions(roomId:cohostId:canManageProductTags:)` | `updateCohostPermission(roomId, cohostId, canManageProductTags)` |
-| Remove participant | `removeParticipant(roomId, participantUserId)` | `removeParticipant(withId:userId:)` | `removeRoomParticipant(roomId, userId)` |
-| Leave room | `leaveRoom(roomId)` | `leaveRoom(withId:)` | `leaveRoom(roomId)` |
 
 <Info>
   TypeScript exposes room participant events as global room event subscribers, so filter by `event.room.roomId` when a screen only cares about one room. Android and iOS expose room-filtered co-host event streams from the room repository.

--- a/social-plus-sdk/video-new/broadcasting/create-room.mdx
+++ b/social-plus-sdk/video-new/broadcasting/create-room.mdx
@@ -22,7 +22,7 @@ Create a room before you publish it to a feed or connect a broadcaster. Room cre
 | `participants` | No | iOS, Android | Initial participant user IDs. TypeScript room creation does not expose this field. |
 | `type` | No | TypeScript, iOS | Room type such as `coHosts` / `.coHosts` or `directStreaming` / `.directStreaming`. Android creation does not expose a type argument. |
 
-## Create a room
+## Create a Room
 
 Create a room with the title and configuration your product needs before publishing it or connecting a broadcaster.
 
@@ -82,7 +82,7 @@ showSuccessMessage(room.roomId)
 
 </CodeGroup>
 
-## Create with thumbnail or parent room
+## Create with Thumbnail or Parent Room
 
 Use `thumbnailFileId` after uploading an image through the file APIs. Use `parentRoomId` only when your product intentionally creates a room hierarchy.
 
@@ -131,7 +131,7 @@ showSuccessMessage(childRoom.roomId)
 
 </CodeGroup>
 
-## Get broadcaster data
+## Get Broadcaster Data
 
 After creating the room, request broadcaster credentials before connecting the media layer. TypeScript and Android expose broadcaster-data APIs. iOS exposes room token generation.
 

--- a/social-plus-sdk/video-new/broadcasting/live-viewing.mdx
+++ b/social-plus-sdk/video-new/broadcasting/live-viewing.mdx
@@ -18,6 +18,17 @@ Live room viewing starts from a room ID or a room post. The social.plus SDK owns
 | Android | `AmityPostRepository.getLiveRoomPosts()`, `getCommunityLiveRoomPosts(...)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `room.getLivePlaybackUrl()` | `room.getRecordedPlaybackInfos()` |
 | Flutter | No current public room viewing API found in this audit | Not available | Not available | Not available |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Live room post collection | `getLiveRoomPosts(callback)` | `getLiveRoomPosts()` | `getLiveRoomPosts()` |
+| Community live room posts | `getCommunityLiveRoomPosts({ communityIds })` | `getCommunityLiveRoomPosts(withIds:)` | `getCommunityLiveRoomPosts(communityIds)` |
+| Room ID in post data | `post.data.roomId` when `dataType === "room"` | `post.data?["roomId"]` when `dataType == "room"` | `AmityPost.Data.ROOM.getRoomId()` |
+| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
+| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
+| Recorded URL | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
+
 ## Find Live Room Posts
 
 Use live room post collections when your product shows a live shelf or a community-specific live section. Extract the `roomId` from room post data, then observe the room itself for playback state.
@@ -225,17 +236,6 @@ func playbackSource(for room: AmityRoom) -> String? {
 ```
 
 </CodeGroup>
-
-## Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Live room post collection | `getLiveRoomPosts(callback)` | `getLiveRoomPosts()` | `getLiveRoomPosts()` |
-| Community live room posts | `getCommunityLiveRoomPosts({ communityIds })` | `getCommunityLiveRoomPosts(withIds:)` | `getCommunityLiveRoomPosts(communityIds)` |
-| Room ID in post data | `post.data.roomId` when `dataType === "room"` | `post.data?["roomId"]` when `dataType == "room"` | `AmityPost.Data.ROOM.getRoomId()` |
-| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
-| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
-| Recorded URL | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
 
 ## Status Handling
 

--- a/social-plus-sdk/video-new/broadcasting/manage-rooms.mdx
+++ b/social-plus-sdk/video-new/broadcasting/manage-rooms.mdx
@@ -18,6 +18,33 @@ Manage rooms after creation by observing a single room, querying room lists, upd
 | Android | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `AmityVideoClient.newRoomRepository().getRooms().build().query()` | `updateRoom()`, `stopRoom()`, `deleteRoom()` | Single rooms are `Flowable<AmityRoom>`; room lists are `Flowable<PagingData<AmityRoom>>`. |
 | Flutter | No current public room repository found in this audit | Not available | Not available | The Flutter SDK source exposes older stream APIs, not the room broadcasting repository. |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Status filter | `statuses?: Amity.RoomStatus[]` | `statuses: [AmityRoomStatus]?` | `setStatuses(Array<AmityRoomStatus>)` |
+| Room type filter | `type?: Amity.RoomType` | `type: AmityRoomType?` | `setTypes(Array<AmityRoomType>)` |
+| Deleted rooms | `includeDeleted?: boolean` | `isDeleted: Bool` | `setIsDeleted(Boolean?)` |
+| Sort order | `sortBy?: "firstCreated"` or `"lastCreated"` | `sortBy: AmityRoomSortOption` | `setSortBy(AmityRoomSortOption?)` |
+| Page size | `limit?: number` | Not exposed on `AmityRoomQueryOptions` | Paging 3 controls consumption after `PagingData` emission |
+
+### Mutation Parameters
+
+| Operation | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Update | `updateRoom(roomId, bundle)` | `updateRoom(withId:options:)` | `updateRoom(roomId, ...)` |
+| Stop | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
+| Delete | `deleteRoom(roomId)` | `deleteRoom(withId:)` | `deleteRoom(roomId)` |
+
+| Update field | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Title | `title` | `title` | `title` |
+| Description | `description` | `description` | `description` |
+| Thumbnail | `thumbnailFileId` | `thumbnailFileId` | `thumbnailFileId` |
+| Metadata | `metadata` | `metadata` | `metadata` |
+| Live chat flag | `liveChatEnabled` | `channelEnabled` | `liveChatEnabled` |
+| Parent room | `parentRoomId` | Not exposed by update options | Not exposed by update API |
+
 ## Get a Room
 
 Use the single-room API when a screen needs live updates for one room.
@@ -151,16 +178,6 @@ roomCollectionToken = rooms.observe { collection, error in
 
 </CodeGroup>
 
-## Query Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Status filter | `statuses?: Amity.RoomStatus[]` | `statuses: [AmityRoomStatus]?` | `setStatuses(Array<AmityRoomStatus>)` |
-| Room type filter | `type?: Amity.RoomType` | `type: AmityRoomType?` | `setTypes(Array<AmityRoomType>)` |
-| Deleted rooms | `includeDeleted?: boolean` | `isDeleted: Bool` | `setIsDeleted(Boolean?)` |
-| Sort order | `sortBy?: "firstCreated"` or `"lastCreated"` | `sortBy: AmityRoomSortOption` | `setSortBy(AmityRoomSortOption?)` |
-| Page size | `limit?: number` | Not exposed on `AmityRoomQueryOptions` | Paging 3 controls consumption after `PagingData` emission |
-
 <Info>
   TypeScript filters by a single `type` value. Android's builder accepts `setTypes(...)` because the Android query model supports an array of room types.
 </Info>
@@ -271,23 +288,6 @@ showSuccessMessage(roomId)
 <Warning>
   Stopping a room ends the current broadcast session. Do not document or build a "restart same room" flow unless your product and backend contract explicitly support it.
 </Warning>
-
-## Mutation Parameters
-
-| Operation | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Update | `updateRoom(roomId, bundle)` | `updateRoom(withId:options:)` | `updateRoom(roomId, ...)` |
-| Stop | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
-| Delete | `deleteRoom(roomId)` | `deleteRoom(withId:)` | `deleteRoom(roomId)` |
-
-| Update field | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Title | `title` | `title` | `title` |
-| Description | `description` | `description` | `description` |
-| Thumbnail | `thumbnailFileId` | `thumbnailFileId` | `thumbnailFileId` |
-| Metadata | `metadata` | `metadata` | `metadata` |
-| Live chat flag | `liveChatEnabled` | `channelEnabled` | `liveChatEnabled` |
-| Parent room | `parentRoomId` | Not exposed by update options | Not exposed by update API |
 
 ## Recorded Playback Boundary
 

--- a/social-plus-sdk/video-new/broadcasting/recorded-playback.mdx
+++ b/social-plus-sdk/video-new/broadcasting/recorded-playback.mdx
@@ -18,6 +18,18 @@ Recorded playback becomes available after a room finishes broadcasting and the b
 | Android | `AmityVideoClient.newRoomRepository().getRoom(roomId)` | `room.getRecordedPlaybackInfos()`, `room.getRecordedResolution()` | `getRecordedUrls(roomId)` | `getRecordedUrls()` returns URL strings only. |
 | Flutter | No current public room recorded playback API found in this audit | Not available | Not available | The Flutter SDK source exposes older stream APIs, not the room broadcasting repository. |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
+| Recorded status | `room.status === "recorded"` | `room.status == .recorded` | `room.getStatus() == AmityRoomStatus.RECORDED` |
+| Processing status | `room.status === "ended"` | `room.status == .ended` | `room.getStatus() == AmityRoomStatus.ENDED` |
+| Playback URL metadata | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
+| Thumbnail metadata | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
+| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
+| Fresh URL helper | `RoomRepository.getRecordedUrl(roomId)` | Re-observe `AmityRoom` | `getRecordedUrls(roomId)` |
+
 ## Wait for Recorded Status
 
 Observe the room while the playback screen is open. Treat `ended` as a processing state and only hand a recorded URL to your player after the room status becomes `recorded`.
@@ -221,18 +233,6 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 ```
 
 </CodeGroup>
-
-## Recorded Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Observe room | `RoomRepository.getRoom(roomId, callback)` | `AmityRoomRepository().getRoom(withId:)` | `AmityVideoClient.newRoomRepository().getRoom(roomId)` |
-| Recorded status | `room.status === "recorded"` | `room.status == .recorded` | `room.getStatus() == AmityRoomStatus.RECORDED` |
-| Processing status | `room.status === "ended"` | `room.status == .ended` | `room.getStatus() == AmityRoomStatus.ENDED` |
-| Playback URL metadata | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
-| Thumbnail metadata | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
-| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
-| Fresh URL helper | `RoomRepository.getRecordedUrl(roomId)` | Re-observe `AmityRoom` | `getRecordedUrls(roomId)` |
 
 ## Status Handling
 

--- a/social-plus-sdk/video-new/broadcasting/start-broadcasting.mdx
+++ b/social-plus-sdk/video-new/broadcasting/start-broadcasting.mdx
@@ -18,6 +18,25 @@ Starting a broadcast has two parts: the social.plus SDK returns room broadcaster
 | Android | `AmityVideoClient.newRoomRepository().getBroadcasterData(roomId)` | `getRoom(roomId)` plus room topic subscription when real-time updates are needed | `stopRoom(roomId)` | Returns `AmityRoomBroadcastData.CoHosts` or `AmityRoomBroadcastData.DirectStreaming`. |
 | Flutter | No current public room broadcaster API found in this audit | Not available | Not available | The Flutter SDK source exposes older stream read APIs, not the room broadcasting repository. |
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android | Notes |
+| --- | --- | --- | --- | --- |
+| Fetch credentials | `getBroadcasterData(roomId)` | `generateRoomToken(withId:)` | `getBroadcasterData(roomId)` | Requires an existing room ID. |
+| Co-host URL | `coHostUrl?: string` | `tokenPayload["coHostUrl"]` | `AmityRoomBroadcastData.CoHosts.getCoHostUrl()` | Use as the media connection URL for co-host rooms. |
+| Co-host token | `coHostToken?: string` | `tokenPayload["coHostToken"]` | `AmityRoomBroadcastData.CoHosts.getCoHostToken()` | Use as the media access token for co-host rooms. |
+| Direct stream URL | `directStreamUrl?: string` | `tokenPayload["directStreamUrl"]` | `AmityRoomBroadcastData.DirectStreaming.getDirectStreamUrl()` | Use only for direct-streaming publisher flows. |
+| Flutter room broadcasting | Not applicable | Not applicable | Not applicable | No current public Flutter room broadcaster API found in this audit. |
+
+### Lifecycle Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Start event | `onRoomStartBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
+| End event | `onRoomEndBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
+| Stop room | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
+| Cleanup | Call returned `Amity.Unsubscriber` functions | Retain and release the `AmityNotificationToken` with the screen lifecycle | Dispose Rx subscriptions and unsubscribe room topics when no longer needed |
+
 ## Get Broadcaster Data
 
 Call this after the room exists and before connecting your app-owned media client. Co-host rooms use `coHostUrl` and `coHostToken`; direct-streaming rooms use `directStreamUrl`.
@@ -287,25 +306,6 @@ showSuccessMessage(stoppedRoom.status.rawValue)
 <Warning>
   Stopping a room ends the current broadcast session. Do not build a "restart the same room" flow unless your product and backend contract explicitly support it.
 </Warning>
-
-## Credential Parameters
-
-| Concept | TypeScript | iOS | Android | Notes |
-| --- | --- | --- | --- | --- |
-| Fetch credentials | `getBroadcasterData(roomId)` | `generateRoomToken(withId:)` | `getBroadcasterData(roomId)` | Requires an existing room ID. |
-| Co-host URL | `coHostUrl?: string` | `tokenPayload["coHostUrl"]` | `AmityRoomBroadcastData.CoHosts.getCoHostUrl()` | Use as the media connection URL for co-host rooms. |
-| Co-host token | `coHostToken?: string` | `tokenPayload["coHostToken"]` | `AmityRoomBroadcastData.CoHosts.getCoHostToken()` | Use as the media access token for co-host rooms. |
-| Direct stream URL | `directStreamUrl?: string` | `tokenPayload["directStreamUrl"]` | `AmityRoomBroadcastData.DirectStreaming.getDirectStreamUrl()` | Use only for direct-streaming publisher flows. |
-| Flutter room broadcasting | Not applicable | Not applicable | Not applicable | No current public Flutter room broadcaster API found in this audit. |
-
-## Lifecycle Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Start event | `onRoomStartBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
-| End event | `onRoomEndBroadcasting(callback)` | Observe `AmityRoom.status` via `getRoom(withId:)` | Observe `getRoom(roomId)` and subscribe to `AmityRoomEvents.STREAMER` when needed |
-| Stop room | `stopRoom(roomId)` | `stopRoom(withId:)` | `stopRoom(roomId)` |
-| Cleanup | Call returned `Amity.Unsubscriber` functions | Retain and release the `AmityNotificationToken` with the screen lifecycle | Dispose Rx subscriptions and unsubscribe room topics when no longer needed |
 
 ## Media Boundary
 

--- a/social-plus-sdk/video-new/migration-guide.mdx
+++ b/social-plus-sdk/video-new/migration-guide.mdx
@@ -43,6 +43,16 @@ Use room APIs for new livestream and co-host experiences. Legacy Stream APIs sti
 | Stream watcher URL / recordings | Room live and recorded playback fields | Pass SDK-returned room playback URLs to your app-owned player. |
 | Stream session analytics | Room watch-session analytics | Use `room.analytics()` for new room watch sessions. |
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Observe room content | `roomId` | Yes | TypeScript, iOS, Android | Room ID used when replacing new Stream observation flows with room observation. |
+| Create room | Room options | Yes | TypeScript, iOS, Android | Room title and configuration passed to the room repository. |
+| Publish room post | `communityId` or target ID | Yes | TypeScript, iOS, Android | Feed target where the room post should be published. |
+| Publish room post | `roomId` | Yes | TypeScript, iOS, Android | Room ID returned by room creation and embedded in the room post. |
+| Publish room post | Text or title fields | No | TypeScript, iOS, Android | Display text used by the feed post that references the room. |
+
 ## Observe Room Content
 
 Replace new Stream observation flows with room observation for new room-based screens. Each snippet below is standalone and uses the current room repository surface.

--- a/social-plus-sdk/video-new/playback/overview.mdx
+++ b/social-plus-sdk/video-new/playback/overview.mdx
@@ -35,6 +35,19 @@ Playback in the social.plus SDK is a room-data workflow. The SDK gives your app 
   </Step>
 </Steps>
 
+## Parameters
+
+| Concept | TypeScript | iOS | Android |
+| --- | --- | --- | --- |
+| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
+| Room status | `room.status` | `room.status` | `room.getStatus()` |
+| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
+| Recorded URL list | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
+| Recorded thumbnail list | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
+| Live resolution | `room.liveResolution` | `room.liveResolution` | `room.getLiveResolution()` |
+| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
+| Watch analytics | `room.analytics()` | `room.analytics()` | `room.analytics()` |
+
 ## Choose a Playback Source
 
 Select a URL from SDK room state before creating or updating your player. Return no source for statuses that are not playable.
@@ -224,19 +237,6 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 
 </CodeGroup>
 
-## Playback Parameters
-
-| Concept | TypeScript | iOS | Android |
-| --- | --- | --- | --- |
-| Room ID | `room.roomId` | `room.roomId` | `room.getRoomId()` |
-| Room status | `room.status` | `room.status` | `room.getStatus()` |
-| Live URL | `room.livePlaybackUrl` | `room.livePlaybackUrl` | `room.getLivePlaybackUrl()` |
-| Recorded URL list | `room.recordedPlaybackInfos[].url` | `room.recordedData[].playbackUrl` | `room.getRecordedPlaybackInfos()[].url` |
-| Recorded thumbnail list | `room.recordedPlaybackInfos[].thumbnailUrl` | `room.recordedData[].thumbnailUrl` | `room.getRecordedPlaybackInfos()[].thumbnailUrl` |
-| Live resolution | `room.liveResolution` | `room.liveResolution` | `room.getLiveResolution()` |
-| Recorded resolution | `room.recordedResolution` | `room.recordedResolution` | `room.getRecordedResolution()` |
-| Watch analytics | `room.analytics()` | `room.analytics()` | `room.analytics()` |
-
 ## Status Handling
 
 | Room status | Playback behavior |
@@ -261,6 +261,8 @@ refreshToken = roomObject.observeOnce { liveObject, error in
 | Source data | Live URLs, recorded URLs, thumbnails, and resolution metadata | Player initialization, buffering, seek controls, captions, DRM, and release lifecycle |
 | Freshness | Platform refresh or re-observation helpers | Retry timing, expired URL recovery, and player reload |
 | Analytics | Room watch-session APIs | Deciding which player states count as active watch time |
+
+## Related Topics
 
 <CardGroup cols={3}>
   <Card title="Live Viewing" icon="tower-broadcast" href="/social-plus-sdk/video-new/broadcasting/live-viewing">


### PR DESCRIPTION
## Summary
- Normalize core concept user/logging/PII pages with consistent Parameters sections and heading casing
- Move video-new parameter references near the top of each SDK operation page before code examples
- Add missing Parameters coverage for room migration and related-topic heading polish for playback overview
- Refresh llms-full.txt after the SDK docs updates

## Validation
- python3 .docs-ops/ci/check-mdx.py social-plus-sdk
- python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk
- python3 tools/check_internal_links.py social-plus-sdk
- go test ./... (in llmstxt)
- git diff --check