### PR TITLE
docs: restore technical FAQ from PR #119

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -63555,129 +63555,341 @@ For individual platforms, ✅ means supported and **—** means not yet supporte
 
 ### [Technical FAQ](https://learn.social.plus/social-plus-sdk/technical-faq)
 
-> Common SDK integration questions for social.plus developers and product teams.
+> Explore our Technical FAQ for quick answers to common questions about social.plus products. Get troubleshooting tips, best practices, and insights to optimize your technical experience.
 
-This FAQ is SDK-first. It summarizes implementation decisions that come up across iOS, Android, TypeScript, and Flutter integrations, then points to the source SDK pages for the exact platform details.
-
-  REST API, UIKit, Console, Portal, and Dashboard behavior are not certified by this SDK FAQ. Use the dedicated docs for those surfaces when your question is not about client SDK integration.
+Central, living knowledge base for developers integrating <strong>social.plus</strong>. Use the quick navigation, browser find (⌘/Ctrl + F), or your docs site search to jump to relevant answers. Each category groups focused, implementation‑level questions gathered from support & community discussions.
 
 ## Quick Navigation
 
-    Installation, API keys, regions, login, and visitor mode.
-    Live objects, live collections, pagination, cleanup, and realtime updates.
-    Posts, comments, media, reactions, mentions, moderation, and feeds.
-    Channels, messages, unread state, receipts, members, and governance.
-    How to read feature support across iOS, Android, TypeScript, and Flutter.
-    Common SDK symptoms and the first checks to run.
+## Using This FAQ
 
-## Setup and Authentication
+Looking for a question that is not here? Use the <strong>Developer Forum</strong> anchor in the SDK navigation to open community discussions or submit a new thread.
 
-    Use the SDK when you need custom UI and app-owned product flows. Choose the platform SDK that matches your app runtime: iOS, Android, TypeScript, or Flutter.
+## API
 
-    See [SDK Overview](/social-plus-sdk/overview) and [Installation & Quick Start](/social-plus-sdk/getting-started/overview).
+    To create a large number of users, use the session registration endpoint: <a href="https://api-docs.amity.co/#/Session/post_api_v4_sessions">Register a session</a>. Script the call over your user list (respecting rate limits) to establish accounts.
+    This question is answered under the <strong>Console</strong> section ("Where can I get my admin token?"). See <a href="#console">Console &raquo; Admin token</a>.
+    API list endpoints return a <code>paging.next</code> token. Pass it back as the <code>options[token]</code> (or documented query param) to fetch the next slice.
+    <br/><br/>
+    Example response:
+```json
+{
+  "paging": { "next": "eyJza2lwIjoyMCwibGltaXQiOjEwfQ==" }
+}
+```
+    Example request:
+    <pre><code>curl --location --globoff 'https://api.sg.amity.co/api/v3/communities?filter=all&sortBy=lastCreated&options[token]=eyJza2lwIjoxMCwibGltaXQiOjEwfQ%3D%3D' \\
+  --header 'accept: application/json' \\
+  --header 'Authorization: Bearer xxx'</code></pre>
+    Use the blocklist records endpoint:
+```bash
+curl --location 'https://api.sg.amity.co/api/v3/blacklist/records' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer xxx' \
+  --data '{
+    "regexs": ["word1", "word2", "word3"],
+    "isMatchExactWord": true
+}'
+```
+    Set <code>isMatchExactWord</code> to <code>true</code> for exact term blocking or <code>false</code> for substring / regex style matches. API Ref: <a href="https://api-docs.amity.co/#/Moderation/post_api_v3_blocklists">Moderation &raquo; Blocklists</a>.
+    Update social network settings via: <a href="https://api-docs.amity.co/#/Network%20Setting/put_api_v3_network_settings_social">PUT /network-settings/social</a>
+```bash
+curl --location --request PUT 'https://api.sg.amity.co/api/v3/network-settings/social' \
+  --header 'accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer xxx' \
+  --data '{"isFollowWithRequestEnabled": false}'
+```
+    Append <code>?size=full</code> to the file download URL. Sizes: <code>small</code> | <code>medium</code> | <code>large</code> | <code>full</code>.
+    <br/>Example: <code>.../files/{fileId}/download?size=full</code>
+    The SDK auto-manages refresh / access tokens. When using raw REST, simply request a new session (register session) instead of manually rotating a refresh token.
+    Auth tokens (secure mode) are valid 10 minutes. See: <a href="https://docs.amity.co/analytics-and-moderation/console/settings/security#secure-mode">Secure Mode docs</a>. Obtain a fresh one server-side when expiring, then call Session create.
+    Filter with <code>filter=member</code> on communities endpoint:
+```bash
+curl --location 'https://apix.sg.amity.co/api/v3/communities?filter=member&sortBy=lastCreated&options[limit]=100' \
+  --header 'accept: application/json' \
+  --header 'Authorization: Bearer xxx'
+```
+    1. Get new auth token:
+```bash
+curl --location 'https://api.sg.amity.co/api/v3/authentication/token?userId=Amity' \
+  --header 'accept: application/json' \
+  --header 'x-server-key: xxx'
+```
+    2. Exchange via Session API:
+```bash
+curl --location 'https://apix.sg.amity.co/api/v4/sessions' \
+  --header 'accept: application/json' \
+  --header 'x-api-key: xxx' \
+  --header 'Content-Type: application/json' \
+  --data '{"userId":"Amity","deviceId":"test","authToken":"xxx"}'
+```
+    Use the Authentication token endpoint then register session. Docs: <a href="https://api-docs.amity.co/#/Authentication/get_api_v3_authentication_token">Authentication</a>. For context see Security page.
+    No direct "my reacted posts" endpoint. Query reactions (<a href="https://api-docs.amity.co/#/Reaction/get_api_v3_reactions">Reactions list</a>) and filter client-side for your <code>userId</code> per target post.
+    Send only the <code>metadata</code> field in a user update body; unspecified fields remain unchanged.
+```bash
+curl --location --request PUT 'https://api.eu.amity.co/api/v2/users' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer xxx' \
+  --data '{"userId":"Test","metadata":{"tier":"gold"}}'
+```
+    Iterate: list posts (community / user feeds) then call delete for each (<a href="https://api-docs.amity.co/#/Post%20v4/delete_api_v4_posts__postId">Delete Post v4</a>). Build an idempotent script with backoff; respect rate limits.
+    Use <a href="https://api-docs.amity.co/#/File/post_api_v4_files">POST /files</a> then attach returned fileId when creating the post/message referencing audio.
+```bash
+curl --location --globoff 'https://apix.sg.amity.co/api/v3/communities/COMMUNITY_ID/users?memberships[]=member&roles[]=moderator&options[limit]=10' \
+  --header 'accept: application/json' \
+  --header 'Authorization: Bearer xxx'
+```
+    Not supported: upload endpoints expect file data (multipart / direct). Fetch remote file server-side then re-upload if needed.
+    Creating a new session with the same <code>deviceId</code> invalidates the old access token. Use stable per-device identifiers; avoid reusing one id across multiple concurrent logins.
+    To receive real-time event notifications, register a webhook by supplying a callback URL in the Social Plus Console. Once registered, the platform will deliver event data via HTTP POST requests to the specified URL whenever supported events occur (e.g., users added to a channel, messages created, users joining, or posts being flagged).
 
-    Initialize the SDK with the API key for your social.plus application and the region where that application was created. Keep production key management aligned with your app security model and avoid committing secrets.
+    Event names follow a structured format, such as:
+    <code>"event": "channel.didAddUsers"</code>
 
-    See [Installation & Quick Start](/social-plus-sdk/getting-started/overview).
+    For the full list of supported webhook events and payload details, refer to the <a href="https://learn.social.plus/api-reference/webhook-event/channel-users-added-webhook">documentation</a>.
+    Our API rate limit is 100 requests per 5 seconds per user (<code>userId</code>).
+    This means the limit is shared across all devices for the same user. For example, if one user is logged in on multiple devices, all requests from those devices are counted together under the same limit.
 
-    The SDK manages its session and access-token lifecycle after login. If secure mode is enabled, your backend provides an auth token and your app supplies a session handler or renewal callback where the platform SDK requires it.
+    If the limit is exceeded, the API will return a rate limit error (e.g., HTTP 429).
 
-    See [Authentication](/social-plus-sdk/getting-started/authentication) and [User Token Management](/social-plus-sdk/core-concepts/user-management/user-operations/user-token-management).
+    To handle high-volume traffic, we recommend implementing throttling, retry with backoff, batching, and caching to ensure smooth and reliable performance.
+    Via Console: Navigate to Moderation → AI Content Moderation and set confidence levels per category.
+    In case you want to autojoin users to a community, we recommend using the "Invitation" API, as you can use your admin token in order to add new users into a community and only incurr in only one MAU.
 
-    Visitor mode is available for read-oriented browsing scenarios where supported. Use it only for screens that do not need authenticated actions such as posting, reacting, joining, or messaging.
+***
 
-    See [Visitor Mode](/social-plus-sdk/getting-started/visitor-mode).
+## Social and Chat
 
-## Data Loading and Realtime
+    <p><code>targetType</code> identifies feed scope (<code>user</code> | <code>community</code>); <code>targetId</code> is the userId or communityId. Together they scope post queries. See SDK docs: https://docs.amity.co/amity-sdk/social/posts/query-post</p>
+    Engagement-based sort is only available on global feed. Community feeds support <code>lastCreated</code> and <code>firstCreated</code> ordering. Docs: https://docs.amity.co/amity-sdk/social/posts/query-post
+    API: add <code>isDeleted=false</code> param.
+```bash
+curl --location 'https://api.sg.amity.co/api/v3/communities?filter=all&isDeleted=false' \
+  --header 'accept: application/json' \
+  --header 'Authorization: Bearer xxx'
+```
+    SDK: set <code>includeDeleted</code> (or <code>includeDelete</code>) flag false. Docs: https://docs.amity.co/amity-sdk/social/communities/query-communities
+    Only the current authenticated user can list their joined communities (<code>filter=member</code>). Privacy prevents enumerating others' memberships.
+```bash
+curl --location 'https://api.sg.amity.co/api/v3/communities?filter=member' \
+  --header 'accept: application/json' \
+  --header 'Authorization: Bearer xxx'
+```
+    Standard page size is 20. Use <code>paging.next</code> (API) or <code>nextPage()</code> (SDK live collections) to iterate. See Live Objects & Collections docs.
+    API (Add roles):
+```bash
+curl --location 'https://api.sg.amity.co/api/v4/communities/COMMUNITY_ID/users/roles' \
+  --header 'accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer xxx' \
+  --data '{"roles":["community-moderator"],"userIds":["test"]}'
+```
+    Console path: Community > Members > (⋮) beside user > Change user role.
+    <img src=".gitbook/assets/Screenshot 2566-12-21 at 22.53.59.png" alt="Change user role screenshot" data-size="original" />
+    Use SDK moderation APIs or <a href="https://api-docs.amity.co/#/Community/delete_api_v3_communities__communityId__users">Delete community users</a> endpoint.
+    Delete via API (<a href="https://api-docs.amity.co/#/Community/delete_api_v3_communities__communityId_">delete community</a>) or close in Console: Communities > select > Settings > Close Community.
+    <img src=".gitbook/assets/Screenshot 2566-12-21 at 15.59.45.png" alt="Close community screenshot" data-size="original" />
+    Auto-join starter communities immediately after user creation (call Join Community API) so their feed contains initial posts.
+    Lightweight extensible key/value storage for custom attributes (e.g. user tier). Not for large blobs or high-write analytics fields.
+    User has no joined communities and follows no users. Ensure onboarding joins at least one community or recommends follows.
+    Formats: JPG, PNG. Max size: 1 GB. Up to 10 images per post. UIKit v4 auto-converts unsupported formats (e.g. HEIC) client-side.
+    Formats: 3gp, avi, f4v, flv, m4v, mov, mp4, ogv, 3g2, wmv, vob, webm, mkv. Max 1 GB, ≤ 2 hours, ≤ 10 videos/post. HEVC/HDR converted in UIKit v4.
+    Provide only auth token to SDK during login; SDK handles session/access token internally. Docs: user creation page.
+    Global feed may use custom ranking (engagement, freshness blend). Contact support to adjust configuration. See Custom Post Ranking docs.
+    Call <code>queryCommunities(&#123; filter: 'membership' &#125;)</code>. Docs: /social/communities/query-communities.
+    Construct download URL: <code>https://api.{region}.amity.co/api/v3/files/{fileId}</code>. Retrieve fileId from message/post objects via SDK.
+    Customize RecentChat component: on mount select first channel when list populated (example previously shown) to avoid blank panel.
+    Use conversation channel creation endpoint in idempotent mode (or SDK convenience) which returns existing if already present.
+    Append repeated <code>tags[]=</code> query params.
+```bash
+curl --location --globoff 'https://api.sg.amity.co/api/v4/posts?targetId=COMMUNITY_ID&targetType=community&sortBy=lastCreated&tags[]=tag1&tags[]=tag2' \
+  --header 'accept: application/json' \
+  --header 'Authorization: Bearer xxx'
+```
+    Not supported; comments are fetched by post. Store needed mappings externally if user-centric aggregation required.
+    Configure who can join and what they can do.<br/>
+    First, set your community or network membership mode (open, request/approval, or invite‑only) so users either join freely or require approval/invites.<br/>
+    Then, define role types (e.g. admin, moderator, member, guest) and assign them to users to control permissions like posting, moderating, and managing settings.<br/>
+    Review these settings regularly to match your business rules and compliance needs.
+    AI is used to evaluate the livestream going on and based on the defined confidence levels, if the content is considered as not adequate it will be automatically terminated. More details about how our AI Livestream moderation works can be found <a href="https://learn.social.plus/analytics-and-moderation/console/moderation/livestream-moderation#livestream-moderation ">here</a>.
+    Yes, you can search for chat messages by calling the following <a href="https://api.docs.social.plus/#tag/message/get/api/v2/search/messages">API</a>. At the same time, we do have this feature available in our Flutter SDK.
 
-    A live object tracks one entity, such as a post, user, channel, message, community, or room. A live collection tracks a list, such as posts, comments, messages, members, followers, reactions, rooms, or notifications.
+***
 
-    See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview).
+## UIKits and SDKs
 
-    Most list reads return a paged live collection or platform paging type. Render the current data, check whether a next page exists, and call the platform-specific next-page API when the user scrolls or requests more.
+    Ensure ALL of:
+    <ul>
+      <li>Production APNs cert or key uploaded (Sandbox & Production) and not expired</li>
+      <li>App capability: Push Notifications enabled</li>
+      <li>Correct <code>app_id</code> matches certificate</li>
+      <li>Running on real device (not simulator) and production/TestFlight build when testing prod cert</li>
+      <li>User granted notification permission & device not in Do Not Disturb / Focus</li>
+      <li>APNs key also uploaded to Firebase if using FCM bridge (<a href="https://firebase.google.com/docs/cloud-messaging/ios/client#upload_your_apns_authentication_key">docs</a>)</li>
+    </ul>
+    Docs: certificate setup & register/unregister pages.
+    Not supported. Ship with bundled Realm version aligned to SDK. See iOS SDK & UIKit changelogs for compatibility matrix.
+    Upload APNs (.p12 or key) selecting "Apple Push Notification service SSL (Sandbox & Production)" so a single cert covers both.
+    Not recommended / unsupported. Use a package manager (npm, Yarn, pnpm) for versioned SDK distribution.
+    Use blocked users list query. Docs: /social/block-and-unblock-user#blocked-users-list.
+    Call SDK mark-read API or start/stop reading subchannel utilities (unread-count docs). Ensures backend updates unread counters.
+    Poll post type not yet supported in current Flutter SDK (only video/image/file). Track changelog for availability.
+    The SDK provides two methods:<br/>
+        •        Search Users — Find users by displayName (min 3 characters), ranked by relevance<br/>
+        •        Query Users — Retrieve users with sorting (displayName, firstCreated, lastCreated)<br/>
 
-    See the live collection guide for your platform and the relevant query page, such as [Query Posts](/social-plus-sdk/social/content-management/posts/retrieval/query-posts), [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments), or [Query Messages](/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages).
+    <a href="https://learn.social.plus/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users">Full documentation</a>
+    1. Create keys/certs in Apple Developer
+      * In Apple Developer account, create an APNs Auth Key (.p8) with Push Notifications enabled.
+      * Note the Key ID, Team ID, and download the .p8 file.
+    2. Configure your backend / Social+ console
+        * Go to your project’s Notifications → Apple (iOS) page.
+        * Upload the .p8 file, fill in Key ID, Team ID, and Bundle ID, then click Activate.
+    3. Enable push in Xcode
+        * Open your app target → Signing & Capabilities.
+        * Add Push Notifications and (if needed) Background Modes → Remote notifications.
+        * Make sure you use a provisioning profile that includes push.
+    4. Request permission and get APNs token
+        * In your app, ask for notification permission on first launch (UNUserNotificationCenter).
+        * Implement application(_:didRegisterForRemoteNotificationsWithDeviceToken:) to get the APNs device token.
+    5. Register token with your SDK
+        * Native iOS: pass the APNs token via `client.registerPushNotification(withDeviceToken:)` (iOS SDK API — not available in the TypeScript SDK).
+        * React Native: pass the token as `fcmToken={apnsToken}` to `AmityUiKitProvider`; `@amityco/ts-sdk` does not expose a client-side push registration API.
+    6.  Test real production push notifications.<br/>
+        * Install a TestFlight (release) build on a physical iPhone (push notifications are not supported on simulators).
+        * Trigger a real notification from your production backend or console, and verify that it is successfully delivered and displayed on the device.
+    Metadata in posts and comments is an optional Object field for storing additional custom properties. To configure it correctly:
 
-    Live objects and collections observe SDK-managed state. Some SDKs or features also require explicit realtime topic subscription for cross-device updates. Follow the platform-specific realtime guide instead of assuming one subscription model across every SDK.
+    Pass metadata as a JSON object (e.g; "key": "value") when creating or updating posts/comments.
+    Metadata patching is allowed for all post types via the patch <a href="https://learn.social.plus/api-reference/post/patch-post-data-and-metadata"> post data and metadata API</a> using set/delete operations.
+    There is no strict schema, it accepts arbitrary key-value pairs for your custom needs.
+    The Social plus Portal is your organization-level management platform where you create and manage applications, handle billing, and control team access. Each application lives in its own Console, where you configure settings, moderate content, manage users, and grab your API key for integration.
+    iOS (UIKit):
 
-    See [Realtime Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview).
+    * Add AmitySDK and AmityUIKit4 via Swift Package Manager in Xcode.
 
-    Clean up the platform-native subscription handle: unsubscribe callbacks in TypeScript, invalidate notification tokens in iOS, dispose Rx subscriptions or cancel coroutine collectors in Android, and cancel streams or dispose live collections in Flutter.
+    * Link to your app target and initialize in AppDelegate.
 
-    See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview).
+    Android (UIKit):
 
-## Social Content
+    * Add Amity SDK and UIKit dependencies in your Gradle files.
 
-    `targetType` selects the feed scope, usually a user feed or community feed. `targetId` identifies the user or community that owns the feed. Use the post creation page for the post type you are building.
+    * Initialize SDK in your Application class.
+    Visitor Secure Mode is also available for UIKit. We will publish documentation about this soon. In the meantime, please contact us if you would like to use it.
+    Currently our stories feature is based on communities, which means that user can create stories but they need to be directed to a specific community. <br/>
+    More details about our story features can be found <a href="https://learn.social.plus/social-plus-sdk/social/content-management/stories/overview">here</a>.
+    The SocialPlus SDK supports real-time updates through its built-in real-time event system. This system maintains persistent connectivity to deliver live updates such as new posts, comments, reactions, notifications, and membership changes. If you are using the SDK directly, developers subscribe to the relevant real-time event topics (for example communities, posts, comments, or user updates). Once subscribed, the SDK automatically keeps the observed objects and collections synchronized. If you are using UIKit, this real-time functionality is already integrated for the supported features, so no additional implementation is required.<br/>
+    More details about the real-time event model can be found <a href="https://learn.social.plus/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview">here</a>.
+    Our open soure UIKits are fully customisable, so you can change any part of them. You can select between multiple components and based on them get the right version you are looking for. The idea of these UIKits is to help you accelerate implementation, making it easir to have our features available.
 
-    See [Posts Overview](/social-plus-sdk/social/content-management/posts/overview).
+***
 
-    Match the SDK post type to the content you are creating: text, image, video, file, audio, clip, poll, room, live stream, custom, or mixed media. Platform support is not identical, so read the platform notes on the specific page.
+## Poll
 
-    See [Content Management](/social-plus-sdk/social/content-management/overview).
+    Call Get Poll Answer endpoint to retrieve voters (userIds) for specific answerId. Ref: API docs.
+    Not supported: create either a poll OR other attachment types, not combined.
+    Not directly. Use Portal: My Dashboard > Posts and filter type=Poll. (Console UI lacks poll list.)
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 13.49.24.png" alt="Poll posts screenshot" data-size="original" />
 
-    Upload or obtain the media/file object first where the SDK requires it, then pass the resulting file, file ID, URI, or platform-specific media data into the post or message creation API.
+***
 
-    See [File Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file), [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling), and [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling).
+## Console
 
-    No. The shared product concepts are similar, but each SDK exposes native method names, builders, return types, and support gaps. Use the platform-specific snippets and notes on each page.
+    Console: Settings &gt; Admin Users &gt; (cog icon). Screenshot below.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 14.50.43 1.png" alt="Admin token screenshot" data-size="original" />
+    Admin user creates others: Settings &gt; Admin Users &gt; Create New Admin (top right) then share credentials securely.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 14.56.55.png" alt="Create admin screenshot" data-size="original" />
+    Only portal owner initially. Use "+ Add new certificate" button in Push Notification section.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 15.13.36.png" alt="Add certificate screenshot" data-size="original" />
+    User option fetches user feed posts only; not a cross-community aggregation by userId.
+    Console: Settings &gt; Security tab shows API key and region endpoint.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 15.15.33.png" alt="Security tab screenshot" data-size="original" />
+    Performed by super admin; user-level self-service not provided.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 11.53.57.png" alt="Password change screenshot" data-size="original" />
+    Hidden by design (privacy / noise). See Channel Characteristics docs for rationale.
+    Only one active push certificate per platform allowed simultaneously.
 
-    See [Comments Overview](/social-plus-sdk/social/content-management/comments/overview), [Reactions](/social-plus-sdk/core-concepts/content-handling/reactions), [Mentions](/social-plus-sdk/core-concepts/content-handling/mentions), and [Content Flagging](/social-plus-sdk/social/content-management/moderation/content-flagging).
+***
 
-## Chat
+## Portal
 
-    Chat is organized around channels, members, messages, and unread or receipt state. Channel and message APIs are platform-specific, so start with the chat overview and then use the exact page for the operation you need.
+    Portal: Create Application button (top right). Use distinct apps per environment to isolate data & config.
+    <img src=".gitbook/assets/Screenshot 2566-12-08 at 18.13.22.png" alt="Create application screenshot" data-size="original" />
+    In-place upgrade unavailable; create new application with desired plan, migrate, then retire old one.
+    Portal: Manage Payment tab &gt; update Organization Name.
+    <img src=".gitbook/assets/Screenshot 2567-09-24 at 15.16.06.png" alt="Manage payment screenshot" data-size="original" />
+    The Social+ Portal does not support deleting applications once created, an app remains in your list permanently. You can only rename existing apps to keep things organized, and if you're nearing the 50-app cap, contact support to request a limit increase.
 
-    See [Chat Overview](/social-plus-sdk/chat/overview).
+***
 
-    Create or retrieve the target channel, then use the message creation page for the message type you need. Text, image, file, video, audio, custom, and reply flows have separate platform notes.
+## Alternative solutions for unsupported features
 
-    See [Messaging Features](/social-plus-sdk/chat/messaging-features/overview).
+    Store array of postIds in user metadata (e.g. <code>favorites</code>). On profile render, fetch posts by those IDs.
+    Add <code>metadata.verified=true</code> (or role) on user; frontend displays badge based on flag.
+    New post with metadata.originalPostID referencing source. On display, fetch original, render nested.
+    Subscribe to webhook (post flagged) then trigger email via external service. See Real-time Events & WebhookEvent docs.
+    Store pinned postId in community metadata (e.g. <code>pinPostID</code>) and prepend when rendering feed if present.
+    UI hide non-admin button (weak) OR enforce via Pre-Hook Event (Max package) to reject non-admin create attempts.
+    Client filter after fetching OR use search/posts (beta) filtering by type then show results.
+    Capture duration client-side after record; store in message metadata; display using stored value.
+    Use Search Post API with <code>postedUserId</code> param (beta feature) to filter.
+    GIF upload is <a href="https://learn.social.plus/social-plus-sdk/technical-faq#gif-support">not</a> natively supported by Social plus currently. As a workaround, GIFs can be uploaded via the Upload File API, and clients can customize the UI rendering on their end to display them.
 
-    Use the SDK unread and receipt APIs instead of deriving state only from local UI. Read, delivered, and receipt-sync surfaces differ by platform and by channel/subchannel concept.
+***
 
-    See [Unread Status](/social-plus-sdk/chat/engagement-features/unread-status/overview).
+## Beta features
 
-    Channel join/leave, member queries, preview members, roles, bans, and mutes live under conversation management. Treat these as SDK operations, while app policy decides who is allowed to see or trigger each action.
+    Use webhook events backend -> push service to send notifications (posts/comments). Reference WebhookEvent list.
+    Only indexes posts created after feature enablement; earlier posts excluded.
+    Include <code>hashtagList</code> in content search query.
+```json
+{
+  "hashtagList": ["#tags1", "#tags2", "#tags3"]
+}
+```
+    Subscribe to follow create / follow request webhooks, then dispatch notification to target user.
 
-    See [Conversation Management](/social-plus-sdk/chat/conversation-management/overview).
+***
 
-## Platform Differences
+## Frequent error types: Definition
 
-    Use snippets as platform-specific examples, not as cross-platform contracts. The same capability may use callbacks in TypeScript, async or live objects in iOS, Rx or Paging in Android, and Dart streams or builders in Flutter.
+    Occurs when SDK calls made before session established. Wait until session state == <code>established</code> (listen to session state changes) before repository operations.
+    Use the <code>paging.next</code> (or previous) token from prior response. Do not reuse stale/modified tokens.
+    Queue actions until login promise resolves; avoid concurrent login + API operations.
+    More than 100 calls per user within 5s. Debounce, batch, or add exponential backoff; remove accidental loops.
+    Triggered by image moderation threshold. Adjust confidence level or disable temporarily in Settings &gt; Image Moderation.
+    Link moderation allow list enforced. Add domain to Allow list or disable link moderation.
 
-    Check the platform notes on the feature page and the platform changelog. If a page says a feature is not exposed on a platform, do not build against an inferred method name.
+***
 
-    See [SDK Changelogs](/social-plus-sdk/changelogs/android-sdk-changelog).
+## General
 
-    Ask the assistant to cite the exact SDK page and platform before generating code. It should not infer missing SDK APIs from another platform or from REST API documentation.
+    Permanent. Delete user API cannot be undone.
+    Iterate list of users meeting inactivity criteria then call DELETE user API (example with flags). Irreversible.
+    User cannot authenticate; removed from channels; messages deleted (cache may persist until refresh); social content intact.
+    Per active WebSocket/tab. Background/inactive tabs may auto-disconnect reducing CCU.
+    No native dark theme; customize via open-source UIKit theming.
+    Contact support (support.asc@amity.co) to remove.
+    Registered but no connections in the month being measured (historic register date irrelevant).
+    Social: https://www.amity.co/social/uikit#figma  | Chat: https://www.amity.co/chat/uikit#figma
+    Achieved via multiple applications; strict data isolation per app.
+    Not supported; must upload through Social Plus SDK/API to store & moderate.
+    Not exposed; metrics available per application (Dashboard/Console). Use Portal Dashboard Guide for details.
+    Backend stores plain text (security). Implement client-side markup (e.g. markdown) and render safely.
+    GIF upload not supported currently.
+    You can extract at any point your data by calling our APIs:<a href="https://api.docs.social.plus/#description/using-social-apis.">#description/using-social-apis</a>.<br/>
+    In case you want some built-in reports that contain some of the most recent data and metrics, you can call our 1st party data API: <a href="https://api.docs.social.plus/#tag/admin/get/api/v1/reports/1p/download.">#tag/admin/get/api/v1/reports/1p/download.</a> <br/>
+    To see further detail, please access here: <a href="https://learn.social.plus/api-reference/admin/get-first-party-data-export#get-first-party-data-export">#get-first-party-data-export</a>
+    We recommend keeping your SDK/UIKit updated to the latest version whenever possible. However, if you are not encountering any bugs or do not require new features that are supported by new version of SDK/UIKit, an immediate update may not be strictly necessary.
 
-## Troubleshooting
+***
 
-| Symptom | First checks |
-| --- | --- |
-| Login fails | Confirm API key, region, user ID, secure-mode token flow, and session handler behavior. |
-| A list never loads more | Check the live collection or paging API for next-page availability and lifecycle cleanup. |
-| UI does not update after another device changes data | Confirm realtime subscription requirements for the platform and feature. |
-| A post or message type is missing | Verify platform support on the exact creation page and changelog before assuming parity. |
-| Media creation fails | Confirm upload step, returned file or media type, size/format requirements, and platform-specific attachment builder. |
-| Unread counts look stale | Use SDK read/delivered/receipt-sync APIs and verify channel or subchannel scope. |
+## Dashboard
 
-## Escalation Checklist
-
-When the docs do not answer your issue, open a forum or support thread with:
-
-- SDK platform and version
-- App platform version and runtime
-- Region
-- Feature page you followed
-- Minimal code shape or operation sequence
-- Expected result and actual result
-- Error codes, timestamps, and safe entity IDs where available
-- Whether the same issue reproduces after a clean login/session renewal
-
-    Ask an implementation question with enough context for others to reproduce or reason about it.
-    Check service health before treating a runtime issue as an SDK integration bug.
+    Users who view content without active engagement (posting/commenting/reactions).
+    Dashboard &gt; Channels section &gt; "New Messages by Day" widget.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 12.19.36.png" alt="New messages widget screenshot" data-size="original" />
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -405,7 +405,7 @@
 - [Home](https://learn.social.plus/index): Welcome to the social.plus documentation
 - [social.plus SDK](https://learn.social.plus/social-plus-sdk/overview): Build custom social, chat, and supported video experiences with the social.plus SDK
 - [Feature Matrix](https://learn.social.plus/feature-matrix): Feature availability and platform support across SDK and UIKit.
-- [Technical FAQ](https://learn.social.plus/social-plus-sdk/technical-faq): Common SDK integration questions for social.plus developers and product teams.
+- [Technical FAQ](https://learn.social.plus/social-plus-sdk/technical-faq): Explore our Technical FAQ for quick answers to common questions about social.plus products. Get troubleshooting tips, best practices, and insights to optimize your technical experience.
 - [Developer Forum](https://learn.social.plus/social-plus-sdk/developer-forum): Use the social.plus Developer Forum and support resources when SDK docs do not answer your integration question.
 - [Chat Data Model Reference](https://learn.social.plus/api-reference/chat-data-model): Core chat and messaging entities, fields, relationships, and data import guidance for engineers working with the social.plus API
 - [Social Data Model Reference](https://learn.social.plus/api-reference/social-data-model): Core social entities, fields, relationships, polymorphic patterns, and data import guidance for engineers working with the social.plus API

--- a/social-plus-sdk/technical-faq.mdx
+++ b/social-plus-sdk/technical-faq.mdx
@@ -1,196 +1,612 @@
 ---
 title: "Technical FAQ"
-description: "Common SDK integration questions for social.plus developers and product teams."
+description: "Explore our Technical FAQ for quick answers to common questions about social.plus products. Get troubleshooting tips, best practices, and insights to optimize your technical experience."
 ---
 
-This FAQ is SDK-first. It summarizes implementation decisions that come up across iOS, Android, TypeScript, and Flutter integrations, then points to the source SDK pages for the exact platform details.
-
-<Note>
-  REST API, UIKit, Console, Portal, and Dashboard behavior are not certified by this SDK FAQ. Use the dedicated docs for those surfaces when your question is not about client SDK integration.
-</Note>
+<Info>
+Central, living knowledge base for developers integrating <strong>social.plus</strong>. Use the quick navigation, browser find (⌘/Ctrl + F), or your docs site search to jump to relevant answers. Each category groups focused, implementation‑level questions gathered from support & community discussions.
+</Info>
 
 ## Quick Navigation
-
-<CardGroup cols={2}>
-  <Card title="Setup" icon="download" href="#setup-and-authentication">
-    Installation, API keys, regions, login, and visitor mode.
-  </Card>
-  <Card title="Data Loading" icon="arrows-rotate" href="#data-loading-and-realtime">
-    Live objects, live collections, pagination, cleanup, and realtime updates.
-  </Card>
-  <Card title="Social Content" icon="newspaper" href="#social-content">
-    Posts, comments, media, reactions, mentions, moderation, and feeds.
-  </Card>
-  <Card title="Chat" icon="comments" href="#chat">
-    Channels, messages, unread state, receipts, members, and governance.
-  </Card>
-  <Card title="Platform Gaps" icon="layer-group" href="#platform-differences">
-    How to read feature support across iOS, Android, TypeScript, and Flutter.
-  </Card>
-  <Card title="Troubleshooting" icon="triangle-exclamation" href="#troubleshooting">
-    Common SDK symptoms and the first checks to run.
-  </Card>
+<CardGroup cols={3}>
+  <Card title="API" icon="network-wired" href="#api">Authentication • Pagination • Bulk Ops • Moderation</Card>
+  <Card title="Social & Chat" icon="comments" href="#social-and-chat">Feeds • Communities • Roles • Media</Card>
+  <Card title="UIKits & SDKs" icon="mobile-screen" href="#sdks">Platforms • Push • Blocking • Feature Gaps</Card>
+  <Card title="Poll" icon="square-poll-vertical" href="#poll">Creation • Limits • Retrieval</Card>
+  <Card title="Console" icon="gauge" href="#console">Admin • Certificates • Access • Limits</Card>
+  <Card title="Portal" icon="layer-group" href="#portal">Environments • Plans • Org Data</Card>
+  <Card title="Alt Solutions" icon="lightbulb" href="#alternative-solutions-for-unsupported-features">Workarounds & Patterns</Card>
+  <Card title="Beta Features" icon="flask" href="#beta-features">Realtime • Search • Webhooks</Card>
+  <Card title="Errors" icon="triangle-exclamation" href="#frequent-error-types-definition">Common Failures & Fixes</Card>
+  <Card title="General" icon="circle-info" href="#general">Accounts • Theming • Multi‑tenant</Card>
+  <Card title="Dashboard" icon="chart-line" href="#dashboard">Metrics • Definitions</Card>
 </CardGroup>
 
-## Setup and Authentication
+## Using This FAQ
+<Steps>
+  <Step title="Scan Categories">Skim the Quick Navigation cards to locate a domain (e.g. Errors vs API).</Step>
+  <Step title="Deep Link">Copy the URL after clicking a section heading to share precise context with teammates.</Step>
+  <Step title="Validate Versions">For SDK questions, confirm your SDK / UIKit versions vs latest changelogs before implementing a workaround.</Step>
+  <Step title="Escalate Gaps">If an answer points to a workaround, log a feature request in the Developer Forum with context (scale, impact, timeline).</Step>
+  <Step title="Contribute Back">Found a nuance or edge case? Propose an edit so the knowledge stays current.</Step>
+</Steps>
+
+<Tip>
+Looking for a question that is not here? Use the <strong>Developer Forum</strong> anchor in the SDK navigation to open community discussions or submit a new thread.
+</Tip>
+
+## API
 
 <AccordionGroup>
-  <Accordion title="Which SDK should I start with?">
-    Use the SDK when you need custom UI and app-owned product flows. Choose the platform SDK that matches your app runtime: iOS, Android, TypeScript, or Flutter.
-
-    See [SDK Overview](/social-plus-sdk/overview) and [Installation & Quick Start](/social-plus-sdk/getting-started/overview).
+  <Accordion title="Create users in bulk">
+    To create a large number of users, use the session registration endpoint: <a href="https://api-docs.amity.co/#/Session/post_api_v4_sessions">Register a session</a>. Script the call over your user list (respecting rate limits) to establish accounts.
   </Accordion>
-
-  <Accordion title="Where do API key and region fit?">
-    Initialize the SDK with the API key for your social.plus application and the region where that application was created. Keep production key management aligned with your app security model and avoid committing secrets.
-
-    See [Installation & Quick Start](/social-plus-sdk/getting-started/overview).
+  <Accordion title="Admin Authorization token">
+    This question is answered under the <strong>Console</strong> section ("Where can I get my admin token?"). See <a href="#console">Console &raquo; Admin token</a>.
   </Accordion>
-
-  <Accordion title="Do SDK apps manage access tokens directly?">
-    The SDK manages its session and access-token lifecycle after login. If secure mode is enabled, your backend provides an auth token and your app supplies a session handler or renewal callback where the platform SDK requires it.
-
-    See [Authentication](/social-plus-sdk/getting-started/authentication) and [User Token Management](/social-plus-sdk/core-concepts/user-management/user-operations/user-token-management).
+  <Accordion title="Pagination (next page token)">
+    API list endpoints return a <code>paging.next</code> token. Pass it back as the <code>options[token]</code> (or documented query param) to fetch the next slice.
+    <br/><br/>
+    Example response:
+    ```json
+    {
+      "paging": { "next": "eyJza2lwIjoyMCwibGltaXQiOjEwfQ==" }
+    }
+    ```
+    Example request:
+    <pre><code>curl --location --globoff 'https://api.sg.amity.co/api/v3/communities?filter=all&sortBy=lastCreated&options[token]=eyJza2lwIjoxMCwibGltaXQiOjEwfQ%3D%3D' \\
+  --header 'accept: application/json' \\
+  --header 'Authorization: Bearer xxx'</code></pre>
   </Accordion>
+  <Accordion title="Bulk upload blocklisted words">
+    Use the blocklist records endpoint:
+    ```bash
+    curl --location 'https://api.sg.amity.co/api/v3/blacklist/records' \
+      --header 'Content-Type: application/json' \
+      --header 'Authorization: Bearer xxx' \
+      --data '{
+        "regexs": ["word1", "word2", "word3"],
+        "isMatchExactWord": true
+    }'
+    ```
+    Set <code>isMatchExactWord</code> to <code>true</code> for exact term blocking or <code>false</code> for substring / regex style matches. API Ref: <a href="https://api-docs.amity.co/#/Moderation/post_api_v3_blocklists">Moderation &raquo; Blocklists</a>.
+  </Accordion>
+  <Accordion title="Configure follow / unfollow mode">
+    Update social network settings via: <a href="https://api-docs.amity.co/#/Network%20Setting/put_api_v3_network_settings_social">PUT /network-settings/social</a>
+    ```bash
+    curl --location --request PUT 'https://api.sg.amity.co/api/v3/network-settings/social' \
+      --header 'accept: application/json' \
+      --header 'Content-Type: application/json' \
+      --header 'Authorization: Bearer xxx' \
+      --data '{"isFollowWithRequestEnabled": false}'
+    ```
+  </Accordion>
+  <Accordion title="Request higher-quality images">
+    Append <code>?size=full</code> to the file download URL. Sizes: <code>small</code> | <code>medium</code> | <code>large</code> | <code>full</code>.
+    <br/>Example: <code>.../files/{fileId}/download?size=full</code>
+  </Accordion>
+  <Accordion title="refreshToken vs accessToken">
+    The SDK auto-manages refresh / access tokens. When using raw REST, simply request a new session (register session) instead of manually rotating a refresh token.
+  </Accordion>
+  <Accordion title="Authentication token lifetime">
+    Auth tokens (secure mode) are valid 10 minutes. See: <a href="https://docs.amity.co/analytics-and-moderation/console/settings/security#secure-mode">Secure Mode docs</a>. Obtain a fresh one server-side when expiring, then call Session create.
+  </Accordion>
+  <Accordion title="List communities I've joined (API)">
+    Filter with <code>filter=member</code> on communities endpoint:
+    ```bash
+    curl --location 'https://apix.sg.amity.co/api/v3/communities?filter=member&sortBy=lastCreated&options[limit]=100' \
+      --header 'accept: application/json' \
+      --header 'Authorization: Bearer xxx'
+    ```
+  </Accordion>
+  <Accordion title="Renew expired authentication token">
+    1. Get new auth token:
+    ```bash
+    curl --location 'https://api.sg.amity.co/api/v3/authentication/token?userId=Amity' \
+      --header 'accept: application/json' \
+      --header 'x-server-key: xxx'
+    ```
+    2. Exchange via Session API:
+    ```bash
+    curl --location 'https://apix.sg.amity.co/api/v4/sessions' \
+      --header 'accept: application/json' \
+      --header 'x-api-key: xxx' \
+      --header 'Content-Type: application/json' \
+      --data '{"userId":"Amity","deviceId":"test","authToken":"xxx"}'
+    ```
+  </Accordion>
+  <Accordion title="Obtain an authentication token (secure mode)">
+    Use the Authentication token endpoint then register session. Docs: <a href="https://api-docs.amity.co/#/Authentication/get_api_v3_authentication_token">Authentication</a>. For context see Security page.
+  </Accordion>
+  <Accordion title="Find posts I reacted to">
+    No direct "my reacted posts" endpoint. Query reactions (<a href="https://api-docs.amity.co/#/Reaction/get_api_v3_reactions">Reactions list</a>) and filter client-side for your <code>userId</code> per target post.
+  </Accordion>
+  <Accordion title="Update only user metadata">
+    Send only the <code>metadata</code> field in a user update body; unspecified fields remain unchanged.
+    ```bash
+    curl --location --request PUT 'https://api.eu.amity.co/api/v2/users' \
+      --header 'Content-Type: application/json' \
+      --header 'Authorization: Bearer xxx' \
+      --data '{"userId":"Test","metadata":{"tier":"gold"}}'
+    ```
+  </Accordion>
+  <Accordion title="Delete ALL posts (bulk)">
+    Iterate: list posts (community / user feeds) then call delete for each (<a href="https://api-docs.amity.co/#/Post%20v4/delete_api_v4_posts__postId">Delete Post v4</a>). Build an idempotent script with backoff; respect rate limits.
+  </Accordion>
+  <Accordion title="Upload audio files">
+    Use <a href="https://api-docs.amity.co/#/File/post_api_v4_files">POST /files</a> then attach returned fileId when creating the post/message referencing audio.
+  </Accordion>
+  <Accordion title="List users by role in a community">
+    ```bash
+    curl --location --globoff 'https://apix.sg.amity.co/api/v3/communities/COMMUNITY_ID/users?memberships[]=member&roles[]=moderator&options[limit]=10' \
+      --header 'accept: application/json' \
+      --header 'Authorization: Bearer xxx'
+    ```
+  </Accordion>
+  <Accordion title="Upload from URL?">
+    Not supported: upload endpoints expect file data (multipart / direct). Fetch remote file server-side then re-upload if needed.
+  </Accordion>
+  <Accordion title="Access token invalidated early">
+    Creating a new session with the same <code>deviceId</code> invalidates the old access token. Use stable per-device identifiers; avoid reusing one id across multiple concurrent logins.
+  </Accordion>
+  <Accordion title="How do we configure webhook events correctly for our backend integration?">
+    To receive real-time event notifications, register a webhook by supplying a callback URL in the Social Plus Console. Once registered, the platform will deliver event data via HTTP POST requests to the specified URL whenever supported events occur (e.g., users added to a channel, messages created, users joining, or posts being flagged).
 
-  <Accordion title="Can users browse without logging in?">
-    Visitor mode is available for read-oriented browsing scenarios where supported. Use it only for screens that do not need authenticated actions such as posting, reacting, joining, or messaging.
+    Event names follow a structured format, such as:
+    <code>"event": "channel.didAddUsers"</code>
 
-    See [Visitor Mode](/social-plus-sdk/getting-started/visitor-mode).
+    For the full list of supported webhook events and payload details, refer to the <a href="https://learn.social.plus/api-reference/webhook-event/channel-users-added-webhook">documentation</a>.
+  </Accordion>
+  <Accordion title="How do we configure rate limits or handle high-volume API requests?">
+    Our API rate limit is 100 requests per 5 seconds per user (<code>userId</code>).
+    This means the limit is shared across all devices for the same user. For example, if one user is logged in on multiple devices, all requests from those devices are counted together under the same limit.
+
+    If the limit is exceeded, the API will return a rate limit error (e.g., HTTP 429).
+
+    To handle high-volume traffic, we recommend implementing throttling, retry with backoff, batching, and caching to ensure smooth and reliable performance.
+  </Accordion>
+  <Accordion title="How do we configure AI Moderation confidence levels?">
+    Via Console: Navigate to Moderation → AI Content Moderation and set confidence levels per category.
+  </Accordion>
+  <Accordion title="What is the recommended approach for autojoining users: using the v4/communities/{communityId}/join endpoint or the Invitation API section?">
+    In case you want to autojoin users to a community, we recommend using the "Invitation" API, as you can use your admin token in order to add new users into a community and only incurr in only one MAU. 
   </Accordion>
 </AccordionGroup>
 
-## Data Loading and Realtime
+***
+
+## Social and Chat
 
 <AccordionGroup>
-  <Accordion title="What is the difference between a live object and a live collection?">
-    A live object tracks one entity, such as a post, user, channel, message, community, or room. A live collection tracks a list, such as posts, comments, messages, members, followers, reactions, rooms, or notifications.
-
-    See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview).
+  <Accordion title="targetType & targetId purpose">
+    <p><code>targetType</code> identifies feed scope (<code>user</code> | <code>community</code>); <code>targetId</code> is the userId or communityId. Together they scope post queries. See SDK docs: https://docs.amity.co/amity-sdk/social/posts/query-post</p>
   </Accordion>
-
-  <Accordion title="Why do I only see the first page of results?">
-    Most list reads return a paged live collection or platform paging type. Render the current data, check whether a next page exists, and call the platform-specific next-page API when the user scrolls or requests more.
-
-    See the live collection guide for your platform and the relevant query page, such as [Query Posts](/social-plus-sdk/social/content-management/posts/retrieval/query-posts), [Query Comments](/social-plus-sdk/social/content-management/comments/retrieval/query-comments), or [Query Messages](/social-plus-sdk/chat/messaging-features/messages/query-and-filter-messages).
+  <Accordion title="Sort community posts by engagement?">
+    Engagement-based sort is only available on global feed. Community feeds support <code>lastCreated</code> and <code>firstCreated</code> ordering. Docs: https://docs.amity.co/amity-sdk/social/posts/query-post
   </Accordion>
-
-  <Accordion title="Do live objects automatically mean cross-device realtime?">
-    Live objects and collections observe SDK-managed state. Some SDKs or features also require explicit realtime topic subscription for cross-device updates. Follow the platform-specific realtime guide instead of assuming one subscription model across every SDK.
-
-    See [Realtime Events](/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview).
+  <Accordion title="Exclude deleted communities">
+    API: add <code>isDeleted=false</code> param.
+    ```bash
+    curl --location 'https://api.sg.amity.co/api/v3/communities?filter=all&isDeleted=false' \
+      --header 'accept: application/json' \
+      --header 'Authorization: Bearer xxx'
+    ```
+    SDK: set <code>includeDeleted</code> (or <code>includeDelete</code>) flag false. Docs: https://docs.amity.co/amity-sdk/social/communities/query-communities
   </Accordion>
-
-  <Accordion title="What should I clean up when a screen is closed?">
-    Clean up the platform-native subscription handle: unsubscribe callbacks in TypeScript, invalidate notification tokens in iOS, dispose Rx subscriptions or cancel coroutine collectors in Android, and cancel streams or dispose live collections in Flutter.
-
-    See [Live Objects & Collections](/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview).
+  <Accordion title="Check which communities a user joined">
+    Only the current authenticated user can list their joined communities (<code>filter=member</code>). Privacy prevents enumerating others' memberships.
+    ```bash
+    curl --location 'https://api.sg.amity.co/api/v3/communities?filter=member' \
+      --header 'accept: application/json' \
+      --header 'Authorization: Bearer xxx'
+    ```
+  </Accordion>
+  <Accordion title="Why only 20 items returned?">
+    Standard page size is 20. Use <code>paging.next</code> (API) or <code>nextPage()</code> (SDK live collections) to iterate. See Live Objects & Collections docs.
+  </Accordion>
+  <Accordion title="Update community user role">
+    API (Add roles):
+    ```bash
+    curl --location 'https://api.sg.amity.co/api/v4/communities/COMMUNITY_ID/users/roles' \
+      --header 'accept: application/json' \
+      --header 'Content-Type: application/json' \
+      --header 'Authorization: Bearer xxx' \
+      --data '{"roles":["community-moderator"],"userIds":["test"]}'
+    ```
+    Console path: Community > Members > (⋮) beside user > Change user role.
+    <img src=".gitbook/assets/Screenshot 2566-12-21 at 22.53.59.png" alt="Change user role screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Remove community members">
+    Use SDK moderation APIs or <a href="https://api-docs.amity.co/#/Community/delete_api_v3_communities__communityId__users">Delete community users</a> endpoint.
+  </Accordion>
+  <Accordion title="Delete / close a community">
+    Delete via API (<a href="https://api-docs.amity.co/#/Community/delete_api_v3_communities__communityId_">delete community</a>) or close in Console: Communities > select > Settings > Close Community.
+    <img src=".gitbook/assets/Screenshot 2566-12-21 at 15.59.45.png" alt="Close community screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Pre-populate global feed for new users">
+    Auto-join starter communities immediately after user creation (call Join Community API) so their feed contains initial posts.
+  </Accordion>
+  <Accordion title="Metadata purpose">
+    Lightweight extensible key/value storage for custom attributes (e.g. user tier). Not for large blobs or high-write analytics fields.
+  </Accordion>
+  <Accordion title="Empty global feed explanation">
+    User has no joined communities and follows no users. Ensure onboarding joins at least one community or recommends follows.
+  </Accordion>
+  <Accordion title="Image upload requirements">
+    Formats: JPG, PNG. Max size: 1 GB. Up to 10 images per post. UIKit v4 auto-converts unsupported formats (e.g. HEIC) client-side.
+  </Accordion>
+  <Accordion title="Video upload requirements">
+    Formats: 3gp, avi, f4v, flv, m4v, mov, mp4, ogv, 3g2, wmv, vob, webm, mkv. Max 1 GB, ≤ 2 hours, ≤ 10 videos/post. HEVC/HDR converted in UIKit v4.
+  </Accordion>
+  <Accordion title="Do I need access token when using SDK secure mode?">
+    Provide only auth token to SDK during login; SDK handles session/access token internally. Docs: user creation page.
+  </Accordion>
+  <Accordion title="Global feed not sorted by newest">
+    Global feed may use custom ranking (engagement, freshness blend). Contact support to adjust configuration. See Custom Post Ranking docs.
+  </Accordion>
+  <Accordion title="List joined communities via SDK">
+    Call <code>queryCommunities(&#123; filter: 'membership' &#125;)</code>. Docs: /social/communities/query-communities.
+  </Accordion>
+  <Accordion title="Implement file download feature">
+    Construct download URL: <code>https://api.{region}.amity.co/api/v3/files/{fileId}</code>. Retrieve fileId from message/post objects via SDK.
+  </Accordion>
+  <Accordion title="Auto-open first chat channel in Web UIKit">
+    Customize RecentChat component: on mount select first channel when list populated (example previously shown) to avoid blank panel.
+  </Accordion>
+  <Accordion title="Check if conversation channel exists between users">
+    Use conversation channel creation endpoint in idempotent mode (or SDK convenience) which returns existing if already present.
+  </Accordion>
+  <Accordion title="Query posts by tags[]">
+    Append repeated <code>tags[]=</code> query params.
+    ```bash
+    curl --location --globoff 'https://api.sg.amity.co/api/v4/posts?targetId=COMMUNITY_ID&targetType=community&sortBy=lastCreated&tags[]=tag1&tags[]=tag2' \
+      --header 'accept: application/json' \
+      --header 'Authorization: Bearer xxx'
+    ```
+  </Accordion>
+  <Accordion title="Query comments by user ID?">
+    Not supported; comments are fetched by post. Store needed mappings externally if user-centric aggregation required.
+  </Accordion>
+  <Accordion title="How do we properly configure community membership or user access roles?">
+    Configure who can join and what they can do.<br/>
+    First, set your community or network membership mode (open, request/approval, or invite‑only) so users either join freely or require approval/invites.<br/>
+    Then, define role types (e.g. admin, moderator, member, guest) and assign them to users to control permissions like posting, moderating, and managing settings.<br/>
+    Review these settings regularly to match your business rules and compliance needs.
+  </Accordion>
+  <Accordion title="How does Livestream AI moderation works?">
+    AI is used to evaluate the livestream going on and based on the defined confidence levels, if the content is considered as not adequate it will be automatically terminated. More details about how our AI Livestream moderation works can be found <a href="https://learn.social.plus/analytics-and-moderation/console/moderation/livestream-moderation#livestream-moderation ">here</a>.
+  </Accordion>
+  <Accordion title="Can we search messages within a specific chat/channel?">
+    Yes, you can search for chat messages by calling the following <a href="https://api.docs.social.plus/#tag/message/get/api/v2/search/messages">API</a>. At the same time, we do have this feature available in our Flutter SDK.
   </Accordion>
 </AccordionGroup>
 
-## Social Content
+***
+
+## UIKits and SDKs
 
 <AccordionGroup>
-  <Accordion title="What do targetType and targetId mean for posts?">
-    `targetType` selects the feed scope, usually a user feed or community feed. `targetId` identifies the user or community that owns the feed. Use the post creation page for the post type you are building.
-
-    See [Posts Overview](/social-plus-sdk/social/content-management/posts/overview).
+  <Accordion title="iOS push not working (checklist)">
+    Ensure ALL of:
+    <ul>
+      <li>Production APNs cert or key uploaded (Sandbox & Production) and not expired</li>
+      <li>App capability: Push Notifications enabled</li>
+      <li>Correct <code>app_id</code> matches certificate</li>
+      <li>Running on real device (not simulator) and production/TestFlight build when testing prod cert</li>
+      <li>User granted notification permission & device not in Do Not Disturb / Focus</li>
+      <li>APNs key also uploaded to Firebase if using FCM bridge (<a href="https://firebase.google.com/docs/cloud-messaging/ios/client#upload_your_apns_authentication_key">docs</a>)</li>
+    </ul>
+    Docs: certificate setup & register/unregister pages.
   </Accordion>
-
-  <Accordion title="How should I choose a post creation page?">
-    Match the SDK post type to the content you are creating: text, image, video, file, audio, clip, poll, room, live stream, custom, or mixed media. Platform support is not identical, so read the platform notes on the specific page.
-
-    See [Content Management](/social-plus-sdk/social/content-management/overview).
+  <Accordion title="Use my own Realm (iOS)?">
+    Not supported. Ship with bundled Realm version aligned to SDK. See iOS SDK & UIKit changelogs for compatibility matrix.
   </Accordion>
-
-  <Accordion title="How do media uploads fit into post and message creation?">
-    Upload or obtain the media/file object first where the SDK requires it, then pass the resulting file, file ID, URI, or platform-specific media data into the post or message creation API.
-
-    See [File Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/file), [Image Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/image-handling), and [Video Handling](/social-plus-sdk/core-concepts/content-handling/files-images-and-videos/video-handling).
+  <Accordion title="Which iOS certificate type for push?">
+    Upload APNs (.p12 or key) selecting "Apple Push Notification service SSL (Sandbox & Production)" so a single cert covers both.
   </Accordion>
+  <Accordion title="TypeScript via CDN only?">
+    Not recommended / unsupported. Use a package manager (npm, Yarn, pnpm) for versioned SDK distribution.
+  </Accordion>
+  <Accordion title="Check if I blocked a user">
+    Use blocked users list query. Docs: /social/block-and-unblock-user#blocked-users-list.
+  </Accordion>
+  <Accordion title="Mark message as read">
+    Call SDK mark-read API or start/stop reading subchannel utilities (unread-count docs). Ensures backend updates unread counters.
+  </Accordion>
+  <Accordion title="Flutter: retrieve poll posts">
+    Poll post type not yet supported in current Flutter SDK (only video/image/file). Track changelog for availability.
+  </Accordion>
+  <Accordion title="How do we query users correctly using the SDK?">
+    The SDK provides two methods:<br/>
+        •        Search Users — Find users by displayName (min 3 characters), ranked by relevance<br/>
+        •        Query Users — Retrieve users with sorting (displayName, firstCreated, lastCreated)<br/>
 
-  <Accordion title="Can I assume comments, reactions, mentions, and moderation work the same on every platform?">
-    No. The shared product concepts are similar, but each SDK exposes native method names, builders, return types, and support gaps. Use the platform-specific snippets and notes on each page.
+    <a href="https://learn.social.plus/social-plus-sdk/core-concepts/user-management/user-operations/search-and-query-users">Full documentation</a>
+  </Accordion>
+  <Accordion title="How should we properly set up push notifications in iOS?">
+    1. Create keys/certs in Apple Developer
+      * In Apple Developer account, create an APNs Auth Key (.p8) with Push Notifications enabled.
+      * Note the Key ID, Team ID, and download the .p8 file.
+    2. Configure your backend / Social+ console
+        * Go to your project’s Notifications → Apple (iOS) page.
+        * Upload the .p8 file, fill in Key ID, Team ID, and Bundle ID, then click Activate.
+    3. Enable push in Xcode
+        * Open your app target → Signing & Capabilities.
+        * Add Push Notifications and (if needed) Background Modes → Remote notifications.
+        * Make sure you use a provisioning profile that includes push.
+    4. Request permission and get APNs token
+        * In your app, ask for notification permission on first launch (UNUserNotificationCenter).
+        * Implement application(_:didRegisterForRemoteNotificationsWithDeviceToken:) to get the APNs device token.
+    5. Register token with your SDK
+        * Native iOS: pass the APNs token via `client.registerPushNotification(withDeviceToken:)` (iOS SDK API — not available in the TypeScript SDK).
+        * React Native: pass the token as `fcmToken={apnsToken}` to `AmityUiKitProvider`; `@amityco/ts-sdk` does not expose a client-side push registration API.
+    6.  Test real production push notifications.<br/>
+        * Install a TestFlight (release) build on a physical iPhone (push notifications are not supported on simulators).
+        * Trigger a real notification from your production backend or console, and verify that it is successfully delivered and displayed on the device.
+      </Accordion>
+  <Accordion title="How do we correctly configure metadata structure in posts or comments?">
+    Metadata in posts and comments is an optional Object field for storing additional custom properties. To configure it correctly:
 
-    See [Comments Overview](/social-plus-sdk/social/content-management/comments/overview), [Reactions](/social-plus-sdk/core-concepts/content-handling/reactions), [Mentions](/social-plus-sdk/core-concepts/content-handling/mentions), and [Content Flagging](/social-plus-sdk/social/content-management/moderation/content-flagging).
+    Pass metadata as a JSON object (e.g; "key": "value") when creating or updating posts/comments.
+    Metadata patching is allowed for all post types via the patch <a href="https://learn.social.plus/api-reference/post/patch-post-data-and-metadata"> post data and metadata API</a> using set/delete operations.
+    There is no strict schema, it accepts arbitrary key-value pairs for your custom needs.
+  </Accordion>
+  <Accordion title="How do we access or initialize Social+ correctly in our environment?">
+    The Social plus Portal is your organization-level management platform where you create and manage applications, handle billing, and control team access. Each application lives in its own Console, where you configure settings, moderate content, manage users, and grab your API key for integration. 
+  </Accordion>
+  <Accordion title="How do we properly install and configure UIKit dependencies for iOS/Android?">
+    iOS (UIKit):
+
+    * Add AmitySDK and AmityUIKit4 via Swift Package Manager in Xcode.
+
+    * Link to your app target and initialize in AppDelegate.
+
+    Android (UIKit):
+
+    * Add Amity SDK and UIKit dependencies in your Gradle files.
+
+    * Initialize SDK in your Application class.
+  </Accordion>
+  <Accordion title="Does UIKit allow visitors to use Secure Mode?">
+    Visitor Secure Mode is also available for UIKit. We will publish documentation about this soon. In the meantime, please contact us if you would like to use it.
+  </Accordion>
+  <Accordion title="The SDK and UIKit support stories associated directly with individual users (user-specific stories)?">
+    Currently our stories feature is based on communities, which means that user can create stories but they need to be directed to a specific community. <br/>
+    More details about our story features can be found <a href="https://learn.social.plus/social-plus-sdk/social/content-management/stories/overview">here</a>.
+  </Accordion>
+  <Accordion title="Does the SDK require persistent connections or WebSocket infrastructure?">
+    The SocialPlus SDK supports real-time updates through its built-in real-time event system. This system maintains persistent connectivity to deliver live updates such as new posts, comments, reactions, notifications, and membership changes. If you are using the SDK directly, developers subscribe to the relevant real-time event topics (for example communities, posts, comments, or user updates). Once subscribed, the SDK automatically keeps the observed objects and collections synchronized. If you are using UIKit, this real-time functionality is already integrated for the supported features, so no additional implementation is required.<br/>
+    More details about the real-time event model can be found <a href="https://learn.social.plus/social-plus-sdk/core-concepts/realtime-communication/realtime-events/overview">here</a>.
+  </Accordion>
+  <Accordion title="How customizable is your open source UIKit?">
+    Our open soure UIKits are fully customisable, so you can change any part of them. You can select between multiple components and based on them get the right version you are looking for. The idea of these UIKits is to help you accelerate implementation, making it easir to have our features available.
   </Accordion>
 </AccordionGroup>
 
-## Chat
+***
+
+## Poll
 
 <AccordionGroup>
-  <Accordion title="What is the main chat data model?">
-    Chat is organized around channels, members, messages, and unread or receipt state. Channel and message APIs are platform-specific, so start with the chat overview and then use the exact page for the operation you need.
-
-    See [Chat Overview](/social-plus-sdk/chat/overview).
+  <Accordion title="List voters for a poll answer">
+    Call Get Poll Answer endpoint to retrieve voters (userIds) for specific answerId. Ref: API docs.
   </Accordion>
-
-  <Accordion title="How do I create and send messages?">
-    Create or retrieve the target channel, then use the message creation page for the message type you need. Text, image, file, video, audio, custom, and reply flows have separate platform notes.
-
-    See [Messaging Features](/social-plus-sdk/chat/messaging-features/overview).
+  <Accordion title="Poll plus other attachment?">
+    Not supported: create either a poll OR other attachment types, not combined.
   </Accordion>
-
-  <Accordion title="How should unread counts and read receipts be handled?">
-    Use the SDK unread and receipt APIs instead of deriving state only from local UI. Read, delivered, and receipt-sync surfaces differ by platform and by channel/subchannel concept.
-
-    See [Unread Status](/social-plus-sdk/chat/engagement-features/unread-status/overview).
-  </Accordion>
-
-  <Accordion title="Where do channel membership and governance actions live?">
-    Channel join/leave, member queries, preview members, roles, bans, and mutes live under conversation management. Treat these as SDK operations, while app policy decides who is allowed to see or trigger each action.
-
-    See [Conversation Management](/social-plus-sdk/chat/conversation-management/overview).
+  <Accordion title="View my polls in console?">
+    Not directly. Use Portal: My Dashboard > Posts and filter type=Poll. (Console UI lacks poll list.)
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 13.49.24.png" alt="Poll posts screenshot" data-size="original" />
   </Accordion>
 </AccordionGroup>
 
-## Platform Differences
+***
+
+## Console
 
 <AccordionGroup>
-  <Accordion title="Can I copy a snippet from one platform to another?">
-    Use snippets as platform-specific examples, not as cross-platform contracts. The same capability may use callbacks in TypeScript, async or live objects in iOS, Rx or Paging in Android, and Dart streams or builders in Flutter.
+  <Accordion title="Find admin token">
+    Console: Settings &gt; Admin Users &gt; (cog icon). Screenshot below.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 14.50.43 1.png" alt="Admin token screenshot" data-size="original" />
   </Accordion>
-
-  <Accordion title="How do I know whether a feature exists on my SDK?">
-    Check the platform notes on the feature page and the platform changelog. If a page says a feature is not exposed on a platform, do not build against an inferred method name.
-
-    See [SDK Changelogs](/social-plus-sdk/changelogs/android-sdk-changelog).
+  <Accordion title="Grant console access">
+    Admin user creates others: Settings &gt; Admin Users &gt; Create New Admin (top right) then share credentials securely.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 14.56.55.png" alt="Create admin screenshot" data-size="original" />
   </Accordion>
-
-  <Accordion title="How should AI assistants use these docs?">
-    Ask the assistant to cite the exact SDK page and platform before generating code. It should not infer missing SDK APIs from another platform or from REST API documentation.
+  <Accordion title="Upload first PNS certificate">
+    Only portal owner initially. Use "+ Add new certificate" button in Push Notification section.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 15.13.36.png" alt="Add certificate screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Can't retrieve community posts via User option">
+    User option fetches user feed posts only; not a cross-community aggregation by userId.
+  </Accordion>
+  <Accordion title="Locate API key & region">
+    Console: Settings &gt; Security tab shows API key and region endpoint.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 15.15.33.png" alt="Security tab screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Change console password">
+    Performed by super admin; user-level self-service not provided.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 11.53.57.png" alt="Password change screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Why no conversation channels in console?">
+    Hidden by design (privacy / noise). See Channel Characteristics docs for rationale.
+  </Accordion>
+  <Accordion title="Multiple push certs per platform?">
+    Only one active push certificate per platform allowed simultaneously.
   </Accordion>
 </AccordionGroup>
 
-## Troubleshooting
+***
 
-| Symptom | First checks |
-| --- | --- |
-| Login fails | Confirm API key, region, user ID, secure-mode token flow, and session handler behavior. |
-| A list never loads more | Check the live collection or paging API for next-page availability and lifecycle cleanup. |
-| UI does not update after another device changes data | Confirm realtime subscription requirements for the platform and feature. |
-| A post or message type is missing | Verify platform support on the exact creation page and changelog before assuming parity. |
-| Media creation fails | Confirm upload step, returned file or media type, size/format requirements, and platform-specific attachment builder. |
-| Unread counts look stale | Use SDK read/delivered/receipt-sync APIs and verify channel or subchannel scope. |
+## Portal
 
-## Escalation Checklist
+<AccordionGroup>
+  <Accordion title="Create separate environments (test/prod)">
+    Portal: Create Application button (top right). Use distinct apps per environment to isolate data & config.
+    <img src=".gitbook/assets/Screenshot 2566-12-08 at 18.13.22.png" alt="Create application screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="Upgrade pricing plan">
+    In-place upgrade unavailable; create new application with desired plan, migrate, then retire old one.
+  </Accordion>
+  <Accordion title="Change organization name for invoices">
+    Portal: Manage Payment tab &gt; update Organization Name.
+    <img src=".gitbook/assets/Screenshot 2567-09-24 at 15.16.06.png" alt="Manage payment screenshot" data-size="original" />
+  </Accordion>
+  <Accordion title="How do we manage or delete stuck/inactive applications via Portal?">
+    The Social+ Portal does not support deleting applications once created, an app remains in your list permanently. You can only rename existing apps to keep things organized, and if you're nearing the 50-app cap, contact support to request a limit increase.
+  </Accordion>
+</AccordionGroup>
 
-When the docs do not answer your issue, open a forum or support thread with:
+***
 
-- SDK platform and version
-- App platform version and runtime
-- Region
-- Feature page you followed
-- Minimal code shape or operation sequence
-- Expected result and actual result
-- Error codes, timestamps, and safe entity IDs where available
-- Whether the same issue reproduces after a clean login/session renewal
+## Alternative solutions for unsupported features
 
-<CardGroup cols={2}>
-  <Card title="Developer Forum" icon="comments" href="/social-plus-sdk/developer-forum">
-    Ask an implementation question with enough context for others to reproduce or reason about it.
-  </Card>
-  <Card title="Status Page" icon="signal" href="https://status.social.plus/">
-    Check service health before treating a runtime issue as an SDK integration bug.
-  </Card>
-</CardGroup>
+<AccordionGroup>
+  <Accordion title="Save favourite posts">
+    Store array of postIds in user metadata (e.g. <code>favorites</code>). On profile render, fetch posts by those IDs.
+  </Accordion>
+  <Accordion title="Verified badge implementation">
+    Add <code>metadata.verified=true</code> (or role) on user; frontend displays badge based on flag.
+  </Accordion>
+  <Accordion title="Post sharing pattern">
+    New post with metadata.originalPostID referencing source. On display, fetch original, render nested.
+  </Accordion>
+  <Accordion title="Email notification on flagged post">
+    Subscribe to webhook (post flagged) then trigger email via external service. See Real-time Events & WebhookEvent docs.
+  </Accordion>
+  <Accordion title="Pin a post workaround (pre UIKit support)">
+    Store pinned postId in community metadata (e.g. <code>pinPostID</code>) and prepend when rendering feed if present.
+  </Accordion>
+  <Accordion title="Restrict channel creation to admins">
+    UI hide non-admin button (weak) OR enforce via Pre-Hook Event (Max package) to reject non-admin create attempts.
+  </Accordion>
+  <Accordion title="Filter only video posts in global feed">
+    Client filter after fetching OR use search/posts (beta) filtering by type then show results.
+  </Accordion>
+  <Accordion title="Audio message duration shows 00:00">
+    Capture duration client-side after record; store in message metadata; display using stored value.
+  </Accordion>
+  <Accordion title="Retrieve community posts by userId">
+    Use Search Post API with <code>postedUserId</code> param (beta feature) to filter.
+  </Accordion>
+  <Accordion title="To update GIF implementation guidelines ">
+    GIF upload is <a href="https://learn.social.plus/social-plus-sdk/technical-faq#gif-support">not</a> natively supported by Social plus currently. As a workaround, GIFs can be uploaded via the Upload File API, and clients can customize the UI rendering on their end to display them.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Beta features
+
+<AccordionGroup>
+  <Accordion title="Web React push notifications">
+    Use webhook events backend -> push service to send notifications (posts/comments). Reference WebhookEvent list.
+  </Accordion>
+  <Accordion title="Content search returns fewer posts">
+    Only indexes posts created after feature enablement; earlier posts excluded.
+  </Accordion>
+  <Accordion title="Search posts by hashtags">
+    Include <code>hashtagList</code> in content search query.
+    ```json
+    {
+      "hashtagList": ["#tags1", "#tags2", "#tags3"]
+    }
+    ```
+  </Accordion>
+  <Accordion title="Notify user on new follower">
+    Subscribe to follow create / follow request webhooks, then dispatch notification to target user.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Frequent error types: Definition
+
+<AccordionGroup>
+  <Accordion title="Error: Connect client first">
+    Occurs when SDK calls made before session established. Wait until session state == <code>established</code> (listen to session state changes) before repository operations.
+  </Accordion>
+  <Accordion title="Query Token is invalid">
+    Use the <code>paging.next</code> (or previous) token from prior response. Do not reuse stale/modified tokens.
+  </Accordion>
+  <Accordion title="Unable to use SDK while logging in">
+    Queue actions until login promise resolves; avoid concurrent login + API operations.
+  </Accordion>
+  <Accordion title="RateLimit Exceed / 400311">
+    More than 100 calls per user within 5s. Debounce, batch, or add exponential backoff; remove accidental loops.
+  </Accordion>
+  <Accordion title="Image post error 400314">
+    Triggered by image moderation threshold. Adjust confidence level or disable temporarily in Settings &gt; Image Moderation.
+  </Accordion>
+  <Accordion title="Link post blocked 400309">
+    Link moderation allow list enforced. Add domain to Allow list or disable link moderation.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## General
+
+<AccordionGroup>
+  <Accordion title="Restore deleted user?">
+    Permanent. Delete user API cannot be undone.
+  </Accordion>
+  <Accordion title="Delete inactive users">
+    Iterate list of users meeting inactivity criteria then call DELETE user API (example with flags). Irreversible.
+  </Accordion>
+  <Accordion title="Global ban effects">
+    User cannot authenticate; removed from channels; messages deleted (cache may persist until refresh); social content intact.
+  </Accordion>
+  <Accordion title="Counting concurrent connections (CCU)">
+    Per active WebSocket/tab. Background/inactive tabs may auto-disconnect reducing CCU.
+  </Accordion>
+  <Accordion title="Dark theme availability">
+    No native dark theme; customize via open-source UIKit theming.
+  </Accordion>
+  <Accordion title="Delete unused application">
+    Contact support (support.asc@amity.co) to remove.
+  </Accordion>
+  <Accordion title="Definition: inactive user">
+    Registered but no connections in the month being measured (historic register date irrelevant).
+  </Accordion>
+  <Accordion title="Download Figma files">
+    Social: https://www.amity.co/social/uikit#figma  | Chat: https://www.amity.co/chat/uikit#figma
+  </Accordion>
+  <Accordion title="Multi-tenant architecture">
+    Achieved via multiple applications; strict data isolation per app.
+  </Accordion>
+  <Accordion title="External backend for file uploads?">
+    Not supported; must upload through Social Plus SDK/API to store & moderate.
+  </Accordion>
+  <Accordion title="Account-wide metrics across apps">
+    Not exposed; metrics available per application (Dashboard/Console). Use Portal Dashboard Guide for details.
+  </Accordion>
+  <Accordion title="Include HTML formatting tags in posts/messages">
+    Backend stores plain text (security). Implement client-side markup (e.g. markdown) and render safely.
+  </Accordion>
+  <Accordion title="GIF support">
+    GIF upload not supported currently.
+  </Accordion>
+  <Accordion title="How can I get reports of the data in my SocialPlus environment?">
+    You can extract at any point your data by calling our APIs:<a href="https://api.docs.social.plus/#description/using-social-apis.">#description/using-social-apis</a>.<br/>
+    In case you want some built-in reports that contain some of the most recent data and metrics, you can call our 1st party data API: <a href="https://api.docs.social.plus/#tag/admin/get/api/v1/reports/1p/download.">#tag/admin/get/api/v1/reports/1p/download.</a> <br/>
+    To see further detail, please access here: <a href="https://learn.social.plus/api-reference/admin/get-first-party-data-export#get-first-party-data-export">#get-first-party-data-export</a>  
+  </Accordion>
+  <Accordion title="How often do we need to update the UIKit/SDK?">
+    We recommend keeping your SDK/UIKit updated to the latest version whenever possible. However, if you are not encountering any bugs or do not require new features that are supported by new version of SDK/UIKit, an immediate update may not be strictly necessary.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Dashboard
+
+<AccordionGroup>
+  <Accordion title="Lurking users definition">
+    Users who view content without active engagement (posting/commenting/reactions).
+  </Accordion>
+  <Accordion title="Conversation metrics location">
+    Dashboard &gt; Channels section &gt; "New Messages by Day" widget.
+    <img src=".gitbook/assets/Screenshot 2567-03-22 at 12.19.36.png" alt="New messages widget screenshot" data-size="original" />
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## Summary
- restore the broader `social-plus-sdk/technical-faq.mdx` content that originally landed in PR #119
- preserve the later June 4 push-registration clarification while bringing back the broader FAQ structure
- regenerate `llms.txt` and `llms-full.txt` so the checked-in AI docs outputs stay in sync

## Context
The broad Technical FAQ from PR #119 was later narrowed by the June 22, 2026 rewrite in `ab1d9aa6` (`Audit SDK root utility docs`). This PR restores that earlier FAQ surface on top of current `main` without touching unrelated docs work.

## Validation
- `go run ./cmd/main.go`
- `python3 tools/check_internal_links.py`
