### PR TITLE
Add parameters to getting started SDK pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,6 +12,17 @@ Install the social.plus SDK and add social features to your app, whether you're 
 
   **New to social.plus SDK?** Check out our [SDK Overview](/social-plus-sdk/overview) to learn about all available features and choose what's right for your project.
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript, Flutter | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript, Flutter | Region where your social.plus application was created, such as US, EU, or SG. |
+| Authenticate user | `userId` | Yes | iOS, Android, TypeScript, Flutter | Stable user identifier from your own identity system. |
+| Authenticate user | `displayName` | No | iOS, Android, TypeScript, Flutter | Display name stored in the social.plus user profile. |
+| Authenticate user | `authToken` | Production | iOS, Android, TypeScript, Flutter | Backend-generated auth token for production authentication. |
+| Authenticate user | `sessionHandler` | Recommended | iOS, Android, TypeScript, Flutter | Token-renewal handler used by production session flows. |
+
     Select the SDK that matches your development environment:
 
         - [iOS SDK](/social-plus-sdk/getting-started/platform-setup/mobile/ios-quick-start)
@@ -262,6 +273,20 @@ await Client.login({
 
 
       Development mode bypasses auth token requirements for easier testing. Never use this in production as it skips your backend verification.
+
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript, Flutter | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript, Flutter | Region where your social.plus application was created. |
+| Login user | `userId` | Yes | iOS, Android, TypeScript, Flutter | Stable user identifier from your identity system. |
+| Login user | `displayName` | No | iOS, Android, TypeScript, Flutter | Display name stored in the social.plus user profile. |
+| Login user | `authToken` | Production | iOS, Android, TypeScript, Flutter | Backend-generated token proving your system authenticated the user. |
+| Login user | `sessionHandler` | Recommended | iOS, Android, TypeScript, Flutter | Callback used to renew auth tokens when the SDK session expires. |
+| Login with access token | `accessToken` | Yes | iOS, Android, TypeScript | JWT access token issued by your backend. |
+| Login with access token | access token handler | Yes | iOS, Android, TypeScript | Handler registered before login so the SDK can renew access tokens. |
+| Logout | None | No | iOS, Android, TypeScript, Flutter | Ends the current SDK session; secure logout revokes the access token where supported. |
 
 ## Quick Start (Basic Authentication)
 
@@ -1132,6 +1157,19 @@ await Client.loginAsBot({ sessionHandler });
     - ❌ No push notifications
     - ❌ No write operations
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript | Region where your social.plus application was created. |
+| Get visitor device ID | None | No | iOS, Android, TypeScript | SDK returns or generates the stable anonymous device ID. |
+| Login as visitor | `sessionHandler` | Recommended | iOS, Android, TypeScript | Token-renewal handler for visitor sessions. |
+| Secure visitor login | `authSignature` | Secure mode | iOS, Android, TypeScript | Backend-generated HMAC signature for the visitor device ID and expiration time. |
+| Secure visitor login | `authSignatureExpiresAt` | Secure mode | iOS, Android, TypeScript | Expiration timestamp that was included in the signature. |
+| Login as bot | `sessionHandler` | Recommended | TypeScript | Token-renewal handler for explicit bot sessions. |
+| Check user type | None | No | iOS, Android, TypeScript | SDK returns the current user type so the UI can adjust capabilities. |
+
 ## Quick Start (Visitor Mode)
 
 ### Step 1: Initialize the SDK
@@ -1945,6 +1983,16 @@ Add the dependency:
 implementation 'com.github.AmityCo:Amity-Social-Cloud-Android-SDK:x.y.z'
 ```
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Endpoint | No | Region endpoint such as `AmityEndpoint.US`, `EU`, or `SG`; SG is the default when omitted. |
+| Initialize SDK with encryption | `dbEncryption` | No | Database encryption mode: `NONE`, `AUTH`, or `ALL`. |
+| Initialize SDK with encryption | Encryption key | Required when encryption is enabled | Stable key bytes supplied to the selected database encryption mode. |
+| Build configuration | SDK version | Yes | Android SDK version in the Gradle dependency declaration. |
+
 ## Initialize the SDK
 
 Set up the client with your API key so the SDK is ready for authentication - highly recommended to do this on the application class.
@@ -2249,6 +2297,16 @@ android {
 
 The Flutter SDK example app uses `minSdkVersion flutter.minSdkVersion` in `example/android/app/build.gradle`; if you override it in your own app, keep the value at 19 or above to match the SDK requirements.
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Install SDK | Package version | Yes | `amity_sdk` version declared in `pubspec.yaml`. |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Endpoint | No | Region endpoint passed through `AmityCoreClientOption` where your app needs a non-default region. |
+| Native project setup | iOS deployment target | Yes | Minimum iOS version in `ios/Podfile`; keep it at 12.0 or above. |
+| Native project setup | Android min SDK | Yes | Android minimum SDK version; keep it at API 19 or above. |
+
 ## Initialize the SDK
 
 Create the client with your API key so the SDK is ready for authentication.
@@ -2327,6 +2385,17 @@ https://github.com/AmityCo/Amity-Social-Cloud-SDK-iOS-SwiftPM
     4. Set the **Embed** option to **Embed & Sign**
 
       For M1 Macs using the simulator, enable Rosetta mode for the application.
+
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Region | Yes | Region passed to `AmityClient`, such as `.US`, `.EU`, or `.SG`. |
+| Objective-C bridge login | `userId` | Yes | Stable user identifier from your identity system. |
+| Objective-C bridge login | `displayName` | No | Display name passed through the Swift bridge. |
+| Objective-C bridge login | `authToken` | Production | Backend-generated auth token passed through the Swift bridge. |
+| Objective-C bridge login | Completion callback | Yes | Callback that reports success or failure back to Objective-C. |
 
 ## Initialize the SDK
 
@@ -2577,6 +2646,14 @@ yarn add @amityco/ts-sdk
 pnpm add @amityco/ts-sdk
 ```
 
+
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Region | Yes | Region string passed to `Client.createClient`, such as `us`, `eu`, or `sg`. |
+| Initialize SDK | Client options | No | Optional TypeScript client configuration, such as custom endpoints where supported. |
 
 ## Initialize the SDK
 
@@ -2920,6 +2997,14 @@ Create custom roles with specific permissions in the social.plus Console
 ## User Repository
 
 While social.plus doesn't store user profiles, it provides tools for querying and searching users within your social features.
+
+## Parameters
+
+| Operation | Input | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize user repository | Initialized SDK client | Yes | iOS, Android, TypeScript, Flutter | The SDK must be initialized before user repository APIs are used. |
+| Initialize user repository | User repository object or import | Yes | iOS, Android, TypeScript, Flutter | Platform-specific entry point for querying and searching users. |
+| Query or search users | `userId`, display-name keyword, sort, or pagination options | Operation-dependent | iOS, Android, TypeScript, Flutter | Use the user operation pages for method-specific parameters and examples. |
 
 ### Initializing the User Repository
 

--- a/social-plus-sdk/core-concepts/user-management/user-identity.mdx
+++ b/social-plus-sdk/core-concepts/user-management/user-identity.mdx
@@ -175,6 +175,14 @@ Create custom roles with specific permissions in the social.plus Console
 
 While social.plus doesn't store user profiles, it provides tools for querying and searching users within your social features.
 
+## Parameters
+
+| Operation | Input | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize user repository | Initialized SDK client | Yes | iOS, Android, TypeScript, Flutter | The SDK must be initialized before user repository APIs are used. |
+| Initialize user repository | User repository object or import | Yes | iOS, Android, TypeScript, Flutter | Platform-specific entry point for querying and searching users. |
+| Query or search users | `userId`, display-name keyword, sort, or pagination options | Operation-dependent | iOS, Android, TypeScript, Flutter | Use the user operation pages for method-specific parameters and examples. |
+
 ### Initializing the User Repository
 
 Initialize the user repository before querying or searching users from SDK-powered social surfaces.

--- a/social-plus-sdk/getting-started/authentication.mdx
+++ b/social-plus-sdk/getting-started/authentication.mdx
@@ -114,6 +114,20 @@ sequenceDiagram
   </Tab>
 </Tabs>
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript, Flutter | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript, Flutter | Region where your social.plus application was created. |
+| Login user | `userId` | Yes | iOS, Android, TypeScript, Flutter | Stable user identifier from your identity system. |
+| Login user | `displayName` | No | iOS, Android, TypeScript, Flutter | Display name stored in the social.plus user profile. |
+| Login user | `authToken` | Production | iOS, Android, TypeScript, Flutter | Backend-generated token proving your system authenticated the user. |
+| Login user | `sessionHandler` | Recommended | iOS, Android, TypeScript, Flutter | Callback used to renew auth tokens when the SDK session expires. |
+| Login with access token | `accessToken` | Yes | iOS, Android, TypeScript | JWT access token issued by your backend. |
+| Login with access token | access token handler | Yes | iOS, Android, TypeScript | Handler registered before login so the SDK can renew access tokens. |
+| Logout | None | No | iOS, Android, TypeScript, Flutter | Ends the current SDK session; secure logout revokes the access token where supported. |
+
 ## Quick Start (Basic Authentication)
 
 ### Step 1: Initialize the SDK

--- a/social-plus-sdk/getting-started/overview.mdx
+++ b/social-plus-sdk/getting-started/overview.mdx
@@ -9,6 +9,17 @@ Install the social.plus SDK and add social features to your app, whether you're 
   **New to social.plus SDK?** Check out our [SDK Overview](/social-plus-sdk/overview) to learn about all available features and choose what's right for your project.
 </Note>
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript, Flutter | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript, Flutter | Region where your social.plus application was created, such as US, EU, or SG. |
+| Authenticate user | `userId` | Yes | iOS, Android, TypeScript, Flutter | Stable user identifier from your own identity system. |
+| Authenticate user | `displayName` | No | iOS, Android, TypeScript, Flutter | Display name stored in the social.plus user profile. |
+| Authenticate user | `authToken` | Production | iOS, Android, TypeScript, Flutter | Backend-generated auth token for production authentication. |
+| Authenticate user | `sessionHandler` | Recommended | iOS, Android, TypeScript, Flutter | Token-renewal handler used by production session flows. |
+
 <Steps>
   <Step title="Choose Your Platform">
     Select the SDK that matches your development environment:

--- a/social-plus-sdk/getting-started/platform-setup/mobile/android-quick-start.mdx
+++ b/social-plus-sdk/getting-started/platform-setup/mobile/android-quick-start.mdx
@@ -95,6 +95,16 @@ implementation 'com.github.AmityCo:Amity-Social-Cloud-Android-SDK:x.y.z'
 </Tab>
 </Tabs>
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Endpoint | No | Region endpoint such as `AmityEndpoint.US`, `EU`, or `SG`; SG is the default when omitted. |
+| Initialize SDK with encryption | `dbEncryption` | No | Database encryption mode: `NONE`, `AUTH`, or `ALL`. |
+| Initialize SDK with encryption | Encryption key | Required when encryption is enabled | Stable key bytes supplied to the selected database encryption mode. |
+| Build configuration | SDK version | Yes | Android SDK version in the Gradle dependency declaration. |
+
 ## Initialize the SDK
 
 Set up the client with your API key so the SDK is ready for authentication - highly recommended to do this on the application class.

--- a/social-plus-sdk/getting-started/platform-setup/mobile/flutter-quick-start.mdx
+++ b/social-plus-sdk/getting-started/platform-setup/mobile/flutter-quick-start.mdx
@@ -83,6 +83,16 @@ android {
 The Flutter SDK example app uses `minSdkVersion flutter.minSdkVersion` in `example/android/app/build.gradle`; if you override it in your own app, keep the value at 19 or above to match the SDK requirements.
 </Info>
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Install SDK | Package version | Yes | `amity_sdk` version declared in `pubspec.yaml`. |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Endpoint | No | Region endpoint passed through `AmityCoreClientOption` where your app needs a non-default region. |
+| Native project setup | iOS deployment target | Yes | Minimum iOS version in `ios/Podfile`; keep it at 12.0 or above. |
+| Native project setup | Android min SDK | Yes | Android minimum SDK version; keep it at API 19 or above. |
+
 ## Initialize the SDK
 
 Create the client with your API key so the SDK is ready for authentication.

--- a/social-plus-sdk/getting-started/platform-setup/mobile/ios-quick-start.mdx
+++ b/social-plus-sdk/getting-started/platform-setup/mobile/ios-quick-start.mdx
@@ -42,6 +42,17 @@ Get your iOS app connected to social.plus in just a few steps. This guide covers
   </Tab>
 </Tabs>
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Region | Yes | Region passed to `AmityClient`, such as `.US`, `.EU`, or `.SG`. |
+| Objective-C bridge login | `userId` | Yes | Stable user identifier from your identity system. |
+| Objective-C bridge login | `displayName` | No | Display name passed through the Swift bridge. |
+| Objective-C bridge login | `authToken` | Production | Backend-generated auth token passed through the Swift bridge. |
+| Objective-C bridge login | Completion callback | Yes | Callback that reports success or failure back to Objective-C. |
+
 ## Initialize the SDK
 
 Create the client with your API key and region so the SDK is ready for authentication.

--- a/social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx
+++ b/social-plus-sdk/getting-started/platform-setup/web/web-quick-start.mdx
@@ -75,6 +75,14 @@ pnpm add @amityco/ts-sdk
 
 </Tabs>
 
+## Parameters
+
+| Operation | Parameter | Required | Description |
+| --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | Application API key from the social.plus Console. |
+| Initialize SDK | Region | Yes | Region string passed to `Client.createClient`, such as `us`, `eu`, or `sg`. |
+| Initialize SDK | Client options | No | Optional TypeScript client configuration, such as custom endpoints where supported. |
+
 ## Initialize the SDK
 
 Create the client with your API key and region so the SDK is ready for authentication.

--- a/social-plus-sdk/getting-started/visitor-mode.mdx
+++ b/social-plus-sdk/getting-started/visitor-mode.mdx
@@ -156,6 +156,19 @@ Understanding the different user types helps you design the right access pattern
   </Tab>
 </Tabs>
 
+## Parameters
+
+| Operation | Parameter | Required | Platforms | Description |
+| --- | --- | --- | --- | --- |
+| Initialize SDK | API key | Yes | iOS, Android, TypeScript | Application API key from the social.plus Console. |
+| Initialize SDK | Region / endpoint | Yes | iOS, Android, TypeScript | Region where your social.plus application was created. |
+| Get visitor device ID | None | No | iOS, Android, TypeScript | SDK returns or generates the stable anonymous device ID. |
+| Login as visitor | `sessionHandler` | Recommended | iOS, Android, TypeScript | Token-renewal handler for visitor sessions. |
+| Secure visitor login | `authSignature` | Secure mode | iOS, Android, TypeScript | Backend-generated HMAC signature for the visitor device ID and expiration time. |
+| Secure visitor login | `authSignatureExpiresAt` | Secure mode | iOS, Android, TypeScript | Expiration timestamp that was included in the signature. |
+| Login as bot | `sessionHandler` | Recommended | TypeScript | Token-renewal handler for explicit bot sessions. |
+| Check user type | None | No | iOS, Android, TypeScript | SDK returns the current user type so the UI can adjust capabilities. |
+
 ## Quick Start (Visitor Mode)
 
 ### Step 1: Initialize the SDK


### PR DESCRIPTION
## Summary
- Add concise Parameters sections to SDK getting-started overview, authentication, visitor mode, and platform quick-start pages
- Add repository setup Parameters coverage to user identity so every SDK CodeGroup page has a top-level Parameters section
- Refresh llms-full.txt after the SDK docs updates

## Validation
- python3 .docs-ops/ci/check-mdx.py social-plus-sdk
- python3 .docs-ops/ci/check-sdk-style.py social-plus-sdk
- python3 tools/check_internal_links.py social-plus-sdk
- go test ./... (in llmstxt)
- git diff --check
- SDK CodeGroup missing Parameters scan: missing_count=0