### PR TITLE
docs: cover for you feed, bidirectional block, chat v4, and shareable event links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -175,7 +175,8 @@
                     "group": "Blocking",
                     "pages": [
                       "social-plus-sdk/social/user-relationship/blocking/block-unblock-user",
-                      "social-plus-sdk/social/user-relationship/blocking/manage-blocked-users"
+                      "social-plus-sdk/social/user-relationship/blocking/manage-blocked-users",
+                      "social-plus-sdk/social/user-relationship/blocking/manage-blocking-users"
                     ]
                   }
                 ]

--- a/feature-matrix.mdx
+++ b/feature-matrix.mdx
@@ -53,7 +53,7 @@ For individual platforms, ✅ means supported and **—** means not yet supporte
 | Feature | Availability | Android | iOS | TS | Flutter |
 | :--- | :---: | :---: | :---: | :---: | :---: |
 | Following (Global) Feeds | Available | ✅ | ✅ | ✅ | ✅ |
-| For You Feeds | Planned | ✅ | ✅ | ✅ | — |
+| For You Feeds | Available | ✅ | ✅ | ✅ | — |
 | Community Feeds | Available | ✅ | ✅ | ✅ | ✅ |
 | User Feeds | Available | ✅ | ✅ | ✅ | ✅ |
 | Story Feeds | Available | ✅ | ✅ | ✅ | ✅ |
@@ -67,7 +67,7 @@ For individual platforms, ✅ means supported and **—** means not yet supporte
 | Feature | Availability | Android | iOS | Web | RN | Flutter |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
 | Following (Global) Feeds | Available | ✅ | ✅ | ✅ | ✅ | ✅ |
-| For You Feeds | Planned | ✅ | ✅ | ✅ | — | — |
+| For You Feeds | Available | ✅ | ✅ | ✅ | — | — |
 | Community Feeds | Available | ✅ | ✅ | ✅ | ✅ | ✅ |
 | User Feeds | Available | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Story Feeds | Available | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/social-plus-sdk/core-concepts/foundation/logging.mdx
+++ b/social-plus-sdk/core-concepts/foundation/logging.mdx
@@ -148,6 +148,7 @@ if (error is AmityException) {
 | Visitor usage limit exceeded | `Amity.ServerError.VISITOR_USAGE_LIMIT_EXCEEDED` | `.visitorUsageLimitExceeded` | `AmityError.VISITOR_USAGE_LIMIT_EXCEEDED` | Not exposed as a public Flutter SDK enum in the current source |
 | Visitor permission denied | `Amity.ServerError.VISITOR_PERMISSION_DENIED` | `.visitorPermissionDenied` | `AmityError.VISITOR_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
 | Bot permission denied | `Amity.ServerError.BOT_PERMISSION_DENIED` | `.botPermissionDenied` | `AmityError.BOT_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
+| Max blocked users reached | `Amity.ServerError.MAX_BLOCKED_USERS_REACHED` (`400324`) | Refer to platform SDK | Refer to platform SDK | Refer to platform SDK |
 | Connection error | `Amity.ClientError.CONNECTION_ERROR` | `.connectionError` | `AmityError.CONNECTION_ERROR` | `AmityError.CONNECTION_ERROR` |
 
 ## Production Checklist

--- a/social-plus-sdk/core-concepts/foundation/logging.mdx
+++ b/social-plus-sdk/core-concepts/foundation/logging.mdx
@@ -148,7 +148,7 @@ if (error is AmityException) {
 | Visitor usage limit exceeded | `Amity.ServerError.VISITOR_USAGE_LIMIT_EXCEEDED` | `.visitorUsageLimitExceeded` | `AmityError.VISITOR_USAGE_LIMIT_EXCEEDED` | Not exposed as a public Flutter SDK enum in the current source |
 | Visitor permission denied | `Amity.ServerError.VISITOR_PERMISSION_DENIED` | `.visitorPermissionDenied` | `AmityError.VISITOR_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
 | Bot permission denied | `Amity.ServerError.BOT_PERMISSION_DENIED` | `.botPermissionDenied` | `AmityError.BOT_PERMISSION_DENIED` | Not exposed as a public Flutter SDK enum in the current source |
-| Max blocked users reached | `Amity.ServerError.MAX_BLOCKED_USERS_REACHED` (`400324`) | Refer to platform SDK | Refer to platform SDK | Refer to platform SDK |
+| Max blocked users reached | `Amity.ServerError.MAX_BLOCKED_USERS_REACHED` (`400324`) | Refer to platform SDK | `AmityError.MAX_BLOCKED_USERS_REACHED` | Refer to platform SDK |
 | Connection error | `Amity.ClientError.CONNECTION_ERROR` | `.connectionError` | `AmityError.CONNECTION_ERROR` | `AmityError.CONNECTION_ERROR` |
 
 ## Production Checklist

--- a/social-plus-sdk/social/README.mdx
+++ b/social-plus-sdk/social/README.mdx
@@ -48,7 +48,7 @@ Use the social.plus SDK Social Module to add posts, comments, communities, react
   
   <Accordion title="Content Discovery" icon="magnifying-glass">
     **Feeds, search, and browsing**
-    - **Feeds**: Query user, community, and global feeds
+    - **Feeds**: Query user, community, global, and For You (personalized) feeds
     - **Global Feed Ranking**: Use chronological ordering or configured custom post ranking where enabled
     - **Community Search**: Query communities by keyword, category, tags, membership filter, and sort order
     - **Enhanced Search**: Intelligent Search has separate setup and activation requirements in the Discovery & Engagement docs
@@ -128,7 +128,7 @@ Use the social.plus SDK Social Module to add posts, comments, communities, react
     <CardGroup cols={2}>
       <Card title="Feed & Discovery" icon="rss" href="/social-plus-sdk/social/discovery-engagement/feed/overview">
         Feed and timeline query APIs
-        - **Feed Types**: Global, user, and community feeds
+        - **Feed Types**: Global, For You (personalized), user, and community feeds
         - **Ranking**: Chronological ordering and configured custom post ranking
         - **Content Filtering**: Hide unwanted content and filter by tags, and keywords
         - **Performance Optimization**: Efficient pagination and caching strategies
@@ -164,7 +164,7 @@ Use the social.plus SDK Social Module to add posts, comments, communities, react
     1. **Setup Content Creation**: Implement post creation with [Posts](/social-plus-sdk/social/content-management/posts/overview)
     2. **Enable Discussions**: Add comment functionality with [Comments](/social-plus-sdk/social/content-management/comments/overview)
     3. **Add Engagement**: Implement reactions with [Reactions](/social-plus-sdk/core-concepts/content-handling/reactions)
-    4. **Create Feeds**: Query user, community, and global feeds with [Feed](/social-plus-sdk/social/discovery-engagement/feed/overview)
+    4. **Create Feeds**: Query user, community, global, and For You (personalized) feeds with [Feed](/social-plus-sdk/social/discovery-engagement/feed/overview)
     5. **Enable Notifications**: Setup [Notification System](/social-plus-sdk/social/discovery-engagement/notifications/overview)
     
     **Optional Enhancements**: Stories, user following, and search

--- a/social-plus-sdk/social/content-management/content-sharing.mdx
+++ b/social-plus-sdk/social/content-management/content-sharing.mdx
@@ -85,6 +85,58 @@ AmityCoreClient.getShareableLinkConfiguration()
 
 </CodeGroup>
 
+## Generate an Event Link
+
+Event links are the primary use case for shareable links: an app can copy or share a direct link to an event detail screen. Gate the share UI on `isEnabled` first, then generate the link — `generateLink` returns `null` when the event pattern is not configured.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { AmitySharableContentType, Client } from "@amityco/ts-sdk";
+
+async function getEventShareLink(eventId: string) {
+  const config = await Client.getShareableLinkConfiguration();
+
+  // Feature gate — hide the share action when event links aren't configured
+  if (!config.isEnabled(AmitySharableContentType.EVENT)) return null;
+
+  return config.generateLink(AmitySharableContentType.EVENT, eventId);
+  // → "https://app.example.com/events/abc123" or null
+}
+```
+
+```swift iOS
+let eventId = "event-id"
+let config = try await client.getShareableLinkConfiguration()
+
+if let pattern = config.patterns["events"] {
+    let link = config.domain + pattern.replacingOccurrences(
+        of: "{eventId}",
+        with: eventId
+    )
+    showInfo(link)
+}
+```
+
+```kotlin Android
+AmityCoreClient.getShareableLinkConfiguration()
+    .getShareableLink()
+    .subscribe({ config ->
+        val pattern = config.getPatterns()["events"]
+        val link = pattern?.let {
+            config.getDomain() + it.replace("{eventId}", eventId)
+        }
+    }, { error ->
+        handleGeneralError(error)
+    })
+```
+
+</CodeGroup>
+
+<Note>
+Shareable links are available on TypeScript, iOS, and Android. Flutter has no public shareable-link configuration API in the current SDK source.
+</Note>
+
 ## Best Practices
 
 - Treat missing patterns as a disabled share target for that content type.
@@ -103,5 +155,8 @@ AmityCoreClient.getShareableLinkConfiguration()
   </Card>
   <Card title="User Management" href="../../core-concepts/user-management/overview" icon="user">
     Share user profile destinations after configuring user URL patterns.
+  </Card>
+  <Card title="Events" href="../events/overview" icon="calendar">
+    Share event links after configuring the event URL pattern.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/social/content-management/content-sharing.mdx
+++ b/social-plus-sdk/social/content-management/content-sharing.mdx
@@ -109,22 +109,21 @@ async function getEventShareLink(eventId: string) {
 let eventId = "event-id"
 let config = try await client.getShareableLinkConfiguration()
 
-if let pattern = config.patterns["events"] {
-    let link = config.domain + pattern.replacingOccurrences(
-        of: "{eventId}",
-        with: eventId
-    )
+// Feature gate — hide the share action when event links aren't configured
+guard config.isEnabled(.event) else { return }
+
+if let link = config.generateLink(.event, referenceId: eventId) {
     showInfo(link)
 }
 ```
 
 ```kotlin Android
 AmityCoreClient.getShareableLinkConfiguration()
-    .getShareableLink()
     .subscribe({ config ->
-        val pattern = config.getPatterns()["events"]
-        val link = pattern?.let {
-            config.getDomain() + it.replace("{eventId}", eventId)
+        // Feature gate — hide the share action when event links aren't configured
+        if (config.isEnabled(AmitySharableContentType.EVENT)) {
+            val link = config.generateLink(AmitySharableContentType.EVENT, eventId)
+            // ... copy or share `link`
         }
     }, { error ->
         handleGeneralError(error)

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -242,7 +242,21 @@ unsubscribe();
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+AmitySocialClient.newFeedRepository()
+    .getForYouFeed()
+    .subscribe(
+        { pagingData: PagingData<AmityPost> ->
+            showSuccessMessage(pagingData)
+        },
+        { error ->
+            if (error is AmityForYouFeedDisabledError) {
+                // For You feed is not enabled for this network — hide the tab.
+                hideForYouSurface()
+            } else {
+                handleGeneralError(error)
+            }
+        },
+    )
 ```
 
 </CodeGroup>
@@ -273,7 +287,16 @@ if (setting.forYouFeed.enabled) {
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+AmityCoreClient.getForYouFeedSetting()
+    .doOnSuccess { setting: AmityForYouFeedSetting ->
+        if (setting.enabled) {
+            showForYouTab()
+        }
+    }
+    .doOnError { error ->
+        handleGeneralError(error)
+    }
+    .subscribe()
 ```
 
 </CodeGroup>

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -238,7 +238,23 @@ unsubscribe();
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+let forYouFeed = feedRepository.getForYouFeed()
+
+token = forYouFeed.observe { collection, error in
+    if let error {
+        if error is AmityForYouFeedDisabledError {
+            // For You feed is not enabled for this network — hide the tab.
+            hideForYouSurface()
+            return
+        }
+        handleError(error)
+        return
+    }
+
+    showSuccessMessage(collection.snapshots.count)
+}
+
+forYouFeed.nextPage()
 ```
 
 ```kotlin Android

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -11,6 +11,7 @@ Use `AmityFeedRepository` to read feed-style post collections. The SDK exposes u
 | --- | --- | --- | --- | --- |
 | Global feed | `FeedRepository.getGlobalFeed()` | `AmityFeedRepository().getGlobalFeed()` | `AmitySocialClient.newFeedRepository().getGlobalFeed()` | `AmitySocialClient.newFeedRepository().getGlobalFeed()` |
 | Custom-ranking global feed | `FeedRepository.getCustomRankingGlobalFeed()` | `AmityFeedRepository().getCustomRankingGlobalFeed()` | `AmitySocialClient.newFeedRepository().getCustomRankingGlobalFeed()` | `AmitySocialClient.newFeedRepository().getCustomRankingGlobalFeed()` |
+| For You feed | `FeedRepository.getForYouFeed()` | Supported | Supported | Not available |
 | User feed | `FeedRepository.getUserFeed()` | `AmityFeedRepository().getUserFeed()` | `AmitySocialClient.newFeedRepository().getUserFeed()` | `AmitySocialClient.newFeedRepository().getUserFeed()` |
 | Community feed | `FeedRepository.getCommunityFeed()` | `AmityFeedRepository().getCommunityFeed()` | `AmitySocialClient.newFeedRepository().getCommunityFeed()` | `AmitySocialClient.newFeedRepository().getCommunityFeed()` |
 
@@ -27,6 +28,7 @@ TypeScript still exports `queryGlobalFeed()`, but the SDK source marks it deprec
 | Query custom-ranking global feed | `includeMixedStructure` | No | Include mixed-structure posts in the backend-ranked global feed response. |
 | TypeScript pagination | `limit`, `onNextPage`, `hasNextPage` | No | Control page size and load additional pages from the live collection callback. |
 | Android refresh | `invalidateCache` | No | Skip cached paging data for deliberate refresh flows. |
+| Query For You feed | None | — | `getForYouFeed()` takes no query parameters. Pagination is handled through the live collection callback. |
 
 ## Query Global Feed
 
@@ -177,6 +179,101 @@ final page = await AmitySocialClient.newFeedRepository()
 
 final posts = page.data;
 showError(posts.length);
+```
+
+</CodeGroup>
+
+## Query For You Feed
+
+For You feed is a backend-personalized global feed for the current user. Ranking is owned by the backend; the SDK only requests the feed and returns the posts the backend provides. It is a network-level feature that must be enabled for your network before the feed returns content.
+
+<Info>
+For You feed is a network setting. Read `getForYouFeedSetting()` on the client and only render the surface when `forYouFeed.enabled` is `true`. If the feed is not enabled, the collection reports `AmityForYouFeedDisabledError` (see below) rather than an empty list.
+</Info>
+
+`getForYouFeed()` is a live collection that takes **no query parameters**. Page through results with the `onNextPage` / `hasNextPage` values from the callback; the default page size is 20 posts.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Client, FeedRepository } from '@amityco/ts-sdk';
+
+// 1. Gate the surface on the network setting.
+const { forYouFeed } = await Client.getForYouFeedSetting();
+if (!forYouFeed.enabled) {
+  hideForYouSurface();
+  return;
+}
+
+// 2. Observe the personalized feed.
+let loadNextPage: (() => void) | undefined;
+let canLoadMore = false;
+
+const unsubscribe = FeedRepository.getForYouFeed(
+  ({ data: posts, onNextPage, hasNextPage, loading, error }) => {
+    if (loading) return;
+    if (error) {
+      if (error instanceof FeedRepository.AmityForYouFeedDisabledError) {
+        // For You feed is not enabled for this network — hide the tab.
+        hideForYouSurface();
+        return;
+      }
+      handleError(error);
+      return;
+    }
+
+    renderResults(posts);
+    loadNextPage = onNextPage;
+    canLoadMore = hasNextPage;
+  },
+);
+
+function loadMoreForYouFeed() {
+  if (canLoadMore) {
+    loadNextPage?.();
+  }
+}
+
+unsubscribe();
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
+```
+
+</CodeGroup>
+
+<Note>
+For You feed is available on TypeScript, iOS, and Android. It is not available in the current Flutter SDK.
+</Note>
+
+### Read the For You feed setting
+
+`getForYouFeedSetting()` is a method on the client that reports whether the network has For You feed enabled. Use it to decide whether to render a For You tab or entry point at all.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Client } from '@amityco/ts-sdk';
+
+const setting = await Client.getForYouFeedSetting();
+// setting: { forYouFeed: { enabled: boolean } }
+
+if (setting.forYouFeed.enabled) {
+  showForYouTab();
+}
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
 ```
 
 </CodeGroup>

--- a/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/feed/overview.mdx
@@ -188,7 +188,7 @@ showError(posts.length);
 For You feed is a backend-personalized global feed for the current user. Ranking is owned by the backend; the SDK only requests the feed and returns the posts the backend provides. It is a network-level feature that must be enabled for your network before the feed returns content.
 
 <Info>
-For You feed is a network setting. Read `getForYouFeedSetting()` on the client and only render the surface when `forYouFeed.enabled` is `true`. If the feed is not enabled, the collection reports `AmityForYouFeedDisabledError` (see below) rather than an empty list.
+For You feed is a network setting. Read `getForYouFeedSetting()` on the client and only render the surface when the feed is enabled. If the feed is not enabled, the collection reports a feed-disabled error rather than an empty list — `AmityForYouFeedDisabledError` on TypeScript and Android, or the `.forYouFeedDisabled` error code on iOS (see below).
 </Info>
 
 `getForYouFeed()` is a live collection that takes **no query parameters**. Page through results with the `onNextPage` / `hasNextPage` values from the callback; the default page size is 20 posts.
@@ -242,7 +242,7 @@ let forYouFeed = feedRepository.getForYouFeed()
 
 token = forYouFeed.observe { collection, error in
     if let error {
-        if error is AmityForYouFeedDisabledError {
+        if error.isAmityErrorCode(.forYouFeedDisabled) {
             // For You feed is not enabled for this network — hide the tab.
             hideForYouSurface()
             return
@@ -299,7 +299,10 @@ if (setting.forYouFeed.enabled) {
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+let setting = try await client.getForYouFeedSetting()
+if setting.enabled {
+    showForYouTab()
+}
 ```
 
 ```kotlin Android

--- a/social-plus-sdk/social/discovery-engagement/overview.mdx
+++ b/social-plus-sdk/social/discovery-engagement/overview.mdx
@@ -7,7 +7,7 @@ Discovery and engagement APIs help users find content, communities, and activity
 
 <CardGroup cols={2}>
   <Card title="Feeds" href="./feed/overview" icon="rss">
-    Query global feeds, custom-ranking feeds, and community or user feeds.
+    Query global, custom-ranking, For You (personalized), community, and user feeds.
   </Card>
   <Card title="Intelligent Search" href="./search/overview" icon="search">
     Search posts and communities through SDK-supported semantic search surfaces.

--- a/social-plus-sdk/social/events/overview.mdx
+++ b/social-plus-sdk/social/events/overview.mdx
@@ -18,6 +18,7 @@ The SDK event surface is currently exposed in TypeScript, iOS, and Android. The 
 | Update event | `EventRepository.updateEvent(eventId, options)` | `AmityEventRepository().updateEvent(id:options:)` | `AmitySocialClient.newEventRepository().updateEvent(eventId)...build().apply()` | Not exposed |
 | Delete event | `EventRepository.deleteEvent(eventId)` | `AmityEventRepository().deleteEvent(id:)` | `AmitySocialClient.newEventRepository().deleteEvent(eventId)` | Not exposed |
 | RSVP | `event.createRSVP(...)`, `event.updateRSVP(...)`, `event.getMyRSVP()`, `event.getRSVPs(...)` | Same methods on `AmityEvent` | Same methods on `AmityEvent` | Not exposed |
+| Share event link | `Client.getShareableLinkConfiguration()` + `AmitySharableContentType.EVENT` | Supported | Supported | Not available |
 
 ## Event Fields
 
@@ -67,5 +68,8 @@ This page documents SDK method names and data surfaces only. Product policy such
   </Card>
   <Card title="Event RSVP" href="./event-rsvp" icon="ticket-check">
     Create, update, read, and query RSVP responses.
+  </Card>
+  <Card title="Share Event Link" href="../content-management/content-sharing#generate-an-event-link" icon="link">
+    Generate a shareable deep link to an event.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
@@ -81,7 +81,18 @@ try {
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+let relationship = AmityUserRelationship()
+do {
+    try await relationship.blockUser(userId: "target-user-id")
+    showSuccessMessage()
+} catch {
+    if error.isAmityErrorCode(.maxBlockedUsersReached) {
+        // Already at the per-network block cap — prompt the user to unblock someone first.
+        showBlockedUserLimitReached()
+    } else {
+        handleError(error)
+    }
+}
 ```
 
 ```kotlin Android

--- a/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
@@ -60,6 +60,36 @@ await AmityCoreClient.newUserRepository()
 
 </CodeGroup>
 
+### Handle the blocked-user limit
+
+A network caps how many users one account can block. When the current user is already at that cap, the block call fails with a "maximum blocked users reached" error instead of succeeding. On TypeScript this surfaces as the server error code `Amity.ServerError.MAX_BLOCKED_USERS_REACHED` (`400324`). Catch it and prompt the user to unblock someone before blocking another account.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { UserRepository } from '@amityco/ts-sdk';
+
+try {
+  await UserRepository.Relationship.blockUser(userId);
+} catch (error) {
+  if (error?.code === Amity.ServerError.MAX_BLOCKED_USERS_REACHED) {
+    showBlockedUserLimitReached();
+    return;
+  }
+  handleError(error);
+}
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
+```
+
+</CodeGroup>
+
 ## Unblock User
 
 Unblock a user when the current user removes a previously created block.
@@ -117,8 +147,8 @@ After a successful block or unblock action:
   <Card title="Manage Blocked Users" href="./manage-blocked-users" icon="list">
     Query the blocked-user list.
   </Card>
-  <Card title="Connection Status" href="../following/get-connection-status" icon="signal">
-    Read status and counters.
+  <Card title="Users Who Blocked You" href="./manage-blocking-users" icon="user-slash">
+    Query the reverse direction.
   </Card>
   <Card title="Follow/Unfollow User" href="../following/follow-unfollow-user" icon="user-plus">
     Change follow relationships.

--- a/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/block-unblock-user.mdx
@@ -85,7 +85,21 @@ try {
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+AmityCoreClient.newUserRepository()
+    .relationship()
+    .blockUser(userId = targetUserId)
+    .doOnComplete {
+        showSuccessMessage()
+    }
+    .doOnError { error ->
+        if (AmityError.from(error) == AmityError.MAX_BLOCKED_USERS_REACHED) {
+            // Already at the per-network block cap — prompt the user to unblock someone first.
+            showBlockedUserLimitReached()
+        } else {
+            handleGeneralError(error)
+        }
+    }
+    .subscribe()
 ```
 
 </CodeGroup>

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users.mdx
@@ -13,7 +13,7 @@ There are two read patterns:
 | `getAllBlockedUsers()` | A one-shot list for local decisions | TypeScript, iOS, Android |
 
 <Info>
-You can query users blocked by the current user. These APIs do not reveal which users have blocked the current user.
+These APIs return users the current user has **blocked**. To read the reverse direction — users who have **blocked the current user** — see [Users Who Blocked You](./manage-blocking-users).
 </Info>
 
 ## Parameters
@@ -135,11 +135,11 @@ The one-shot API is not available in the Flutter public repository. For Flutter,
 ## Related Topics
 
 <CardGroup cols={3}>
+  <Card title="Users Who Blocked You" href="./manage-blocking-users" icon="user-slash">
+    Query the reverse direction.
+  </Card>
   <Card title="Block & Unblock User" href="./block-unblock-user" icon="ban">
     Change blocked status.
-  </Card>
-  <Card title="Connection Status" href="../following/get-connection-status" icon="signal">
-    Read follow status.
   </Card>
   <Card title="Follower Lists" href="../following/get-follower-following-list" icon="list">
     Query social graph lists.

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
@@ -55,7 +55,16 @@ unsubscribe();
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+val disposable = AmityCoreClient.newUserRepository()
+    .getBlockingUsers()
+    .subscribe(
+        { pagingData: PagingData<AmityUser> ->
+            showSuccessMessage(pagingData)
+        },
+        { error ->
+            handleGeneralError(error)
+        },
+    )
 ```
 
 </CodeGroup>
@@ -78,7 +87,17 @@ const blockingUserIds = new Set(blockingUsers.map((user) => user.userId));
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+val disposable = AmityCoreClient.newUserRepository()
+    .getAllBlockingUsers()
+    .subscribe(
+        { users: List<AmityUser> ->
+            val blockingUserIds = users.map { it.getUserId() }.toSet()
+            showSuccessMessage(blockingUserIds)
+        },
+        { error ->
+            handleGeneralError(error)
+        },
+    )
 ```
 
 </CodeGroup>

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
@@ -51,7 +51,20 @@ unsubscribe();
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+let repository = AmityUserRepository()
+let blockingUsers = repository.getBlockingUsers()
+
+_ = blockingUsers.observe { collection, error in
+    if let error {
+        handleError(error)
+        return
+    }
+
+    let users = collection.snapshots
+    _ = users.first?.userId
+}
+
+blockingUsers.nextPage()
 ```
 
 ```kotlin Android

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
@@ -1,0 +1,102 @@
+---
+title: "Users Who Blocked You"
+description: "Query the users who have blocked the current user — the reverse direction of the blocked-user list."
+---
+
+Blocking is bi-directional: the current user can see the accounts they have blocked, and — separately — the accounts that have blocked them. Use the blocking-user APIs to read the reverse direction: the users who have blocked the current user.
+
+<Info>
+This is the directional inverse of [Manage Blocked Users](./manage-blocked-users). "Blocked users" are accounts the current user blocked; "blocking users" are accounts that blocked the current user.
+</Info>
+
+There are two read patterns:
+
+| API | Best for | Returns |
+| --- | --- | --- |
+| `getBlockingUsers()` | A live, self-updating list | Live collection of `Amity.User` |
+| `getAllBlockingUsers()` | A one-shot list for local decisions | `Amity.User[]` |
+
+<Note>
+The blocking-user APIs are available on TypeScript, iOS, and Android. They are not available in the current Flutter SDK.
+</Note>
+
+## Get Blocking Users
+
+Observe the users who have blocked the current user as a live collection. Unlike `getBlockedUsers()`, this observer takes **only a callback** — there are no query parameters. Page through results with the `onNextPage` / `hasNextPage` values from the callback.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { UserRepository } from '@amityco/ts-sdk';
+
+let loadMoreBlockingUsers: (() => void) | undefined;
+
+const unsubscribe = UserRepository.getBlockingUsers(
+  ({ data: users, onNextPage, hasNextPage, loading, error }) => {
+    if (error) {
+      handleError(error);
+      return;
+    }
+
+    if (!loading && users) {
+      renderResults(users);
+    }
+
+    loadMoreBlockingUsers = hasNextPage ? onNextPage : undefined;
+  },
+);
+
+// Stop observing when the screen is destroyed.
+unsubscribe();
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
+```
+
+</CodeGroup>
+
+## Get All Blocking Users
+
+Use `getAllBlockingUsers()` when your app needs a one-shot list instead of a live collection — for example, to filter content or hide interactions locally. It returns up to 100 users and uses a short SDK-side cache. Call it again when you need a fresh snapshot.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { UserRepository } from '@amityco/ts-sdk';
+
+const blockingUsers = await UserRepository.getAllBlockingUsers();
+const blockingUserIds = new Set(blockingUsers.map((user) => user.userId));
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
+```
+
+</CodeGroup>
+
+<Tip>
+The SDK already filters content in both block directions. Use these lists for product surfaces — such as hiding a "message" or "follow" action — rather than to re-implement content filtering the SDK performs for you.
+</Tip>
+
+## Related Topics
+
+<CardGroup cols={3}>
+  <Card title="Manage Blocked Users" href="./manage-blocked-users" icon="list">
+    Query accounts the current user blocked.
+  </Card>
+  <Card title="Block & Unblock User" href="./block-unblock-user" icon="ban">
+    Change blocked status.
+  </Card>
+  <Card title="User Relationship" href="../overview" icon="users">
+    Follow, unfollow, and blocking overview.
+  </Card>
+</CardGroup>

--- a/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
+++ b/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users.mdx
@@ -96,7 +96,9 @@ const blockingUserIds = new Set(blockingUsers.map((user) => user.userId));
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+let repository = AmityUserRepository()
+let blockingUsers = try await repository.getAllBlockingUsers()
+let blockingUserIds = Set(blockingUsers.map { $0.userId })
 ```
 
 ```kotlin Android

--- a/social-plus-sdk/social/user-relationship/overview.mdx
+++ b/social-plus-sdk/social/user-relationship/overview.mdx
@@ -14,7 +14,7 @@ For an end-to-end product walkthrough, see [User Profiles & Social Graph](/use-c
 | System | What it manages | Main SDK surface |
 | --- | --- | --- |
 | Following | Follow requests, accepted follows, pending requests, follower/following lists, and follow counts | `UserRepository.Relationship` on TypeScript, `relationship()` on Android and Flutter, `AmityUserRelationship` on iOS |
-| Blocking | Block/unblock actions and the current user's blocked-user list | Relationship block APIs plus `getBlockedUsers()` on the user repository |
+| Blocking | Block/unblock actions, the current user's blocked-user list, and — in the reverse direction — the users who have blocked the current user | Relationship block APIs plus `getBlockedUsers()` / `getBlockingUsers()` on the user repository |
 
 Follow status values are platform-specific enum or string values, but the shared meanings are:
 
@@ -41,6 +41,7 @@ Whether a follow becomes `accepted` immediately or starts as `pending` is determ
 | Block and unblock users | Yes | Yes | Yes | Yes |
 | Query paginated blocked users | Yes | Yes | Yes | Yes |
 | Get all blocked users as a one-shot list | Yes | Yes | Yes | Not available in the Flutter public repository |
+| Query users who blocked the current user (reverse direction) | Yes | Yes | Yes | Not available in the current Flutter SDK |
 
 ## Use The Right Read API
 
@@ -76,5 +77,8 @@ Do not rely on this overview for feed visibility, search visibility, comment per
   </Card>
   <Card title="Manage Blocked Users" href="./blocking/manage-blocked-users" icon="list">
     Query the current user's blocked-user list.
+  </Card>
+  <Card title="Users Who Blocked You" href="./blocking/manage-blocking-users" icon="user-slash">
+    Query the reverse direction — users who blocked you.
   </Card>
 </CardGroup>

--- a/social-plus-sdk/technical-faq.mdx
+++ b/social-plus-sdk/technical-faq.mdx
@@ -307,8 +307,8 @@ Looking for a question that is not here? Use the <strong>Developer Forum</strong
   <Accordion title="TypeScript via CDN only?">
     Not recommended / unsupported. Use a package manager (npm, Yarn, pnpm) for versioned SDK distribution.
   </Accordion>
-  <Accordion title="Check if I blocked a user">
-    Use blocked users list query. Docs: /social/block-and-unblock-user#blocked-users-list.
+  <Accordion title="Check if I blocked a user, or who blocked me">
+    Query the users you blocked with `getBlockedUsers()` / `getAllBlockedUsers()`. To read the reverse direction — users who blocked you — use `getBlockingUsers()` / `getAllBlockingUsers()`. Docs: [Manage Blocked Users](/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users) and [Users Who Blocked You](/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users).
   </Accordion>
   <Accordion title="Mark message as read">
     Call SDK mark-read API or start/stop reading subchannel utilities (unread-count docs). Ensures backend updates unread counters.

--- a/uikit/components/chat.mdx
+++ b/uikit/components/chat.mdx
@@ -60,7 +60,7 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
     - Message editing, deletion, and interaction controls
     - Network awareness and offline handling
 
-    **Platform Support:** Flutter only
+    **Platform Support:** iOS, Android, React, Flutter
 
     <Button href="/uikit/components/chat/conversation-chat" variant="outline">
       📱 Conversation Chat Guide
@@ -75,7 +75,7 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
     - Swipe-to-archive functionality
     - Create new conversations and access archived chats
 
-    **Platform Support:** Flutter only
+    **Platform Support:** iOS, Android, React, Flutter
 
     <Button href="/uikit/components/chat/recent-chats" variant="outline">
       📋 Recent Chats Guide
@@ -95,7 +95,7 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
     - Group settings and profile customization
     - Message reporting and moderation tools
 
-    **Platform Support:** Flutter only
+    **Platform Support:** iOS, Android, React, Flutter
 
     **Components Included:**
     - AmityGroupChatPage - Main group interface
@@ -226,9 +226,9 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
 | Feature | Conversation Chat | Group Chat | Live Chat |
 |---------|------------------|------------|-----------|
 | **Flutter Support** | ✅ Full Support | ✅ Full Support | ❌ Not Available |
-| **iOS Support** | ❌ Not Available | ❌ Not Available | ✅ Full Support |
-| **Android Support** | ❌ Not Available | ❌ Not Available | ✅ Full Support |
-| **React Support** | ❌ Not Available | ❌ Not Available | ✅ Full Support |
+| **iOS Support** | ✅ Full Support | ✅ Full Support | ✅ Full Support |
+| **Android Support** | ✅ Full Support | ✅ Full Support | ✅ Full Support |
+| **React Support** | ✅ Full Support | ✅ Full Support | ✅ Full Support |
 | **React Native Support** | ❌ Not Available | ❌ Not Available | ❌ Not Available |
 | **Use Case** | 1-on-1 messaging | Multi-user collaboration | Live streaming events |
 | **Member Limit** | 2 users | Multiple users | High volume viewers |

--- a/uikit/components/chat/conversation-chat.mdx
+++ b/uikit/components/chat/conversation-chat.mdx
@@ -28,9 +28,9 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
   </Card>
 </CardGroup>
 
-<Warning>
-**Platform Support**: Conversation Chat components are currently supported on **Flutter only**. Additional platform implementations are in progress.
-</Warning>
+<Info>
+**Platform Support**: Conversation Chat components are available on **iOS, Android, React, and Flutter**. Refer to the platform UIKit for React Native availability.
+</Info>
 
 ## Implementation Guide
 

--- a/uikit/components/chat/group-chat.mdx
+++ b/uikit/components/chat/group-chat.mdx
@@ -45,9 +45,9 @@ The Group Chat UIKit is designed to provide a complete solution for multi-user c
   </Card>
 </CardGroup>
 
-<Warning>
-**Platform Support**: Group Chat components are currently supported on **Flutter only**. Additional platforms coming soon.
-</Warning>
+<Info>
+**Platform Support**: Group Chat components are available on **iOS, Android, React, and Flutter**. Refer to the platform UIKit for React Native availability.
+</Info>
 
 ## Implementation Guide
 

--- a/uikit/components/chat/overview.mdx
+++ b/uikit/components/chat/overview.mdx
@@ -3,8 +3,6 @@ title: "Chat Components Overview"
 description: "Complete guide to social.plus UIKit chat components for building messaging experiences"
 ---
 
-# Chat Components
-
 social.plus UIKit provides a comprehensive set of chat components for building modern messaging experiences. These components are designed to work seamlessly across all platforms with consistent functionality and customizable styling.
 
 <CardGroup cols={2}>
@@ -27,8 +25,7 @@ social.plus UIKit provides a comprehensive set of chat components for building m
 <AccordionGroup>
   <Accordion title="Real-Time Messaging">
     - Instant message delivery and receipt
-    - Typing indicators and read receipts
-    - Online presence and status
+    - Read and unread message state
     - Message synchronization across devices
   </Accordion>
   
@@ -36,16 +33,15 @@ social.plus UIKit provides a comprehensive set of chat components for building m
     - Text messages with formatting
     - Image and video sharing
     - File attachments
-    - Voice messages
-    - Location sharing
   </Accordion>
   
   <Accordion title="Advanced Features">
     - Message reactions and replies
+    - Mentions in messages
     - Message editing and deletion
     - Message search and filtering
+    - Archive and unarchive chats
     - Push notifications
-    - Offline message caching
   </Accordion>
   
   <Accordion title="Moderation Tools">
@@ -70,10 +66,9 @@ All chat components are available across platforms with platform-specific optimi
   </Card>
   <Card title="Web & Cross-Platform" icon="globe">
     **React Web & React Native**
-    - Progressive Web App support
-    - Responsive design for all screen sizes
-    - WebRTC integration for voice/video
-    - Service worker for offline support
+    - Responsive design for desktop and mobile
+    - Light and dark theme support
+    - Customization via config IDs
   </Card>
 </CardGroup>
 
@@ -122,16 +117,22 @@ supportFragmentManager.beginTransaction()
     .commit()
 ```
 
-```javascript React
-import { AmityChatRoom } from '@amityco/ui-kit';
+```tsx React
+import { AmityUiKitProvider, AmityUiKitChatV4 } from '@amityco/ui-kit';
+import config from './uikit.config.json';
 
-function MyApp() {
+function MyChatApp() {
   return (
-    <AmityChatRoom
-      channelId="your_channel_id"
-      theme="light"
-      onMessageSent={(message) => console.log('Message sent:', message)}
-    />
+    <AmityUiKitProvider
+      configs={config}
+      apiKey="API_KEY"
+      apiRegion="API_REGION"
+      userId="userId"
+      displayName="displayName"
+      apiEndpoint="https://api.{API_REGION}.amity.co"
+    >
+      <AmityUiKitChatV4 />
+    </AmityUiKitProvider>
   );
 }
 ```
@@ -196,49 +197,34 @@ graph TD
 
 ## Customization Options
 
-### Theme Configuration
+Chat pages follow the UIKit page / component / element ID system. Set a network-wide theme in the top-level `theme`, then override a specific chat surface by its ID under `customizations` in your `uikit.config.json` — the same pattern used across every UIKit page.
 
-```json
+```json uikit.config.json
 {
-  "chat_theme": {
-    "light": {
-      "message_bubble_sent": "#007AFF",
-      "message_bubble_received": "#E5E5EA",
-      "text_color_sent": "#FFFFFF",
-      "text_color_received": "#000000",
-      "timestamp_color": "#8E8E93",
-      "background_color": "#FFFFFF"
+  "preferred_theme": "default",
+  "theme": {
+    "light": { "primary_color": "#1054DE", "background_color": "#FFFFFF" },
+    "dark": { "primary_color": "#1054DE", "background_color": "#191919" }
+  },
+  "excludes": [],
+  "customizations": {
+    "chat_home_page/*/*": {
+      "theme": {
+        "light": { "primary_color": "#1054DE" },
+        "dark": { "primary_color": "#4C91FF" }
+      }
     },
-    "dark": {
-      "message_bubble_sent": "#0A84FF",
-      "message_bubble_received": "#38383A",
-      "text_color_sent": "#FFFFFF",
-      "text_color_received": "#FFFFFF",
-      "timestamp_color": "#8E8E93",
-      "background_color": "#000000"
+    "live_chat/*/*": {
+      "theme": {
+        "light": { "primary_color": "#1054DE" },
+        "dark": { "primary_color": "#4C91FF" }
+      }
     }
   }
 }
 ```
 
-### Feature Configuration
-
-```json
-{
-  "chat_features": {
-    "message_reactions": true,
-    "message_replies": true,
-    "message_editing": true,
-    "message_deletion": true,
-    "file_sharing": true,
-    "image_sharing": true,
-    "voice_messages": true,
-    "typing_indicators": true,
-    "read_receipts": true,
-    "push_notifications": true
-  }
-}
-```
+Chat page IDs include `chat_home_page`, `chat_page`, `group_chat_page`, and `live_chat`. For the full theming and localization model, see [Component styling](/uikit/customization/component-styling) and [Localization](/uikit/customization/localization).
 
 ## Performance Considerations
 
@@ -289,8 +275,8 @@ All chat components include built-in security features to protect user communica
 </Info>
 
 <CardGroup cols={2}>
-  <Card title="Message Encryption" icon="lock">
-    End-to-end encryption for secure messaging
+  <Card title="Secure Transport" icon="lock">
+    Messages are encrypted in transit (TLS)
   </Card>
   <Card title="Content Moderation" icon="shield">
     AI-powered profanity and content filtering

--- a/uikit/components/chat/overview.mdx
+++ b/uikit/components/chat/overview.mdx
@@ -66,9 +66,10 @@ All chat components are available across platforms with platform-specific optimi
   </Card>
   <Card title="Web & Cross-Platform" icon="globe">
     **React Web & React Native**
-    - Responsive design for desktop and mobile
-    - Light and dark theme support
-    - Customization via config IDs
+    - Progressive Web App support
+    - Responsive design for all screen sizes
+    - WebRTC integration for voice/video
+    - Service worker for offline support
   </Card>
 </CardGroup>
 
@@ -203,21 +204,18 @@ Chat pages follow the UIKit page / component / element ID system. Set a network-
 {
   "preferred_theme": "default",
   "theme": {
-    "light": { "primary_color": "#1054DE", "background_color": "#FFFFFF" },
-    "dark": { "primary_color": "#1054DE", "background_color": "#191919" }
+    "light": { "primary_color": "#1054DE", "background_color": "#FFFFFF" }
   },
   "excludes": [],
   "customizations": {
     "chat_home_page/*/*": {
       "theme": {
-        "light": { "primary_color": "#1054DE" },
-        "dark": { "primary_color": "#4C91FF" }
+        "light": { "primary_color": "#1054DE" }
       }
     },
     "live_chat/*/*": {
       "theme": {
-        "light": { "primary_color": "#1054DE" },
-        "dark": { "primary_color": "#4C91FF" }
+        "light": { "primary_color": "#1054DE" }
       }
     }
   }

--- a/uikit/components/chat/recent-chats.mdx
+++ b/uikit/components/chat/recent-chats.mdx
@@ -28,9 +28,9 @@ The UIKit provides users with an overview of all their active chat channels. It 
   </Card>
 </CardGroup>
 
-<Warning>
-**Platform Support**: Recent Chats components are currently supported on **Flutter only**. Additional platforms coming soon.
-</Warning>
+<Info>
+**Platform Support**: Recent Chats components are available on **iOS, Android, React, and Flutter**. Refer to the platform UIKit for React Native availability.
+</Info>
 
 ## Implementation Guide
 

--- a/uikit/components/chat/search-chat.mdx
+++ b/uikit/components/chat/search-chat.mdx
@@ -45,9 +45,9 @@ The Chat Search UIKit provides comprehensive search functionality that enables u
   </Card>
 </CardGroup>
 
-<Warning>
-**Platform Support**: Chat Search components are currently supported on **Flutter only**. Additional platforms coming soon.
-</Warning>
+<Info>
+**Platform Support**: Chat Search is available on **Flutter** (standalone `AmitySearchChannelPage`) and **React Web** (reached from the chat home page — see the React note below). Refer to the platform UIKit for iOS and Android availability.
+</Info>
 
 ## Implementation Guide
 
@@ -85,6 +85,10 @@ The Chat Search UIKit provides comprehensive search functionality that enables u
     <Note>
     **Search Scope**: Chat Search mode searches across both active and archived channels, with clear indicators showing which channels are archived.
     </Note>
+
+    <Info>
+    **React Web**: Search is not a standalone exported page on React Web. It is reached from `AmityChatHomePage` via the header search entry, which opens the search view with the Chat / Message tabs. The Chat tab is backed by the SDK's `ChannelRepository.searchChannels` (member channels of type `conversation` and `community`, sorted by last activity), and archived channels are indicated inline. No extra wiring is required — enable the chat home page and search is available.
+    </Info>
   </Tab>
 
   <Tab title="Message Search">

--- a/uikit/components/overview.mdx
+++ b/uikit/components/overview.mdx
@@ -30,7 +30,7 @@ Consider building custom (or moving to <a href="/uikit/customization/advanced-cu
 ## Quick Navigation
 
 <CardGroup cols={3}>
-	<Card title="Social Overview" icon="sparkles" href="/uikit/components/social/overview">Posts, feeds, stories, clips, livestream</Card>
+	<Card title="Social Overview" icon="sparkles" href="/uikit/components/social/overview">Posts, feeds (incl. For You), stories, clips, livestream</Card>
 	<Card title="Chat Overview" icon="comments" href="/uikit/components/chat/overview">Conversation, group & live chat</Card>
 	<Card title="Communities" icon="building" href="/uikit/components/social/communities">Community spaces</Card>
 	<Card title="Moderation" icon="shield" href="/uikit/components/social/moderation">Safety & reporting</Card>
@@ -50,8 +50,10 @@ Consider building custom (or moving to <a href="/uikit/customization/advanced-cu
 
 <CardGroup cols={3}>
 	<Card title="Recent Chats" icon="list" href="/uikit/components/chat/recent-chats">Channel list</Card>
-	<Card title="Conversation Chat" icon="comments" href="/uikit/components/chat/conversation-chat">1:1 & groups</Card>
+	<Card title="Conversation Chat" icon="comments" href="/uikit/components/chat/conversation-chat">1:1 messaging</Card>
+	<Card title="Group Chat" icon="users" href="/uikit/components/chat/group-chat">Group conversations & management</Card>
 	<Card title="Live Chat" icon="broadcast-tower" href="/uikit/components/chat/live-chat">Event / stream chat</Card>
+	<Card title="Search Chat" icon="magnifying-glass" href="/uikit/components/chat/search-chat">Search channels & messages</Card>
 </CardGroup>
 
 

--- a/uikit/components/social/event.mdx
+++ b/uikit/components/social/event.mdx
@@ -291,6 +291,27 @@ Spec 6 defines the visibility rules for entry points that trigger event creation
 
     </CodeGroup>
 
+    #### Share an event
+
+    The event detail page's 3-dot action menu can surface shareable-link actions that open the event directly:
+
+    | Action | Platforms | Behavior |
+    | --- | --- | --- |
+    | **Copy event link** | iOS, Android, React | Copies the event URL to the clipboard and shows a "Link copied." toast |
+    | **Share to** | iOS, Android | Opens the native OS share sheet with the event URL (not rendered on Web) |
+
+    These actions are backed by the SDK's `Client.getShareableLinkConfiguration()` and appear only when **all** of the following are true:
+
+    - Event shareable links are configured for the network — `config.isEnabled(AmitySharableContentType.EVENT)` is `true` (deep link toggle on and an event URL pattern is set in Console).
+    - The event's origin community is **public**.
+    - The event is not cancelled and not in a draft/unpublished state.
+
+    If any condition fails, the Copy / Share actions are hidden. See [Content Sharing](/social-plus-sdk/social/content-management/content-sharing) for the SDK link-generation API.
+
+    <Note>
+    Event shareable links are available on iOS, Android, and React (Web). "Share to" (native share sheet) is mobile-only. Refer to the platform UIKit for Flutter and React Native availability.
+    </Note>
+
     ### Event Attendees Page
 
     Use **AmityEventAttendeesPage** to browse attendees and navigate to a user profile.

--- a/uikit/components/social/feeds.mdx
+++ b/uikit/components/social/feeds.mdx
@@ -742,6 +742,55 @@ The Social Feeds & Content Discovery UIKit provides a complete suite of componen
   </Tab>
 </Tabs>
 
+## For You Feed
+
+For You is a backend-personalized feed that appears as a tab on the social home page. It is a **network-level setting** — the tab only shows when the network has For You feed enabled and the current user is not a visitor or bot. When the setting is off (or the feed reports that it is disabled), the UIKit hides the tab and falls back to the newsfeed automatically.
+
+<Info>
+**Platform Support**: For You feed is available on the **React Web, iOS, and Android** UIKit. It is not available on Flutter or React Native.
+</Info>
+
+### How the tab is gated
+
+The social home page reads the network setting and the feed collection, then derives whether to show the For You tab:
+
+1. `useForYouFeedSetting()` reads `forYouFeed.enabled` for the network (skipped for visitors/bots).
+2. `useForYouFeedCollection()` observes the personalized posts once the setting is enabled.
+3. The tab is shown only when the setting is enabled **and** the collection did not fail with `AmityForYouFeedDisabledError`. If the feed becomes unavailable while the tab is active, the page switches back to the newsfeed.
+
+### Rendering the feed
+
+`AmitySocialHomePage` wires the For You tab for you — enable For You feed on your network and it appears automatically. To embed the feed on its own, render the `ForYouFeed` component with a `pageId`:
+
+<CodeGroup>
+```tsx React
+import { ForYouFeed } from '@amityco/ui-kit';
+
+function ForYouTab() {
+  return <ForYouFeed pageId="social_home_page" />;
+}
+```
+
+```swift iOS
+// iOS is supported — code sample coming soon.
+```
+
+```kotlin Android
+// Android is supported — code sample coming soon.
+```
+</CodeGroup>
+
+### Hooks
+
+| Hook | Returns | Use for |
+| --- | --- | --- |
+| `useForYouFeedSetting({ shouldCall })` | `{ forYouFeedSetting, isPending, error }` | Decide whether to render a For You entry point. Pass `shouldCall: !isVisitorOrBot`. |
+| `useForYouFeedCollection({ shouldCall })` | `{ posts, isLoading, hasMore, loadMore, error, refresh, isLoadingFirstPage }` | Render the personalized post list and paginate it. Gate `shouldCall` on the enabled setting. |
+
+<Note>
+Both hooks and the `ForYouFeed` component are backed by the SDK's `FeedRepository.getForYouFeed()` and `Client.getForYouFeedSetting()`. See [Feeds & Timelines](/social-plus-sdk/social/discovery-engagement/feed/overview) for the SDK-level behavior.
+</Note>
+
 ## Component Management Strategies
 
 <AccordionGroup>

--- a/uikit/components/social/feeds.mdx
+++ b/uikit/components/social/feeds.mdx
@@ -776,7 +776,10 @@ function ForYouTab() {
 ```
 
 ```kotlin Android
-// Android is supported — code sample coming soon.
+@Composable
+fun composeForYouFeedComponent() {
+    AmityForYouFeedComponent()
+}
 ```
 </CodeGroup>
 

--- a/uikit/components/social/feeds.mdx
+++ b/uikit/components/social/feeds.mdx
@@ -756,7 +756,7 @@ The social home page reads the network setting and the feed collection, then der
 
 1. `useForYouFeedSetting()` reads `forYouFeed.enabled` for the network (skipped for visitors/bots).
 2. `useForYouFeedCollection()` observes the personalized posts once the setting is enabled.
-3. The tab is shown only when the setting is enabled **and** the collection did not fail with `AmityForYouFeedDisabledError`. If the feed becomes unavailable while the tab is active, the page switches back to the newsfeed.
+3. The tab is shown only when the setting is enabled **and** the collection did not fail with a feed-disabled error. If the feed becomes unavailable while the tab is active, the page switches back to the newsfeed.
 
 ### Rendering the feed
 
@@ -772,7 +772,7 @@ function ForYouTab() {
 ```
 
 ```swift iOS
-// iOS is supported — code sample coming soon.
+AmityForYouFeedComponent()
 ```
 
 ```kotlin Android

--- a/uikit/components/social/overview.mdx
+++ b/uikit/components/social/overview.mdx
@@ -76,10 +76,9 @@ All social components are available across platforms with platform-specific opti
   </Card>
   <Card title="Web & Cross-Platform" icon="globe">
     **React Web & Cross-Platform**
-    - Progressive Web App support
     - Responsive design for all screen sizes
-    - WebRTC integration for streaming
-    - Service worker for offline content
+    - Light and dark theme support
+    - Customization via config IDs
   </Card>
 </CardGroup>
 

--- a/uikit/components/social/overview.mdx
+++ b/uikit/components/social/overview.mdx
@@ -76,9 +76,10 @@ All social components are available across platforms with platform-specific opti
   </Card>
   <Card title="Web & Cross-Platform" icon="globe">
     **React Web & Cross-Platform**
+    - Progressive Web App support
     - Responsive design for all screen sizes
-    - Light and dark theme support
-    - Customization via config IDs
+    - WebRTC integration for streaming
+    - Service worker for offline content
   </Card>
 </CardGroup>
 

--- a/uikit/components/social/sharing.mdx
+++ b/uikit/components/social/sharing.mdx
@@ -11,7 +11,7 @@ description: "Enable users to share content through customizable sharing interfa
 
 ## Feature Overview
 
-The Sharing UIKit components provide comprehensive tools for enabling content sharing throughout your application. Users can share posts, profiles, communities, and live streams through two primary methods: copying shareable links or using native platform share sheets. These components integrate seamlessly across multiple pages and content types.
+The Sharing UIKit components provide comprehensive tools for enabling content sharing throughout your application. Users can share posts, profiles, communities, live streams, and events through two primary methods: copying shareable links or using native platform share sheets. These components integrate seamlessly across multiple pages and content types.
 
 ### Key Features
 
@@ -46,6 +46,7 @@ The sharing functionality is available across these key areas of your applicatio
 | **Live Stream Player Page** | Live stream links | Share active live streams                        |
 | **Create Live Stream Page** | Live stream links | Share live stream setup and promotion            |
 | **Clip Feed Page**          | Clip links        | Share video clips from feed views                |
+| **Event Detail Page**       | Event links       | Share events from the event detail page's 3-dot menu |
 
 ## Customization
 
@@ -109,6 +110,21 @@ The sharing functionality is available across these key areas of your applicatio
     | `create_livestream_page/*/copy_link` | Element | Customize copy button for stream creation |
     | `clip_feed_page/*/share_link` | Element | Customize share button for clip feeds |
     | `clip_feed_page/*/copy_link` | Element | Customize copy button for clip feeds |
+
+  </Tab>
+
+  <Tab title="Event Sharing">
+    Enable sharing for events
+
+    Event sharing adds **Copy event link** (all platforms) and **Share to** (mobile only) to the event detail page's 3-dot action menu. Visibility follows the network shareable-link configuration and the event's community type — see [Event → Share an event](/uikit/components/social/event#share-an-event).
+
+    #### Customization Options
+
+    | Config ID | Type | Description |
+    |-----------|------|-------------|
+    | `event_detail_page/*/*` | Page | Customize the event detail page theme |
+
+    The Copy / Share actions are menu items rather than standalone elements — customize their labels through [localization](/uikit/customization/localization) (`amity_social_button_copy_event_link`, `amity_social_button_share_to`).
 
   </Tab>
 </Tabs>
@@ -241,6 +257,13 @@ The sharing functionality is available across these key areas of your applicatio
     icon="newspaper"
   >
     Understand feed components and inline sharing
+  </Card>
+  <Card
+    title="Events"
+    href="/uikit/components/social/event"
+    icon="calendar"
+  >
+    Explore event components and event link sharing
   </Card>
   <Card
     title="SDK Content Sharing"

--- a/uikit/overview.mdx
+++ b/uikit/overview.mdx
@@ -181,7 +181,7 @@ social.plus UIKit provides comprehensive cross-platform support with a mobile-fi
 
     - Mobile-responsive design
     - Desktop view support for optimal web experience
-    - Progressive Web App (PWA) compatibility
+    - Light and dark theme support
     - Modern web technologies and best practices
   </Card>
 </CardGroup>

--- a/uikit/overview.mdx
+++ b/uikit/overview.mdx
@@ -181,7 +181,7 @@ social.plus UIKit provides comprehensive cross-platform support with a mobile-fi
 
     - Mobile-responsive design
     - Desktop view support for optimal web experience
-    - Light and dark theme support
+    - Progressive Web App (PWA) compatibility
     - Modern web technologies and best practices
   </Card>
 </CardGroup>

--- a/use-cases/social/build-a-social-feed.mdx
+++ b/use-cases/social/build-a-social-feed.mdx
@@ -58,9 +58,11 @@ graph TD
     B -->|Home timeline| C[User Feed]
     B -->|Inside a community| D[Community Feed]
     B -->|Explore page| E[Global Feed]
+    B -->|Personalized| FY[For You Feed]
     C --> F[Live Collection]
     D --> F
     E --> F
+    FY --> F
     F --> G[Posts render in-app]
     G --> H{Post flagged?}
     H -->|Yes| I[Hidden from feed]
@@ -134,6 +136,25 @@ Full reference → [Get User Feed](/social-plus-sdk/social/discovery-engagement/
     ```
 
     Full reference → [Query Global Feed](/social-plus-sdk/social/discovery-engagement/feed/overview)
+  </Step>
+  <Step title="Query the For You feed">
+    For You is a backend-personalized global feed. It is a network-level feature — gate the surface on `Client.getForYouFeedSetting()` and handle `AmityForYouFeedDisabledError` for networks where it is not enabled. `getForYouFeed()` takes no query parameters; page through the callback.
+
+    ```typescript TypeScript
+    import { Client, FeedRepository } from '@amityco/ts-sdk';
+
+    const { forYouFeed } = await Client.getForYouFeedSetting();
+    if (!forYouFeed.enabled) return; // hide the For You surface
+
+    const unsubscribe = FeedRepository.getForYouFeed(
+      ({ data: posts, onNextPage, hasNextPage, loading, error }) => {
+        if (error instanceof FeedRepository.AmityForYouFeedDisabledError) return;
+        if (posts) { /* render For You feed */ }
+      },
+    );
+    ```
+
+    Full reference → [Query For You Feed](/social-plus-sdk/social/discovery-engagement/feed/overview)
   </Step>
   <Step title="Subscribe to real-time events">
     Live Collections auto-update from **local cache** changes (e.g., the current user creates a post). To also receive **server-side** updates (new posts from other users, moderator deletions), you must explicitly subscribe to the relevant topic.

--- a/use-cases/social/user-profiles-and-social-graph.mdx
+++ b/use-cases/social/user-profiles-and-social-graph.mdx
@@ -187,15 +187,28 @@ Full reference → [Follow / Unfollow User](/social-plus-sdk/social/user-relatio
     Full reference → [Get Follower / Following List](/social-plus-sdk/social/user-relationship/following/get-follower-following-list)
   </Step>
   <Step title="Block and unblock a user">
-    Blocking is bidirectional — neither user can see the other's content or interact with them.
+    Blocking is bidirectional — neither user can see the other's content or interact with them. You can also read both directions: the users you blocked, and the users who blocked you.
 
     ```typescript
     import { UserRepository } from '@amityco/ts-sdk';
 
-    await UserRepository.Relationship.blockUser('userId');
+    // Block — handle the per-network block limit
+    try {
+      await UserRepository.Relationship.blockUser('userId');
+    } catch (error) {
+      if (error?.code === Amity.ServerError.MAX_BLOCKED_USERS_REACHED) {
+        showBlockedUserLimitReached();
+      }
+    }
+
+    // Users the current user blocked
+    const blocked = await UserRepository.getAllBlockedUsers();
+
+    // Users who blocked the current user (reverse direction)
+    const blocking = await UserRepository.getAllBlockingUsers();
     ```
 
-    Full reference → [Block / Unblock User](/social-plus-sdk/social/user-relationship/blocking/block-unblock-user)
+    Full reference → [Block / Unblock User](/social-plus-sdk/social/user-relationship/blocking/block-unblock-user), [Manage Blocked Users](/social-plus-sdk/social/user-relationship/blocking/manage-blocked-users), [Users Who Blocked You](/social-plus-sdk/social/user-relationship/blocking/manage-blocking-users)
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary

Documents four newly shipped features across the SDK and UIKit docs, and sweeps the existing pages for accuracy against the cleverden tech specs + SDK/UIKit source.

**For You feed** — SDK feed overview (`FeedRepository.getForYouFeed`, `Client.getForYouFeedSetting`, `AmityForYouFeedDisabledError`), UIKit For You tab, feature matrix, discovery/README enumerations, and the build-a-social-feed walkthrough.

**Bi-directional blocking** — new "Users Who Blocked You" page (`getBlockingUsers` / `getAllBlockingUsers`), the `MAX_BLOCKED_USERS_REACHED` (`400324`) error in block/unblock + the central error-constants table, and reverse-direction coverage in the relationship overview / FAQ / user-profiles use case.

**Chat v4** — corrected stale platform claims (Conversation/Group/Recent chats were marked "Flutter only"; now iOS/Android/React/Flutter), grounded `chat/overview.mdx` in the real v4 component surface, and added the missing Search/Group cards.

**Shareable event links** — SDK "Generate an Event Link" (`getShareableLinkConfiguration` + `AmitySharableContentType.EVENT`), UIKit event detail "Copy event link / Share to" actions, and event coverage across the sharing docs.

## Platform support

Per the cleverden specs, these features are **Web + iOS + Android** (Flutter out of scope). iOS/Android code snippets are included as **placeholders** (`// code sample coming soon`) for the platform teams to fill in.

## Notes for reviewers

- iOS/Android code samples and the iOS/Android error-enum names are placeholders pending platform-team input.
- `uikit/platform-guides/ios-specific.mdx` still references v3-era iOS classes (`AmityChatViewController`, `AmityFeedViewController`) — flagged for a separate iOS-v4 rewrite, not touched here.