### PR TITLE
chore(sdk-surface): refresh surfaces to July-2026 SDKs + fix Flutter lib_name

### DIFF
--- a/.docs-ops/extractors/flutter-hybrid-extractor.py
+++ b/.docs-ops/extractors/flutter-hybrid-extractor.py
@@ -90,7 +90,10 @@ def pass1_dartdoc(index_path: Path) -> tuple[dict, list, list, str]:
             by_parent[parent].append(e)
 
     lib_entries = [e for e in index if e.get("kind") == KIND_LIB]
-    lib_name = lib_entries[0]["name"] if lib_entries else "amity_sdk"
+    lib_names = [e["name"] for e in lib_entries]
+    # Prefer the package library (matches pubspec `name: amity_sdk`) over incidental
+    # part-libraries (e.g. `access_token_renewal`) that can sort first in the index.
+    lib_name = "amity_sdk" if "amity_sdk" in lib_names else (lib_names[0] if lib_names else "amity_sdk")
 
     types: dict[str, dict] = {}
     extensions: list[dict] = []

--- a/.docs-ops/sdk-surface/android-from-dokka.json
+++ b/.docs-ops/sdk-surface/android-from-dokka.json
@@ -1,7 +1,7 @@
 {
   "extractor_version": "0.2.0-dokka",
   "extractor": "android-dokka-extractor.py",
-  "extracted_at": "2026-05-19T14:05:19.272137+00:00",
+  "extracted_at": "2026-07-06T04:35:51.898581+00:00",
   "sdk_product": "AmityAndroidSDK",
   "sdk_dokka_source": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk",
   "dokka_invocation": "ANDROID_HOME=~/Library/Android/sdk ./gradlew :amity-sdk:dokkaGfm",
@@ -66,6 +66,19 @@
       },
       "members": [
         {
+          "name": "archiveChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "createChannel",
           "kind": "method",
           "signature": {
@@ -89,6 +102,22 @@
               }
             ],
             "returns": null
+          }
+        },
+        {
+          "name": "getArchivedChannelIds",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<String>>"
+          }
+        },
+        {
+          "name": "getArchivedChannels",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<List<AmityChannel>>"
           }
         },
         {
@@ -192,6 +221,27 @@
               {
                 "name": "timeout",
                 "type": "Duration"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "searchChannels",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityChannelSearchQuery.Builder"
+          }
+        },
+        {
+          "name": "unarchiveChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "String"
               }
             ],
             "returns": null
@@ -766,6 +816,166 @@
       ],
       "nested_types": []
     },
+    "AmityChannelSearchQuery": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.channel.query/-amity-channel-search-query/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "Builder",
+          "kind": "nested_type"
+        },
+        {
+          "name": "query",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityChannel>>"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "Builder",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.channel.query/-amity-channel-search-query/-builder/index.md",
+            "line": null
+          },
+          "members": [
+            {
+              "name": "build",
+              "kind": "method",
+              "signature": {
+                "parameters": [],
+                "returns": "AmityChannelSearchQuery"
+              }
+            },
+            {
+              "name": "exactMatch",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "exactMatch",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "limit",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "limit",
+                    "type": "Int"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "memberOnly",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "isMemberOnly",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "orderBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "orderBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "sortBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "sortBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "token",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "token",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "types",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "types",
+                    "type": "List<AmityChannel.Type>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "withQuery",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "query",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            }
+          ],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityCommunityChannelQuery": {
       "kind": "class",
       "language": "kotlin",
@@ -1032,6 +1242,19 @@
               }
             },
             {
+              "name": "excludeArchived",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeArchived",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "excludingTags",
               "kind": "method",
               "signature": {
@@ -1078,6 +1301,19 @@
                   {
                     "name": "includingTags",
                     "type": "AmityTags"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "keyword",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "keyword",
+                    "type": "String"
                   }
                 ],
                 "returns": null
@@ -1160,6 +1396,19 @@
                   {
                     "name": "metadata",
                     "type": "JsonObject"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "notificationMode",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "mode",
+                    "type": "AmityChannelNotificationMode"
                   }
                 ],
                 "returns": null
@@ -1934,6 +2183,19 @@
             "parameters": [
               {
                 "name": "subChannelId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "searchMessages",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "query",
                 "type": "String"
               }
             ],
@@ -3025,6 +3287,179 @@
         }
       ]
     },
+    "AmityMessageSearchQuery": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.message.query/-amity-message-search-query/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "Builder",
+          "kind": "nested_type"
+        },
+        {
+          "name": "query",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityMessage>>"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "Builder",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.message.query/-amity-message-search-query/-builder/index.md",
+            "line": null
+          },
+          "members": [
+            {
+              "name": "build",
+              "kind": "method",
+              "signature": {
+                "parameters": [],
+                "returns": "AmityMessageSearchQuery"
+              }
+            },
+            {
+              "name": "channelId",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "exactMatch",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "exactMatch",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "limit",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "limit",
+                    "type": "Int"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "messageFeedId",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "messageFeedId",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "orderBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "orderBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "sortBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "sortBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "token",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "token",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "types",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "types",
+                    "type": "List<AmityMessage.DataType>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "userIds",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userIds",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            }
+          ],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityCustomTextMessageUpdate": {
       "kind": "class",
       "language": "kotlin",
@@ -3509,6 +3944,14 @@
       },
       "members": [
         {
+          "name": "autoSubscriptions",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "List<AmityAutoSubscriptionState><br>Snapshot of the managed-subscription registry \u2014 every system handle (active or not) with its `active`, `isSystem`, and `topicCount` flags (REQ-011). Use this to inspect what is consuming broker slots; the BE caps concurrent subscriptions at 20 (client-side enforcement deferred \u2014 R10 known limitation)."
+          }
+        },
+        {
           "name": "disconnect",
           "kind": "method",
           "signature": {
@@ -3593,6 +4036,14 @@
           }
         },
         {
+          "name": "getForYouFeedSetting",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<AmityForYouFeedSetting>"
+          }
+        },
+        {
           "name": "getGlobalBanEvents",
           "kind": "method",
           "signature": {
@@ -3634,7 +4085,7 @@
           "kind": "method",
           "signature": {
             "parameters": [],
-            "returns": "AmityShareableLink"
+            "returns": "Single<AmityShareableLinkConfiguration>"
           }
         },
         {
@@ -3659,6 +4110,14 @@
           "signature": {
             "parameters": [],
             "returns": "String"
+          }
+        },
+        {
+          "name": "getVisitorUsageLimitEvents",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<AmityVisitorUsageLimitEvent>"
           }
         },
         {
@@ -3909,6 +4368,19 @@
           }
         },
         {
+          "name": "subscribeAuto",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feature",
+                "type": "AmityAutoSubscription"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "subscription",
           "kind": "method",
           "signature": {
@@ -3927,6 +4399,19 @@
           "signature": {
             "parameters": [],
             "returns": "Completable"
+          }
+        },
+        {
+          "name": "unsubscribeAuto",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feature",
+                "type": "AmityAutoSubscription"
+              }
+            ],
+            "returns": null
           }
         },
         {
@@ -5961,11 +6446,7 @@
       "members": [
         {
           "name": "getShareableLink",
-          "kind": "method",
-          "signature": {
-            "parameters": [],
-            "returns": "Single<AmityShareableLinkConfiguration>"
-          }
+          "kind": "method"
         }
       ],
       "nested_types": []
@@ -6036,7 +6517,23 @@
           }
         },
         {
+          "name": "getAllBlockingUsers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityUser>>"
+          }
+        },
+        {
           "name": "getBlockedUsers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<PagingData<AmityUser>>"
+          }
+        },
+        {
+          "name": "getBlockingUsers",
           "kind": "method",
           "signature": {
             "parameters": [],
@@ -7590,6 +8087,19 @@
               }
             },
             {
+              "name": "excludeBlockUserComments",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserComments",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeDeleted",
               "kind": "method",
               "signature": {
@@ -8253,6 +8763,19 @@
               }
             },
             {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "userIds",
               "kind": "method",
               "signature": {
@@ -8401,6 +8924,19 @@
               }
             },
             {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "withKeyword",
               "kind": "method",
               "signature": {
@@ -8533,7 +9069,7 @@
               "kind": "method",
               "signature": {
                 "parameters": [],
-                "returns": "AmityCommunitySearch<br>Instantiates AmityCommunitySearch with built params."
+                "returns": "AmityCommunitySearch"
               }
             },
             {
@@ -8583,6 +9119,19 @@
                   {
                     "name": "sortBy",
                     "type": "AmityCommunitySortOption"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
                   }
                 ],
                 "returns": null
@@ -8730,6 +9279,19 @@
                   {
                     "name": "storySettings",
                     "type": "AmityCommunityStorySettings"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
                   }
                 ],
                 "returns": null
@@ -10507,6 +11069,31 @@
           }
         },
         {
+          "name": "getForYouFeed",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<PagingData<AmityPost>><br>Queries the personalized For You feed (relevance-ranked) as a live collection."
+          }
+        },
+        {
+          "name": "getForYouFeedContext",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "String"
+              },
+              {
+                "name": "renderPosition",
+                "type": "Int"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "getGlobalFeed",
           "kind": "method",
           "signature": {
@@ -12092,6 +12679,19 @@
               }
             },
             {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "matchingOnlyParentPosts",
               "kind": "method",
               "signature": {
@@ -12261,6 +12861,19 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "feedType",
               "kind": "method",
               "signature": {
@@ -12293,6 +12906,19 @@
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -12432,6 +13058,19 @@
                 ],
                 "returns": null
               }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
             }
           ],
           "nested_types": []
@@ -12538,12 +13177,38 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeMixedStructure",
               "kind": "method",
               "signature": {
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -12695,6 +13360,19 @@
               }
             },
             {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "matchingOnlyParentPosts",
               "kind": "method",
               "signature": {
@@ -12838,6 +13516,19 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeDeleted",
               "kind": "method",
               "signature": {
@@ -12857,6 +13548,19 @@
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -14886,6 +15590,14 @@
           }
         },
         {
+          "name": "getNotificationMode",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "String?"
+          }
+        },
+        {
           "name": "getSubChannelsUnreadCount",
           "kind": "method",
           "signature": {
@@ -15213,6 +15925,68 @@
         }
       ]
     },
+    "AmityChannelNotificationMode": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "DEFAULT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "SILENT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "SUBSCRIBE",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "apiKey",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "DEFAULT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-d-e-f-a-u-l-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "SILENT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-s-i-l-e-n-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "SUBSCRIBE",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-s-u-b-s-c-r-i-b-e/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityChannelMember": {
       "kind": "data class",
       "language": "kotlin",
@@ -15397,11 +16171,27 @@
           "kind": "nested_type"
         },
         {
+          "name": "getChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityChannel?"
+          }
+        },
+        {
           "name": "getChannelId",
           "kind": "method",
           "signature": {
             "parameters": [],
             "returns": "String"
+          }
+        },
+        {
+          "name": "getChannelMembers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "List<AmityChannelMember>"
           }
         },
         {
@@ -17606,6 +18396,18 @@
           "kind": "enum_entry"
         },
         {
+          "name": "VISITOR_USAGE_LIMIT_EXCEEDED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "FEED_SNAPSHOT_EXPIRED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "MAX_BLOCKED_USERS_REACHED",
+          "kind": "enum_entry"
+        },
+        {
           "name": "VISITOR_PERMISSION_DENIED",
           "kind": "enum_entry"
         },
@@ -17659,6 +18461,10 @@
         },
         {
           "name": "TOKEN_RENEWAL_FAILED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "FOR_YOU_FEED_DISABLED",
           "kind": "enum_entry"
         },
         {
@@ -17797,6 +18603,16 @@
           "nested_types": []
         },
         {
+          "name": "FEED_SNAPSHOT_EXPIRED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-e-e-d_-s-n-a-p-s-h-o-t_-e-x-p-i-r-e-d/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
           "name": "FILE_SIZE_EXCEEDED",
           "kind": "class",
           "primary_decl": {
@@ -17811,6 +18627,16 @@
           "kind": "class",
           "primary_decl": {
             "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-o-r-b-i-d-d-e-n_-e-r-r-o-r/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "FOR_YOU_FEED_DISABLED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-o-r_-y-o-u_-f-e-e-d_-d-i-s-a-b-l-e-d/index.md",
             "line": null
           },
           "members": [],
@@ -17881,6 +18707,16 @@
           "kind": "class",
           "primary_decl": {
             "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-m-a-l-f-o-r-m-e-d_-d-a-t-a/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "MAX_BLOCKED_USERS_REACHED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-m-a-x_-b-l-o-c-k-e-d_-u-s-e-r-s_-r-e-a-c-h-e-d/index.md",
             "line": null
           },
           "members": [],
@@ -18095,6 +18931,16 @@
           },
           "members": [],
           "nested_types": []
+        },
+        {
+          "name": "VISITOR_USAGE_LIMIT_EXCEEDED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-v-i-s-i-t-o-r_-u-s-a-g-e_-l-i-m-i-t_-e-x-c-e-e-d-e-d/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
         }
       ]
     },
@@ -18171,6 +19017,131 @@
             "returns": null
           },
           "from_companion": true
+        }
+      ],
+      "nested_types": []
+    },
+    "AmityForYouFeedDisabledError": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-for-you-feed-disabled-error/index.md",
+        "line": null
+      },
+      "members": [],
+      "nested_types": []
+    },
+    "AmityAutoSubscription": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "CHAT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "NETWORK",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "BLOCK",
+          "kind": "enum_entry"
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "BLOCK",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-b-l-o-c-k/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "CHAT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-c-h-a-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-l-i-v-e-s-t-r-e-a-m/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "NETWORK",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-n-e-t-w-o-r-k/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
+    "AmityAutoSubscriptionState": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription-state/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityAutoSubscriptionState",
+          "kind": "constructor"
+        },
+        {
+          "name": "active",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean<br>True when the underlying broker subscription is active (ref-count 0 or a default-on system handle that has not been opted out)."
+          }
+        },
+        {
+          "name": "feature",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityAutoSubscription"
+          }
+        },
+        {
+          "name": "isSystem",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean<br>True for the default-on system handles (currently every handle)."
+          }
+        },
+        {
+          "name": "topicCount",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>Number of MQTT topic slots this handle consumes against the BE 20-cap."
+          }
         }
       ],
       "nested_types": []
@@ -23252,6 +24223,29 @@
       ],
       "nested_types": []
     },
+    "AmityVisitorUsageLimitEvent": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.session/-amity-visitor-usage-limit-event/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityVisitorUsageLimitEvent",
+          "kind": "constructor"
+        },
+        {
+          "name": "userId",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String"
+          }
+        }
+      ],
+      "nested_types": []
+    },
     "LoginMethod": {
       "kind": "enum",
       "language": "kotlin",
@@ -23337,6 +24331,107 @@
       ],
       "nested_types": []
     },
+    "AmityForYouFeedSetting": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.settings/-amity-for-you-feed-setting/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "enabled",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean"
+          }
+        }
+      ],
+      "nested_types": []
+    },
+    "AmitySharableContentType": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "POST",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "COMMUNITY",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "USER",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "EVENT",
+          "kind": "enum_entry"
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "COMMUNITY",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-c-o-m-m-u-n-i-t-y/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "EVENT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-e-v-e-n-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-l-i-v-e-s-t-r-e-a-m/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "POST",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-p-o-s-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "USER",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-u-s-e-r/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityShareableLinkConfiguration": {
       "kind": "data class",
       "language": "kotlin",
@@ -23350,6 +24445,23 @@
           "kind": "constructor"
         },
         {
+          "name": "generateLink",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              },
+              {
+                "name": "referenceId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "getDomain",
           "kind": "method",
           "signature": {
@@ -23358,11 +24470,33 @@
           }
         },
         {
-          "name": "getPatterns",
+          "name": "getPattern",
           "kind": "method",
           "signature": {
-            "parameters": [],
-            "returns": "Map<String, String>"
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "getPatterns",
+          "kind": "method"
+        },
+        {
+          "name": "isEnabled",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              }
+            ],
+            "returns": null
           }
         }
       ],
@@ -27241,6 +28375,133 @@
         }
       ]
     },
+    "AmityForYouFeedContext": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.social.post/-amity-for-you-feed-context/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityForYouFeedContext",
+          "kind": "constructor"
+        },
+        {
+          "name": "feedAffinityScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedFinalScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedFreshnessScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedInjectionType",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String<br>`ranked` / `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedMmrPenalty",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedMmrScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double?<br>MMR-adjusted score. Null for `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedPagePosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-based position in this page's final output (after injection + validation)."
+          }
+        },
+        {
+          "name": "feedPersonalizationStage",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int?<br>GCF personalization stage for this user. Null for `live_stream`."
+          }
+        },
+        {
+          "name": "feedPopularityScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedRelevanceScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double<br>Per-signal scores. All sourced from the post's `feedMetadata` entry."
+          }
+        },
+        {
+          "name": "feedRenderPosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-indexed visual position assigned by the UIKit at render time. Accounts for posts removed by client-side filtering \u2014 UIKit-computed, not BE-derivable."
+          }
+        },
+        {
+          "name": "feedScoredRank",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int?<br>0-based rank in the GCF-ranked candidate list. Null for `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedScoringId",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String?<br>BE scoring-run identifier. Always null today \u2014 `feed_scoring_id` is required on engagement events per tech-proposals/30 but not yet exposed in the BE feed payload. See `ForYouFeedMetadataDto` for the open gap."
+          }
+        },
+        {
+          "name": "feedSnapshotPosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-indexed position in the Redis snapshot (post-MMR). From `feedMetadata.feedSnapshotPosition`."
+          }
+        }
+      ],
+      "nested_types": []
+    },
     "AmityPost": {
       "kind": "data class",
       "language": "kotlin",
@@ -27331,6 +28592,14 @@
           "signature": {
             "parameters": [],
             "returns": "DateTime?"
+          }
+        },
+        {
+          "name": "getEventId",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "String?"
           }
         },
         {
@@ -27901,6 +29170,19 @@
         "line": null
       },
       "members": [
+        {
+          "name": "markAsMeaningfullyViewed",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feedRenderPosition",
+                "type": "Int? = null"
+              }
+            ],
+            "returns": null
+          }
+        },
         {
           "name": "markAsViewed",
           "kind": "method"
@@ -30299,12 +31581,12 @@
   "typealiases": [],
   "stats": {
     "packages_scanned": 130,
-    "packages_skipped_non_amity": 138,
-    "types": 319,
+    "packages_skipped_non_amity": 140,
+    "types": 329,
     "interfaces": 3,
-    "members_total": 1886,
+    "members_total": 1953,
     "global_funcs": 10,
-    "nested_types_total": 455,
-    "enum_entries_total": 279
+    "nested_types_total": 473,
+    "enum_entries_total": 295
   }
 }

--- a/.docs-ops/sdk-surface/android.json
+++ b/.docs-ops/sdk-surface/android.json
@@ -1,7 +1,7 @@
 {
   "extractor_version": "0.2.0-dokka",
   "extractor": "android-dokka-extractor.py",
-  "extracted_at": "2026-05-19T14:05:19.272137+00:00",
+  "extracted_at": "2026-07-06T04:35:51.898581+00:00",
   "sdk_product": "AmityAndroidSDK",
   "sdk_dokka_source": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk",
   "dokka_invocation": "ANDROID_HOME=~/Library/Android/sdk ./gradlew :amity-sdk:dokkaGfm",
@@ -66,6 +66,19 @@
       },
       "members": [
         {
+          "name": "archiveChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "createChannel",
           "kind": "method",
           "signature": {
@@ -89,6 +102,22 @@
               }
             ],
             "returns": null
+          }
+        },
+        {
+          "name": "getArchivedChannelIds",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<String>>"
+          }
+        },
+        {
+          "name": "getArchivedChannels",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<List<AmityChannel>>"
           }
         },
         {
@@ -192,6 +221,27 @@
               {
                 "name": "timeout",
                 "type": "Duration"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "searchChannels",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityChannelSearchQuery.Builder"
+          }
+        },
+        {
+          "name": "unarchiveChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "String"
               }
             ],
             "returns": null
@@ -766,6 +816,166 @@
       ],
       "nested_types": []
     },
+    "AmityChannelSearchQuery": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.channel.query/-amity-channel-search-query/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "Builder",
+          "kind": "nested_type"
+        },
+        {
+          "name": "query",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityChannel>>"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "Builder",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.channel.query/-amity-channel-search-query/-builder/index.md",
+            "line": null
+          },
+          "members": [
+            {
+              "name": "build",
+              "kind": "method",
+              "signature": {
+                "parameters": [],
+                "returns": "AmityChannelSearchQuery"
+              }
+            },
+            {
+              "name": "exactMatch",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "exactMatch",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "limit",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "limit",
+                    "type": "Int"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "memberOnly",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "isMemberOnly",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "orderBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "orderBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "sortBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "sortBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "token",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "token",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "types",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "types",
+                    "type": "List<AmityChannel.Type>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "withQuery",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "query",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            }
+          ],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityCommunityChannelQuery": {
       "kind": "class",
       "language": "kotlin",
@@ -1032,6 +1242,19 @@
               }
             },
             {
+              "name": "excludeArchived",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeArchived",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "excludingTags",
               "kind": "method",
               "signature": {
@@ -1078,6 +1301,19 @@
                   {
                     "name": "includingTags",
                     "type": "AmityTags"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "keyword",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "keyword",
+                    "type": "String"
                   }
                 ],
                 "returns": null
@@ -1160,6 +1396,19 @@
                   {
                     "name": "metadata",
                     "type": "JsonObject"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "notificationMode",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "mode",
+                    "type": "AmityChannelNotificationMode"
                   }
                 ],
                 "returns": null
@@ -1934,6 +2183,19 @@
             "parameters": [
               {
                 "name": "subChannelId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "searchMessages",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "query",
                 "type": "String"
               }
             ],
@@ -3025,6 +3287,179 @@
         }
       ]
     },
+    "AmityMessageSearchQuery": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.message.query/-amity-message-search-query/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "Builder",
+          "kind": "nested_type"
+        },
+        {
+          "name": "query",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityMessage>>"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "Builder",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.api.chat.message.query/-amity-message-search-query/-builder/index.md",
+            "line": null
+          },
+          "members": [
+            {
+              "name": "build",
+              "kind": "method",
+              "signature": {
+                "parameters": [],
+                "returns": "AmityMessageSearchQuery"
+              }
+            },
+            {
+              "name": "channelId",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "exactMatch",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "exactMatch",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "limit",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "limit",
+                    "type": "Int"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "messageFeedId",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "messageFeedId",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "orderBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "orderBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "sortBy",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "sortBy",
+                    "type": "String"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "token",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "token",
+                    "type": "String?"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "types",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "types",
+                    "type": "List<AmityMessage.DataType>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "userIds",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userIds",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            }
+          ],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityCustomTextMessageUpdate": {
       "kind": "class",
       "language": "kotlin",
@@ -3509,6 +3944,14 @@
       },
       "members": [
         {
+          "name": "autoSubscriptions",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "List<AmityAutoSubscriptionState><br>Snapshot of the managed-subscription registry \u2014 every system handle (active or not) with its `active`, `isSystem`, and `topicCount` flags (REQ-011). Use this to inspect what is consuming broker slots; the BE caps concurrent subscriptions at 20 (client-side enforcement deferred \u2014 R10 known limitation)."
+          }
+        },
+        {
           "name": "disconnect",
           "kind": "method",
           "signature": {
@@ -3593,6 +4036,14 @@
           }
         },
         {
+          "name": "getForYouFeedSetting",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<AmityForYouFeedSetting>"
+          }
+        },
+        {
           "name": "getGlobalBanEvents",
           "kind": "method",
           "signature": {
@@ -3634,7 +4085,7 @@
           "kind": "method",
           "signature": {
             "parameters": [],
-            "returns": "AmityShareableLink"
+            "returns": "Single<AmityShareableLinkConfiguration>"
           }
         },
         {
@@ -3659,6 +4110,14 @@
           "signature": {
             "parameters": [],
             "returns": "String"
+          }
+        },
+        {
+          "name": "getVisitorUsageLimitEvents",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<AmityVisitorUsageLimitEvent>"
           }
         },
         {
@@ -3909,6 +4368,19 @@
           }
         },
         {
+          "name": "subscribeAuto",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feature",
+                "type": "AmityAutoSubscription"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "subscription",
           "kind": "method",
           "signature": {
@@ -3927,6 +4399,19 @@
           "signature": {
             "parameters": [],
             "returns": "Completable"
+          }
+        },
+        {
+          "name": "unsubscribeAuto",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feature",
+                "type": "AmityAutoSubscription"
+              }
+            ],
+            "returns": null
           }
         },
         {
@@ -5961,11 +6446,7 @@
       "members": [
         {
           "name": "getShareableLink",
-          "kind": "method",
-          "signature": {
-            "parameters": [],
-            "returns": "Single<AmityShareableLinkConfiguration>"
-          }
+          "kind": "method"
         }
       ],
       "nested_types": []
@@ -6036,7 +6517,23 @@
           }
         },
         {
+          "name": "getAllBlockingUsers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Single<List<AmityUser>>"
+          }
+        },
+        {
           "name": "getBlockedUsers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<PagingData<AmityUser>>"
+          }
+        },
+        {
+          "name": "getBlockingUsers",
           "kind": "method",
           "signature": {
             "parameters": [],
@@ -7590,6 +8087,19 @@
               }
             },
             {
+              "name": "excludeBlockUserComments",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserComments",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeDeleted",
               "kind": "method",
               "signature": {
@@ -8253,6 +8763,19 @@
               }
             },
             {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "userIds",
               "kind": "method",
               "signature": {
@@ -8401,6 +8924,19 @@
               }
             },
             {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "withKeyword",
               "kind": "method",
               "signature": {
@@ -8533,7 +9069,7 @@
               "kind": "method",
               "signature": {
                 "parameters": [],
-                "returns": "AmityCommunitySearch<br>Instantiates AmityCommunitySearch with built params."
+                "returns": "AmityCommunitySearch"
               }
             },
             {
@@ -8583,6 +9119,19 @@
                   {
                     "name": "sortBy",
                     "type": "AmityCommunitySortOption"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
                   }
                 ],
                 "returns": null
@@ -8730,6 +9279,19 @@
                   {
                     "name": "storySettings",
                     "type": "AmityCommunityStorySettings"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "tags",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "tags",
+                    "type": "List<String>"
                   }
                 ],
                 "returns": null
@@ -10507,6 +11069,31 @@
           }
         },
         {
+          "name": "getForYouFeed",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "Flowable<PagingData<AmityPost>><br>Queries the personalized For You feed (relevance-ranked) as a live collection."
+          }
+        },
+        {
+          "name": "getForYouFeedContext",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "String"
+              },
+              {
+                "name": "renderPosition",
+                "type": "Int"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "getGlobalFeed",
           "kind": "method",
           "signature": {
@@ -12092,6 +12679,19 @@
               }
             },
             {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "matchingOnlyParentPosts",
               "kind": "method",
               "signature": {
@@ -12261,6 +12861,19 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "feedType",
               "kind": "method",
               "signature": {
@@ -12293,6 +12906,19 @@
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -12432,6 +13058,19 @@
                 ],
                 "returns": null
               }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
             }
           ],
           "nested_types": []
@@ -12538,12 +13177,38 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeMixedStructure",
               "kind": "method",
               "signature": {
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -12695,6 +13360,19 @@
               }
             },
             {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "matchingOnlyParentPosts",
               "kind": "method",
               "signature": {
@@ -12838,6 +13516,19 @@
               }
             },
             {
+              "name": "excludeBlockUserPosts",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "excludeBlockUserPosts",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
               "name": "includeDeleted",
               "kind": "method",
               "signature": {
@@ -12857,6 +13548,19 @@
                 "parameters": [
                   {
                     "name": "includeMixedStructure",
+                    "type": "Boolean"
+                  }
+                ],
+                "returns": null
+              }
+            },
+            {
+              "name": "invalidateCache",
+              "kind": "method",
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "invalidateCache",
                     "type": "Boolean"
                   }
                 ],
@@ -14886,6 +15590,14 @@
           }
         },
         {
+          "name": "getNotificationMode",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "String?"
+          }
+        },
+        {
           "name": "getSubChannelsUnreadCount",
           "kind": "method",
           "signature": {
@@ -15213,6 +15925,68 @@
         }
       ]
     },
+    "AmityChannelNotificationMode": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "DEFAULT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "SILENT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "SUBSCRIBE",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "apiKey",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String"
+          }
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "DEFAULT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-d-e-f-a-u-l-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "SILENT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-s-i-l-e-n-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "SUBSCRIBE",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.chat.channel/-amity-channel-notification-mode/-s-u-b-s-c-r-i-b-e/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityChannelMember": {
       "kind": "data class",
       "language": "kotlin",
@@ -15397,11 +16171,27 @@
           "kind": "nested_type"
         },
         {
+          "name": "getChannel",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityChannel?"
+          }
+        },
+        {
           "name": "getChannelId",
           "kind": "method",
           "signature": {
             "parameters": [],
             "returns": "String"
+          }
+        },
+        {
+          "name": "getChannelMembers",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "List<AmityChannelMember>"
           }
         },
         {
@@ -17606,6 +18396,18 @@
           "kind": "enum_entry"
         },
         {
+          "name": "VISITOR_USAGE_LIMIT_EXCEEDED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "FEED_SNAPSHOT_EXPIRED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "MAX_BLOCKED_USERS_REACHED",
+          "kind": "enum_entry"
+        },
+        {
           "name": "VISITOR_PERMISSION_DENIED",
           "kind": "enum_entry"
         },
@@ -17659,6 +18461,10 @@
         },
         {
           "name": "TOKEN_RENEWAL_FAILED",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "FOR_YOU_FEED_DISABLED",
           "kind": "enum_entry"
         },
         {
@@ -17797,6 +18603,16 @@
           "nested_types": []
         },
         {
+          "name": "FEED_SNAPSHOT_EXPIRED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-e-e-d_-s-n-a-p-s-h-o-t_-e-x-p-i-r-e-d/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
           "name": "FILE_SIZE_EXCEEDED",
           "kind": "class",
           "primary_decl": {
@@ -17811,6 +18627,16 @@
           "kind": "class",
           "primary_decl": {
             "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-o-r-b-i-d-d-e-n_-e-r-r-o-r/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "FOR_YOU_FEED_DISABLED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-f-o-r_-y-o-u_-f-e-e-d_-d-i-s-a-b-l-e-d/index.md",
             "line": null
           },
           "members": [],
@@ -17881,6 +18707,16 @@
           "kind": "class",
           "primary_decl": {
             "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-m-a-l-f-o-r-m-e-d_-d-a-t-a/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "MAX_BLOCKED_USERS_REACHED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-m-a-x_-b-l-o-c-k-e-d_-u-s-e-r-s_-r-e-a-c-h-e-d/index.md",
             "line": null
           },
           "members": [],
@@ -18095,6 +18931,16 @@
           },
           "members": [],
           "nested_types": []
+        },
+        {
+          "name": "VISITOR_USAGE_LIMIT_EXCEEDED",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-error/-v-i-s-i-t-o-r_-u-s-a-g-e_-l-i-m-i-t_-e-x-c-e-e-d-e-d/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
         }
       ]
     },
@@ -18171,6 +19017,131 @@
             "returns": null
           },
           "from_companion": true
+        }
+      ],
+      "nested_types": []
+    },
+    "AmityForYouFeedDisabledError": {
+      "kind": "class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.error/-amity-for-you-feed-disabled-error/index.md",
+        "line": null
+      },
+      "members": [],
+      "nested_types": []
+    },
+    "AmityAutoSubscription": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "CHAT",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "NETWORK",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "BLOCK",
+          "kind": "enum_entry"
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "BLOCK",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-b-l-o-c-k/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "CHAT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-c-h-a-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-l-i-v-e-s-t-r-e-a-m/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "NETWORK",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription/-n-e-t-w-o-r-k/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
+    "AmityAutoSubscriptionState": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.events/-amity-auto-subscription-state/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityAutoSubscriptionState",
+          "kind": "constructor"
+        },
+        {
+          "name": "active",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean<br>True when the underlying broker subscription is active (ref-count 0 or a default-on system handle that has not been opted out)."
+          }
+        },
+        {
+          "name": "feature",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "AmityAutoSubscription"
+          }
+        },
+        {
+          "name": "isSystem",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean<br>True for the default-on system handles (currently every handle)."
+          }
+        },
+        {
+          "name": "topicCount",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>Number of MQTT topic slots this handle consumes against the BE 20-cap."
+          }
         }
       ],
       "nested_types": []
@@ -23252,6 +24223,29 @@
       ],
       "nested_types": []
     },
+    "AmityVisitorUsageLimitEvent": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.session/-amity-visitor-usage-limit-event/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityVisitorUsageLimitEvent",
+          "kind": "constructor"
+        },
+        {
+          "name": "userId",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String"
+          }
+        }
+      ],
+      "nested_types": []
+    },
     "LoginMethod": {
       "kind": "enum",
       "language": "kotlin",
@@ -23337,6 +24331,107 @@
       ],
       "nested_types": []
     },
+    "AmityForYouFeedSetting": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.settings/-amity-for-you-feed-setting/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "enabled",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Boolean"
+          }
+        }
+      ],
+      "nested_types": []
+    },
+    "AmitySharableContentType": {
+      "kind": "enum",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "POST",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "COMMUNITY",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "USER",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "enum_entry"
+        },
+        {
+          "name": "EVENT",
+          "kind": "enum_entry"
+        }
+      ],
+      "nested_types": [
+        {
+          "name": "COMMUNITY",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-c-o-m-m-u-n-i-t-y/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "EVENT",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-e-v-e-n-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "LIVESTREAM",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-l-i-v-e-s-t-r-e-a-m/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "POST",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-p-o-s-t/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        },
+        {
+          "name": "USER",
+          "kind": "class",
+          "primary_decl": {
+            "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.core.shareablelink/-amity-sharable-content-type/-u-s-e-r/index.md",
+            "line": null
+          },
+          "members": [],
+          "nested_types": []
+        }
+      ]
+    },
     "AmityShareableLinkConfiguration": {
       "kind": "data class",
       "language": "kotlin",
@@ -23350,6 +24445,23 @@
           "kind": "constructor"
         },
         {
+          "name": "generateLink",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              },
+              {
+                "name": "referenceId",
+                "type": "String"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
           "name": "getDomain",
           "kind": "method",
           "signature": {
@@ -23358,11 +24470,33 @@
           }
         },
         {
-          "name": "getPatterns",
+          "name": "getPattern",
           "kind": "method",
           "signature": {
-            "parameters": [],
-            "returns": "Map<String, String>"
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              }
+            ],
+            "returns": null
+          }
+        },
+        {
+          "name": "getPatterns",
+          "kind": "method"
+        },
+        {
+          "name": "isEnabled",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "contentType",
+                "type": "AmitySharableContentType"
+              }
+            ],
+            "returns": null
           }
         }
       ],
@@ -27241,6 +28375,133 @@
         }
       ]
     },
+    "AmityForYouFeedContext": {
+      "kind": "data class",
+      "language": "kotlin",
+      "primary_decl": {
+        "file": "Amity-Social-Cloud-SDK-Android/amity-sdk/build/dokka/gfm/amity-sdk/com.amity.socialcloud.sdk.model.social.post/-amity-for-you-feed-context/index.md",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "AmityForYouFeedContext",
+          "kind": "constructor"
+        },
+        {
+          "name": "feedAffinityScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedFinalScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedFreshnessScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedInjectionType",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String<br>`ranked` / `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedMmrPenalty",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedMmrScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double?<br>MMR-adjusted score. Null for `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedPagePosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-based position in this page's final output (after injection + validation)."
+          }
+        },
+        {
+          "name": "feedPersonalizationStage",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int?<br>GCF personalization stage for this user. Null for `live_stream`."
+          }
+        },
+        {
+          "name": "feedPopularityScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double"
+          }
+        },
+        {
+          "name": "feedRelevanceScore",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Double<br>Per-signal scores. All sourced from the post's `feedMetadata` entry."
+          }
+        },
+        {
+          "name": "feedRenderPosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-indexed visual position assigned by the UIKit at render time. Accounts for posts removed by client-side filtering \u2014 UIKit-computed, not BE-derivable."
+          }
+        },
+        {
+          "name": "feedScoredRank",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int?<br>0-based rank in the GCF-ranked candidate list. Null for `exploration` / `live_stream`."
+          }
+        },
+        {
+          "name": "feedScoringId",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "String?<br>BE scoring-run identifier. Always null today \u2014 `feed_scoring_id` is required on engagement events per tech-proposals/30 but not yet exposed in the BE feed payload. See `ForYouFeedMetadataDto` for the open gap."
+          }
+        },
+        {
+          "name": "feedSnapshotPosition",
+          "kind": "property",
+          "signature": {
+            "parameters": [],
+            "returns": "Int<br>0-indexed position in the Redis snapshot (post-MMR). From `feedMetadata.feedSnapshotPosition`."
+          }
+        }
+      ],
+      "nested_types": []
+    },
     "AmityPost": {
       "kind": "data class",
       "language": "kotlin",
@@ -27331,6 +28592,14 @@
           "signature": {
             "parameters": [],
             "returns": "DateTime?"
+          }
+        },
+        {
+          "name": "getEventId",
+          "kind": "method",
+          "signature": {
+            "parameters": [],
+            "returns": "String?"
           }
         },
         {
@@ -27901,6 +29170,19 @@
         "line": null
       },
       "members": [
+        {
+          "name": "markAsMeaningfullyViewed",
+          "kind": "method",
+          "signature": {
+            "parameters": [
+              {
+                "name": "feedRenderPosition",
+                "type": "Int? = null"
+              }
+            ],
+            "returns": null
+          }
+        },
         {
           "name": "markAsViewed",
           "kind": "method"
@@ -30299,12 +31581,12 @@
   "typealiases": [],
   "stats": {
     "packages_scanned": 130,
-    "packages_skipped_non_amity": 138,
-    "types": 319,
+    "packages_skipped_non_amity": 140,
+    "types": 329,
     "interfaces": 3,
-    "members_total": 1886,
+    "members_total": 1953,
     "global_funcs": 10,
-    "nested_types_total": 455,
-    "enum_entries_total": 279
+    "nested_types_total": 473,
+    "enum_entries_total": 295
   }
 }

--- a/.docs-ops/sdk-surface/flutter.json
+++ b/.docs-ops/sdk-surface/flutter.json
@@ -1,7 +1,7 @@
 {
   "extractor_version": "0.3.0-hybrid",
   "extractor": "flutter-hybrid-extractor.py",
-  "extracted_at": "2026-05-20T01:03:58.473973+00:00",
+  "extracted_at": "2026-07-06T04:44:59.802020+00:00",
   "sdk_product": "amity_sdk",
   "sdk_source_roots": [
     "/Users/admin/Documents/GitHub/sp-sdks/Amity-Social-Cloud-SDK-Flutter-Internal"
@@ -33,43 +33,6 @@
         {
           "name": "unableToRetrieveAuthToken",
           "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AddReactionQueryBuilder": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AddReactionQueryBuilder.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "addReaction",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "removeReaction",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "All": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "All.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "value",
-          "kind": "const",
           "overridden_depth": 0
         }
       ]
@@ -232,6 +195,47 @@
         {
           "name": "value",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityFrequencySettings": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityFrequencySettings.fromJson",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "AmityFrequencySettings.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "frequency",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getCommentAdFrequency",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getFeedAdFrequency",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getStoryAdFrequency",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toJson",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -420,33 +424,6 @@
         }
       ]
     },
-    "AmityAttachmentCommentCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityAttachmentCommentCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityAudio": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityAudio.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityBlockUserQueryBuilder": {
       "kind": "class",
       "language": "dart",
@@ -596,6 +573,39 @@
           "name": "updatedAt",
           "kind": "getter",
           "overridden_depth": 0
+        }
+      ]
+    },
+    "NotificationMode": {
+      "kind": "enum",
+      "language": "dart",
+      "members": [
+        {
+          "name": "fromString",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "values",
+          "kind": "enum_value",
+          "overridden_depth": 0
+        },
+        {
+          "name": "defaultMode",
+          "kind": "enum_value"
+        },
+        {
+          "name": "silent",
+          "kind": "enum_value"
+        },
+        {
+          "name": "subscribe",
+          "kind": "enum_value"
         }
       ]
     },
@@ -812,32 +822,6 @@
         {
           "name": "BANNED",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityChannelMentionMetadata": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityChannelMentionMetadata.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "index",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "length",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toMap",
-          "kind": "func",
-          "overridden_depth": 1
         }
       ]
     },
@@ -1285,63 +1269,6 @@
         }
       ]
     },
-    "AmityCommentCreationTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentCreationTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "content",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "create",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "parentId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "post",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "story",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityCommentCreationType": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentCreationType.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "attachments",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityCommentData": {
       "kind": "class",
       "language": "dart",
@@ -1378,27 +1305,248 @@
         }
       ]
     },
-    "AmityCommentDataTypeFilter": {
+    "AmityCommentTarget": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityCommentDataTypeFilter.any",
+          "name": "AmityCommentTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentAttachment": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentAttachment.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "AmityCommentDataTypeFilter.exact",
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getFileId",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentFileData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentFileData.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "dataTypes",
+          "name": "file",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentImageAttachment": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentImageAttachment.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getFileId",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getImage",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentImageData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentImageData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
           "kind": "getter",
           "overridden_depth": 0
         },
         {
-          "name": "matchType",
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "CommentLiveStreamData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentLiveStreamData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "streamId",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentTextData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentTextData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "CommentVideoData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentVideoData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "thumbnail",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommunityCommentTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommunityCommentTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "communityId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "creatorMember",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "type",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "ContentCommentTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "ContentCommentTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "contentId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "type",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "UnknownCommentTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UnknownCommentTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "UserCommentTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UserCommentTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "type",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "userId",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -1416,119 +1564,6 @@
         {
           "name": "COMMENT",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityCommentQueryBuilder": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentQueryBuilder.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "applyParentFilter",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "build",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "dataTypeFilter",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "dataTypes",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "filterById",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getLiveCollection",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPagingData",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "includeDeleted",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "parentId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "query",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "referenceId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "referenceType",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "sortBy",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityCommentQueryTypeSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentQueryTypeSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "content",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "post",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "story",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityCommentReactionReference": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentReactionReference.new",
-          "kind": "constructor",
-          "overridden_depth": 0
         }
       ]
     },
@@ -1582,17 +1617,6 @@
         }
       ]
     },
-    "AmityCommentTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityCommentTargetType": {
       "kind": "enum",
       "language": "dart",
@@ -1617,22 +1641,6 @@
         {
           "name": "UNKNOWN",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityCommentUpdater": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCommentUpdater.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "update",
-          "kind": "func",
-          "overridden_depth": 0
         }
       ]
     },
@@ -2213,6 +2221,210 @@
         }
       ]
     },
+    "CommentCreated": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentCreated.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentReacted": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentReacted.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommentReplied": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommentReplied.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommunityNotificationModifier": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommunityNotificationModifier.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "eventName",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "excludedRoles",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "includedRoles",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "isEnabled",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "rolesFilter",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "PostCreated": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "PostCreated.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "PostReacted": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "PostReacted.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "StoryCommentCreated": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "StoryCommentCreated.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "StoryCreated": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "StoryCreated.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "StoryReacted": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "StoryReacted.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityCommunityNotificationSettings": {
       "kind": "class",
       "language": "dart",
@@ -2614,47 +2826,47 @@
         {
           "name": "disconnect",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getAnalyticsEngine",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getConfiguration",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getCurrentUser",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getUserId",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "hasPermission",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "isUserLoggedIn",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "login",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "logout",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "mentionConfigurations",
@@ -2669,47 +2881,47 @@
         {
           "name": "newFileRepository",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "newUserRepository",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "notifications",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeSessionState",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeUnreadCount",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "registerDeviceNotification",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "setup",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "unregisterDeviceNotification",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "updateUser",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "validateTexts",
@@ -2769,64 +2981,6 @@
         }
       ]
     },
-    "AmityCustomMessageCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCustomMessageCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "customData",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 1
-        }
-      ]
-    },
-    "AmityCustomPostCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCustomPostCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityCustomRankingGlobalFeedQuery": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityCustomRankingGlobalFeedQuery.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getLiveCollection",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPagingData",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityDataType": {
       "kind": "enum",
       "language": "dart",
@@ -2862,29 +3016,6 @@
         },
         {
           "name": "CUSTOM",
-          "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityEndpoint": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "SG",
-          "kind": "enum_value"
-        },
-        {
-          "name": "EU",
-          "kind": "enum_value"
-        },
-        {
-          "name": "US",
           "kind": "enum_value"
         }
       ]
@@ -2945,6 +3076,17 @@
         {
           "name": "DECLINED",
           "kind": "enum_value"
+        }
+      ]
+    },
+    "AmityAudio": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityAudio.new",
+          "kind": "constructor",
+          "overridden_depth": 0
         }
       ]
     },
@@ -3025,50 +3167,134 @@
         }
       ]
     },
-    "AmityFileMessageCreator": {
+    "AmityImage": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityFileMessageCreator.new",
+          "name": "AmityImage.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "caption",
+          "name": "getFilePath",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getHeight",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "getData",
+          "name": "getUrl",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
-          "name": "getDataType",
+          "name": "getWidth",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
-          "name": "getUri",
-          "kind": "func",
-          "overridden_depth": 1
+          "name": "hasLocalPreview",
+          "kind": "getter",
+          "overridden_depth": 0
         },
         {
-          "name": "uri",
+          "name": "isFullImage",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityImageSize": {
+      "kind": "enum",
+      "language": "dart",
+      "members": [
+        {
+          "name": "values",
+          "kind": "enum_value",
+          "overridden_depth": 0
+        },
+        {
+          "name": "SMALL",
+          "kind": "enum_value"
+        },
+        {
+          "name": "MEDIUM",
+          "kind": "enum_value"
+        },
+        {
+          "name": "LARGE",
+          "kind": "enum_value"
+        },
+        {
+          "name": "FULL",
+          "kind": "enum_value"
+        }
+      ]
+    },
+    "AmityVideo": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityVideo.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "fileProperties",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getFilePath",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getResolutions",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getVideoUrl",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "hasLocalPreview",
           "kind": "getter",
           "overridden_depth": 0
         }
       ]
     },
-    "AmityFilePostCreator": {
-      "kind": "class",
+    "AmityVideoQuality": {
+      "kind": "enum",
       "language": "dart",
       "members": [
         {
-          "name": "AmityFilePostCreator.new",
-          "kind": "constructor",
+          "name": "values",
+          "kind": "enum_value",
           "overridden_depth": 0
+        },
+        {
+          "name": "ORIGINAL",
+          "kind": "enum_value"
+        },
+        {
+          "name": "HIGH",
+          "kind": "enum_value"
+        },
+        {
+          "name": "MEDIUM",
+          "kind": "enum_value"
+        },
+        {
+          "name": "LOW",
+          "kind": "enum_value"
         }
       ]
     },
@@ -3323,78 +3549,6 @@
         }
       ]
     },
-    "AmityFrequencySettings": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityFrequencySettings.fromJson",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "AmityFrequencySettings.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "frequency",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getCommentAdFrequency",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getFeedAdFrequency",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getStoryAdFrequency",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toJson",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityGlobalFeedQuery": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityGlobalFeedQuery.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getLiveCollection",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPagingData",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPagingDataStream",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "types",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityGlobalPermissionValidator": {
       "kind": "class",
       "language": "dart",
@@ -3435,132 +3589,6 @@
         {
           "name": "SMART",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityImage": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityImage.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getFilePath",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getHeight",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getUrl",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getWidth",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "hasLocalPreview",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isFullImage",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityImageMessageCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityImageMessageCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "caption",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getUri",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "uri",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityImagePostCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityImagePostCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityImageSize": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "SMALL",
-          "kind": "enum_value"
-        },
-        {
-          "name": "MEDIUM",
-          "kind": "enum_value"
-        },
-        {
-          "name": "LARGE",
-          "kind": "enum_value"
-        },
-        {
-          "name": "FULL",
-          "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityLiveStreamPostCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityLiveStreamPostCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
         }
       ]
     },
@@ -3606,6 +3634,32 @@
         }
       ]
     },
+    "AmityChannelMentionMetadata": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityChannelMentionMetadata.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "index",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "length",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toMap",
+          "kind": "func",
+          "overridden_depth": 1
+        }
+      ]
+    },
     "AmityMentionMetadata": {
       "kind": "class",
       "language": "dart",
@@ -3618,6 +3672,37 @@
         {
           "name": "toMap",
           "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityUserMentionMetadata": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityUserMentionMetadata.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "index",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "length",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toMap",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "userId",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -3901,119 +3986,6 @@
         }
       ]
     },
-    "AmityMessageCreateDataTypeSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityMessageCreateDataTypeSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "custom",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "file",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "image",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "parentId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "video",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityMessageCreateTargetSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityMessageCreateTargetSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "subchannelId",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityMessageCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityMessageCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getUri",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "mentionChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "mentionUsers",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "metadata",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "parentId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "send",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "tags",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityMessageData": {
       "kind": "class",
       "language": "dart",
@@ -4050,49 +4022,139 @@
         }
       ]
     },
-    "AmityMessageDataType": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "TEXT",
-          "kind": "enum_value"
-        },
-        {
-          "name": "IMAGE",
-          "kind": "enum_value"
-        },
-        {
-          "name": "FILE",
-          "kind": "enum_value"
-        },
-        {
-          "name": "AUDIO",
-          "kind": "enum_value"
-        },
-        {
-          "name": "VIDEO",
-          "kind": "enum_value"
-        },
-        {
-          "name": "CUSTOM",
-          "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityMessageReactionReference": {
+    "MessageAudioData": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityMessageReactionReference.new",
+          "name": "MessageAudioData.new",
           "kind": "constructor",
           "overridden_depth": 0
+        },
+        {
+          "name": "audio",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "MessageCustomData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "MessageCustomData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "MessageFileData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "MessageFileData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "caption",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "file",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "MessageImageData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "MessageImageData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "caption",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "MessageTextData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "MessageTextData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "MessageVideoData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "MessageVideoData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getVideo",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "thumbnailImageFile",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
         }
       ]
     },
@@ -4127,44 +4189,38 @@
         }
       ]
     },
-    "AmityMessageUpdateQueryBuilder": {
-      "kind": "class",
+    "AmityMessageDataType": {
+      "kind": "enum",
       "language": "dart",
       "members": [
         {
-          "name": "AmityMessageUpdateQueryBuilder.new",
-          "kind": "constructor",
+          "name": "values",
+          "kind": "enum_value",
           "overridden_depth": 0
         },
         {
-          "name": "customData",
-          "kind": "func",
-          "overridden_depth": 0
+          "name": "TEXT",
+          "kind": "enum_value"
         },
         {
-          "name": "messageId",
-          "kind": "getter",
-          "overridden_depth": 0
+          "name": "IMAGE",
+          "kind": "enum_value"
         },
         {
-          "name": "metadata",
-          "kind": "func",
-          "overridden_depth": 0
+          "name": "FILE",
+          "kind": "enum_value"
         },
         {
-          "name": "tags",
-          "kind": "func",
-          "overridden_depth": 0
+          "name": "AUDIO",
+          "kind": "enum_value"
         },
         {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
+          "name": "VIDEO",
+          "kind": "enum_value"
         },
         {
-          "name": "update",
-          "kind": "func",
-          "overridden_depth": 0
+          "name": "CUSTOM",
+          "kind": "enum_value"
         }
       ]
     },
@@ -4536,22 +4592,6 @@
         }
       ]
     },
-    "AmityPermissions": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPermissions.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "permissions",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityPinSortByOptions": {
       "kind": "enum",
       "language": "dart",
@@ -4644,89 +4684,22 @@
         }
       ]
     },
-    "AmityPoll": {
-      "kind": "class",
+    "PinPlacement": {
+      "kind": "enum",
       "language": "dart",
       "members": [
         {
-          "name": "AmityPoll.new",
-          "kind": "constructor",
+          "name": "values",
+          "kind": "enum_value",
           "overridden_depth": 0
         },
         {
-          "name": "answerType",
-          "kind": "getter",
-          "overridden_depth": 0
+          "name": "DEFAULT",
+          "kind": "enum_value"
         },
         {
-          "name": "answers",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "closedAt",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "closedIn",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "createdAt",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isClose",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isDeleted",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isVoted",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "pollId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "question",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "status",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "totalVote",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "updatedAt",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "userId",
-          "kind": "getter",
-          "overridden_depth": 0
+          "name": "ANNOUNCEMENT",
+          "kind": "enum_value"
         }
       ]
     },
@@ -4818,13 +4791,88 @@
         }
       ]
     },
-    "AmityPollPostCreator": {
+    "AmityPoll": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityPollPostCreator.new",
+          "name": "AmityPoll.new",
           "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "answerType",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "answers",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "closedAt",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "closedIn",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "createdAt",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "isClose",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "isDeleted",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "isVoted",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "pollId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "question",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "status",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "totalVote",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "updatedAt",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "userId",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -5038,99 +5086,6 @@
         }
       ]
     },
-    "AmityPostAnalytics": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostAnalytics.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "markPostAsViewed",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "postId",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityPostCreateDataTypeSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostCreateDataTypeSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "custom",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "file",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "image",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "liveStream",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "poll",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "video",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityPostCreateTargetSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostCreateTargetSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetCommunity",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetMe",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetUser",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityPostData": {
       "kind": "class",
       "language": "dart",
@@ -5167,6 +5122,233 @@
         }
       ]
     },
+    "AmityPostTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "CommunityTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CommunityTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "postedCommunityMember",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetCommunity",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetCommunityId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        }
+      ]
+    },
+    "CustomData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "CustomData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "FileData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "FileData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "file",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "ImageData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "ImageData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "LiveStreamData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "LiveStreamData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "streamId",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "PollData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "PollData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "live",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "poll",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "pollId",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "TextData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "TextData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 2
+        }
+      ]
+    },
+    "UnknownTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UnknownTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "UserTarget": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UserTarget.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetUser",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetUserId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
+        }
+      ]
+    },
+    "VideoData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "VideoData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "thumbnail",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPostAnalytics": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostAnalytics.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "markPostAsViewed",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "postId",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityPostEvents": {
       "kind": "enum",
       "language": "dart",
@@ -5186,110 +5368,68 @@
         }
       ]
     },
-    "AmityPostGetQueryBuilder": {
+    "PostRepository": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityPostGetQueryBuilder.new",
+          "name": "PostRepository.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "build",
+          "name": "createPost",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "feedType",
+          "name": "deletePost",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "getLiveCollection",
+          "name": "getGlobalPinnedPosts",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "getPagingData",
+          "name": "getPinnedPosts",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "hasFlag",
+          "name": "getPost",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "includeDeleted",
+          "name": "getPostStream",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "onlyParent",
+          "name": "getPosts",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "query",
+          "name": "getReaction",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "sortBy",
+          "name": "isFlaggedByMe",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "streamQuery",
-          "kind": "func",
+          "name": "live",
+          "kind": "getter",
           "overridden_depth": 0
         },
         {
-          "name": "tags",
+          "name": "reviewPost",
           "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "types",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityPostGetTargetSelector": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostGetTargetSelector.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetCommunity",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetMe",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetUser",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityPostReactionReference": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostReactionReference.new",
-          "kind": "constructor",
           "overridden_depth": 0
         }
       ]
@@ -5313,17 +5453,6 @@
         }
       ]
     },
-    "AmityPostTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityPostTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityPostTargetType": {
       "kind": "enum",
       "language": "dart",
@@ -5343,18 +5472,18 @@
         }
       ]
     },
-    "AmityPostUpdater": {
+    "AmityPermissions": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityPostUpdater.new",
+          "name": "AmityPermissions.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "update",
-          "kind": "func",
+          "name": "permissions",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -5455,6 +5584,39 @@
         }
       ]
     },
+    "AmityCommentReactionReference": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityCommentReactionReference.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityMessageReactionReference": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityMessageReactionReference.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPostReactionReference": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostReactionReference.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityReactionReference": {
       "kind": "class",
       "language": "dart",
@@ -5467,6 +5629,17 @@
         {
           "name": "referenceType",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityStoryReactionReference": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityStoryReactionReference.new",
+          "kind": "constructor",
           "overridden_depth": 0
         }
       ]
@@ -5524,27 +5697,6 @@
         }
       ]
     },
-    "AmityRecordingData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityRecordingData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getUrl",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "recordingData",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityRecordingDataFormat": {
       "kind": "enum",
       "language": "dart",
@@ -5565,78 +5717,6 @@
         {
           "name": "m3u8",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityRegionalHttpEndpoint": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityRegionalHttpEndpoint.custom",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "AmityRegionalHttpEndpoint.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "EU",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "SG",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "US",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "endpoint",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityRegionalMqttEndpoint": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityRegionalMqttEndpoint.custom",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "AmityRegionalMqttEndpoint.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "EU",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "SG",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "US",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "endpoint",
-          "kind": "getter",
-          "overridden_depth": 0
         }
       ]
     },
@@ -5661,10 +5741,68 @@
         }
       ]
     },
+    "All": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "All.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "value",
+          "kind": "const",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityRolesFilter": {
       "kind": "class",
       "language": "dart",
       "members": []
+    },
+    "Not": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "Not.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getRoles",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "roles",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "Only": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "Only.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getRoles",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "roles",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
     },
     "AmitySocialClient": {
       "kind": "class",
@@ -5868,6 +6006,79 @@
       "language": "dart",
       "members": []
     },
+    "ImageStoryData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "ImageStoryData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "imageDisplayMode",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "rawData",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "storyId",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "UnknownStoryData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UnknownStoryData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "VideoStoryData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "VideoStoryData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "rawData",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "storyId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "thumbnail",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "video",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityStoryDataType": {
       "kind": "enum",
       "language": "dart",
@@ -5888,42 +6099,6 @@
         {
           "name": "UNKNOWN",
           "kind": "enum_value"
-        }
-      ]
-    },
-    "AmityStoryGetQueryBuilder": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityStoryGetQueryBuilder.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "build",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "orderBy",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetId",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetType",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targets",
-          "kind": "func",
-          "overridden_depth": 0
         }
       ]
     },
@@ -5972,13 +6147,33 @@
         }
       ]
     },
-    "AmityStoryReactionReference": {
+    "HyperLink": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityStoryReactionReference.new",
+          "name": "HyperLink.fromJson",
           "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "HyperLink.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "customText",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "url",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -6206,6 +6401,28 @@
         }
       ]
     },
+    "AmityStoryTargetUnknown": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityStoryTargetUnknown.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityStoryTargetUser": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityStoryTargetUser.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "AmityStoryTargetType": {
       "kind": "enum",
       "language": "dart",
@@ -6229,24 +6446,23 @@
         }
       ]
     },
-    "AmityStoryTargetUnknown": {
+    "AmityRecordingData": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "AmityStoryTargetUnknown.new",
+          "name": "AmityRecordingData.new",
           "kind": "constructor",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityStoryTargetUser": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
+        },
         {
-          "name": "AmityStoryTargetUser.new",
-          "kind": "constructor",
+          "name": "getUrl",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "recordingData",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -6338,6 +6554,43 @@
         {
           "name": "userId",
           "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "watcherData",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "BroadcasterData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "BroadcasterData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "url",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "WatcherData": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "WatcherData.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getUrl",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
@@ -6490,52 +6743,6 @@
         }
       ]
     },
-    "AmitySubChannelRepository": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmitySubChannelRepository.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "createSubChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getSubChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getSubChannels",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "hardDeleteSubChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "live",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "softDeleteSubChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "updateeditSubChannelSubChannel",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityTags": {
       "kind": "class",
       "language": "dart",
@@ -6567,193 +6774,6 @@
         }
       ]
     },
-    "AmityTextCommentCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextCommentCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextCommentEditor": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextCommentEditor.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "update",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "updater",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextCommentEditorBuilder": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextCommentEditorBuilder.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "attachments",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "build",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "mentionUsers",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "metadata",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "updater",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextMessageCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextMessageCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "text",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextPostCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextPostCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "createTextPost",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextPostEditor": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextPostEditor.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "update",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "updater",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityTextPostEditorBuilder": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityTextPostEditorBuilder.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "build",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "custom",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "file",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "image",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "mentionUsers",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "metadata",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "video",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityTopicSubscription": {
       "kind": "class",
       "language": "dart",
@@ -6777,6 +6797,42 @@
           "name": "unsubscribeTopic",
           "kind": "func",
           "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityUploadInfo": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityUploadInfo.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getBytesWritten",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getContentLength",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getFilePath",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getProgressPercentage",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "toString",
+          "kind": "func",
+          "overridden_depth": 1
         }
       ]
     },
@@ -6807,42 +6863,6 @@
         },
         {
           "name": "file",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityUploadEndpoint": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityUploadEndpoint.custom",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "AmityUploadEndpoint.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "EU",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "SG",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "US",
-          "kind": "const",
-          "overridden_depth": 0
-        },
-        {
-          "name": "endpoint",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -6892,42 +6912,6 @@
           "name": "uploadInfo",
           "kind": "getter",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityUploadInfo": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityUploadInfo.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getBytesWritten",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getContentLength",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getFilePath",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getProgressPercentage",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
         }
       ]
     },
@@ -7283,37 +7267,6 @@
         }
       ]
     },
-    "AmityUserMentionMetadata": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityUserMentionMetadata.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "index",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "length",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toMap",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "userId",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityUserNotification": {
       "kind": "class",
       "language": "dart",
@@ -7352,6 +7305,105 @@
         {
           "name": "rolesFilter",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "Chat": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "Chat.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "Social": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "Social.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "UserNotificationModifier": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "UserNotificationModifier.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "eventName",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "excludedRoles",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "includedRoles",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "isEnabled",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "rolesFilter",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "VideoStreaming": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "VideoStreaming.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "disable",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "enable",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -7629,42 +7681,6 @@
         }
       ]
     },
-    "AmityVideo": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityVideo.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "fileProperties",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getFilePath",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getResolutions",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getVideoUrl",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "hasLocalPreview",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "AmityVideoClient": {
       "kind": "class",
       "language": "dart",
@@ -7678,75 +7694,6 @@
           "name": "newStreamRepository",
           "kind": "func",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityVideoMessageCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityVideoMessageCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getUri",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "uri",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityVideoPostCreator": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "AmityVideoPostCreator.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "AmityVideoQuality": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "ORIGINAL",
-          "kind": "enum_value"
-        },
-        {
-          "name": "HIGH",
-          "kind": "enum_value"
-        },
-        {
-          "name": "MEDIUM",
-          "kind": "enum_value"
-        },
-        {
-          "name": "LOW",
-          "kind": "enum_value"
         }
       ]
     },
@@ -7823,18 +7770,28 @@
         }
       ]
     },
-    "BroadcasterData": {
+    "ChannelCreatorTypeSelection": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "BroadcasterData.new",
+          "name": "ChannelCreatorTypeSelection.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "url",
-          "kind": "getter",
+          "name": "communityType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "conversationType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "liveType",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -7895,32 +7852,6 @@
         }
       ]
     },
-    "ChannelCreatorTypeSelection": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "ChannelCreatorTypeSelection.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "communityType",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "conversationType",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "liveType",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "ChannelLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -7933,32 +7864,32 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -7979,22 +7910,22 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -8015,22 +7946,22 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -8131,65 +8062,86 @@
         }
       ]
     },
-    "Chat": {
+    "AmityAttachmentCommentCreator": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "Chat.new",
+          "name": "AmityAttachmentCommentCreator.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
+          "name": "text",
           "kind": "func",
           "overridden_depth": 0
         }
       ]
     },
-    "CommentAttachment": {
+    "AmityCommentCreationTarget": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CommentAttachment.new",
+          "name": "AmityCommentCreationTarget.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "getDataType",
+          "name": "content",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "getFileId",
+          "name": "create",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "parentId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "post",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "story",
           "kind": "func",
           "overridden_depth": 0
         }
       ]
     },
-    "CommentCreated": {
+    "AmityCommentCreationType": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CommentCreated.new",
+          "name": "AmityCommentCreationType.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "disable",
+          "name": "attachments",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "enable",
+          "name": "text",
           "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextCommentCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextCommentCreator.new",
+          "kind": "constructor",
           "overridden_depth": 0
         }
       ]
@@ -8220,22 +8172,6 @@
         }
       ]
     },
-    "CommentFileData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommentFileData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "file",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "CommentFlagQueryBuilder": {
       "kind": "class",
       "language": "dart",
@@ -8257,55 +8193,131 @@
         }
       ]
     },
-    "CommentImageAttachment": {
+    "AmityCommentDataTypeFilter": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CommentImageAttachment.new",
+          "name": "AmityCommentDataTypeFilter.any",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "getDataType",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getFileId",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "getImage",
-          "kind": "func",
+          "name": "AmityCommentDataTypeFilter.exact",
+          "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "image",
+          "name": "dataTypes",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "matchType",
           "kind": "getter",
           "overridden_depth": 0
         }
       ]
     },
-    "CommentImageData": {
+    "AmityCommentQueryBuilder": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CommentImageData.new",
+          "name": "AmityCommentQueryBuilder.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "image",
+          "name": "applyParentFilter",
           "kind": "getter",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "build",
           "kind": "func",
-          "overridden_depth": 2
+          "overridden_depth": 0
+        },
+        {
+          "name": "dataTypeFilter",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "dataTypes",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "filterById",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getLiveCollection",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getPagingData",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "includeDeleted",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "parentId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "query",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "referenceId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "referenceType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "sortBy",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityCommentQueryTypeSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityCommentQueryTypeSelector.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "content",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "post",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "story",
+          "kind": "func",
+          "overridden_depth": 0
         }
       ]
     },
@@ -8321,84 +8333,26 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "CommentLiveStreamData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommentLiveStreamData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "streamId",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "CommentReacted": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommentReacted.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "CommentReplied": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommentReplied.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -8444,38 +8398,79 @@
         }
       ]
     },
-    "CommentTextData": {
+    "AmityCommentUpdater": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CommentTextData.new",
+          "name": "AmityCommentUpdater.new",
           "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "update",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextCommentEditor": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextCommentEditor.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "update",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "updater",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextCommentEditorBuilder": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextCommentEditorBuilder.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "attachments",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "build",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "mentionUsers",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "metadata",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
           "name": "text",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
           "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
-    "CommentVideoData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommentVideoData.new",
-          "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "thumbnail",
+          "name": "updater",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -8534,37 +8529,6 @@
         {
           "name": "withDisplayName",
           "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "CommunityCommentTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommunityCommentTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "communityId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "creatorMember",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "type",
-          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -8755,37 +8719,37 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -8806,32 +8770,32 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -8893,73 +8857,6 @@
           "name": "usecase",
           "kind": "getter",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "CommunityNotificationModifier": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommunityNotificationModifier.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "eventName",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "excludedRoles",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "includedRoles",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isEnabled",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "rolesFilter",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "CommunityTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "CommunityTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "postedCommunityMember",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetCommunity",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetCommunityId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
         }
       ]
     },
@@ -9039,32 +8936,6 @@
         }
       ]
     },
-    "ContentCommentTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "ContentCommentTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "contentId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "type",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "ConversationChannelCreator": {
       "kind": "class",
       "language": "dart",
@@ -9086,13 +8957,23 @@
         }
       ]
     },
-    "CustomData": {
+    "AmityCustomRankingGlobalFeedQuery": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "CustomData.new",
+          "name": "AmityCustomRankingGlobalFeedQuery.new",
           "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getLiveCollection",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getPagingData",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -9109,22 +8990,45 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
           "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityEndpoint": {
+      "kind": "enum",
+      "language": "dart",
+      "members": [
+        {
+          "name": "values",
+          "kind": "enum_value",
+          "overridden_depth": 0
+        },
+        {
+          "name": "SG",
+          "kind": "enum_value"
+        },
+        {
+          "name": "EU",
+          "kind": "enum_value"
+        },
+        {
+          "name": "US",
+          "kind": "enum_value"
         }
       ]
     },
@@ -9159,22 +9063,6 @@
         }
       ]
     },
-    "FileData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "FileData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "file",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "FollowerLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -9187,17 +9075,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -9218,17 +9106,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -9452,21 +9340,52 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityGlobalFeedQuery": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityGlobalFeedQuery.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getLiveCollection",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getPagingData",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getPagingDataStream",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "types",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -9483,17 +9402,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -9514,17 +9433,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "queryOption",
@@ -9538,84 +9457,37 @@
         }
       ]
     },
-    "HyperLink": {
+    "AmityRegionalHttpEndpoint": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "HyperLink.fromJson",
+          "name": "AmityRegionalHttpEndpoint.custom",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "HyperLink.new",
+          "name": "AmityRegionalHttpEndpoint.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "customText",
-          "kind": "getter",
+          "name": "EU",
+          "kind": "const",
           "overridden_depth": 0
         },
         {
-          "name": "getData",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "url",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "ImageData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "ImageData.new",
-          "kind": "constructor",
+          "name": "SG",
+          "kind": "const",
           "overridden_depth": 0
         },
         {
-          "name": "image",
-          "kind": "getter",
+          "name": "US",
+          "kind": "const",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
-    "ImageStoryData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "ImageStoryData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "image",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "imageDisplayMode",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "rawData",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "storyId",
+          "name": "endpoint",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -9669,7 +9541,7 @@
         {
           "name": "dispose",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getFirstPageRequest",
@@ -9704,7 +9576,7 @@
         {
           "name": "getStream",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
@@ -9714,12 +9586,12 @@
         {
           "name": "hasNextPage",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "hasPreviousPage",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "interactorStream",
@@ -9734,12 +9606,12 @@
         {
           "name": "loadNext",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "loadPrevious",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeLoadingState",
@@ -9754,12 +9626,12 @@
         {
           "name": "onError",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "reset",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "setIsFetching",
@@ -9876,22 +9748,6 @@
         }
       ]
     },
-    "LiveStreamData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "LiveStreamData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "streamId",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
     "LoginQueryBuilder": {
       "kind": "class",
       "language": "dart",
@@ -9928,66 +9784,271 @@
         }
       ]
     },
-    "MessageAudioData": {
+    "AmityCustomMessageCreator": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "MessageAudioData.new",
+          "name": "AmityCustomMessageCreator.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "audio",
+          "name": "customData",
           "kind": "getter",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "getData",
           "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
-    "MessageCustomData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "MessageCustomData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
+          "overridden_depth": 1
         },
         {
-          "name": "toString",
+          "name": "getDataType",
           "kind": "func",
-          "overridden_depth": 2
+          "overridden_depth": 1
         }
       ]
     },
-    "MessageFileData": {
+    "AmityFileMessageCreator": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "MessageFileData.new",
+          "name": "AmityFileMessageCreator.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
           "name": "caption",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getUri",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "uri",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityImageMessageCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityImageMessageCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "caption",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getUri",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "uri",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityMessageCreateDataTypeSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityMessageCreateDataTypeSelector.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "custom",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
           "name": "file",
-          "kind": "getter",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "image",
           "kind": "func",
-          "overridden_depth": 2
+          "overridden_depth": 0
+        },
+        {
+          "name": "parentId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "video",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityMessageCreateTargetSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityMessageCreateTargetSelector.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "subchannelId",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityMessageCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityMessageCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getUri",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "mentionChannel",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "mentionUsers",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "metadata",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "parentId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "send",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "tags",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextMessageCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextMessageCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "text",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityVideoMessageCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityVideoMessageCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getData",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getDataType",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "getUri",
+          "kind": "func",
+          "overridden_depth": 1
+        },
+        {
+          "name": "uri",
+          "kind": "getter",
+          "overridden_depth": 0
         }
       ]
     },
@@ -10083,32 +10144,6 @@
         }
       ]
     },
-    "MessageImageData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "MessageImageData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "caption",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "image",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
     "MessageLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -10121,27 +10156,27 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getPreviousPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -10241,104 +10276,80 @@
         }
       ]
     },
-    "MessageTextData": {
+    "AmityMessageUpdateQueryBuilder": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "MessageTextData.new",
+          "name": "AmityMessageUpdateQueryBuilder.new",
           "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "customData",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "messageId",
+          "kind": "getter",
+          "overridden_depth": 0
+        },
+        {
+          "name": "metadata",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "tags",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
           "name": "text",
-          "kind": "getter",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "update",
           "kind": "func",
-          "overridden_depth": 2
+          "overridden_depth": 0
         }
       ]
     },
-    "MessageVideoData": {
+    "AmityRegionalMqttEndpoint": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "MessageVideoData.new",
+          "name": "AmityRegionalMqttEndpoint.custom",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "getVideo",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "thumbnailImageFile",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
-    "Not": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "Not.new",
+          "name": "AmityRegionalMqttEndpoint.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "getRoles",
-          "kind": "func",
+          "name": "EU",
+          "kind": "const",
           "overridden_depth": 0
         },
         {
-          "name": "roles",
+          "name": "SG",
+          "kind": "const",
+          "overridden_depth": 0
+        },
+        {
+          "name": "US",
+          "kind": "const",
+          "overridden_depth": 0
+        },
+        {
+          "name": "endpoint",
           "kind": "getter",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "NotificationMode": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "fromString",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "defaultMode",
-          "kind": "enum_value"
-        },
-        {
-          "name": "silent",
-          "kind": "enum_value"
-        },
-        {
-          "name": "subscribe",
-          "kind": "enum_value"
         }
       ]
     },
@@ -10359,27 +10370,6 @@
         {
           "name": "unregisterDeviceNotification",
           "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "Only": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "Only.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getRoles",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "roles",
-          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -10485,25 +10475,6 @@
         }
       ]
     },
-    "PinPlacement": {
-      "kind": "enum",
-      "language": "dart",
-      "members": [
-        {
-          "name": "values",
-          "kind": "enum_value",
-          "overridden_depth": 0
-        },
-        {
-          "name": "DEFAULT",
-          "kind": "enum_value"
-        },
-        {
-          "name": "ANNOUNCEMENT",
-          "kind": "enum_value"
-        }
-      ]
-    },
     "PinnedPostLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -10516,17 +10487,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -10551,28 +10522,28 @@
         }
       ]
     },
-    "PollData": {
+    "SubmitPollCreateQueryBuilder": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "PollData.new",
+          "name": "SubmitPollCreateQueryBuilder.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "live",
-          "kind": "getter",
+          "name": "answerType",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "poll",
-          "kind": "getter",
+          "name": "closedIn",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "pollId",
-          "kind": "getter",
+          "name": "create",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -10629,23 +10600,156 @@
         }
       ]
     },
-    "PostCreated": {
+    "AmityCustomPostCreator": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "PostCreated.new",
+          "name": "AmityCustomPostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityFilePostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityFilePostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityImagePostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityImagePostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityLiveStreamPostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityLiveStreamPostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPollPostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPollPostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPostCreateDataTypeSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostCreateDataTypeSelector.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "disable",
+          "name": "custom",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "enable",
+          "name": "file",
           "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "liveStream",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "poll",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "video",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPostCreateTargetSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostCreateTargetSelector.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetCommunity",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetMe",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetUser",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextPostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextPostCreator.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "createTextPost",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityVideoPostCreator": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityVideoPostCreator.new",
+          "kind": "constructor",
           "overridden_depth": 0
         }
       ]
@@ -10702,6 +10806,103 @@
         }
       ]
     },
+    "AmityPostGetQueryBuilder": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostGetQueryBuilder.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "build",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "feedType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getLiveCollection",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "getPagingData",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "hasFlag",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "includeDeleted",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "onlyParent",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "query",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "sortBy",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "streamQuery",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "tags",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "types",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityPostGetTargetSelector": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostGetTargetSelector.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetCommunity",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetMe",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetUser",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "PostLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -10714,113 +10915,26 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "PostReacted": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "PostReacted.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "PostRepository": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "PostRepository.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "createPost",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "deletePost",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getGlobalPinnedPosts",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPinnedPosts",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPost",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPostStream",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getPosts",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getReaction",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isFlaggedByMe",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "live",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "reviewPost",
-          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -10846,6 +10960,94 @@
         }
       ]
     },
+    "AmityPostUpdater": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityPostUpdater.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "update",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextPostEditor": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextPostEditor.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "update",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "updater",
+          "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityTextPostEditorBuilder": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityTextPostEditorBuilder.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "build",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "custom",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "file",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "image",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "mentionUsers",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "metadata",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "text",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "video",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "ReactionLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -10858,36 +11060,57 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AddReactionQueryBuilder": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AddReactionQueryBuilder.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "addReaction",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "removeReaction",
+          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -10985,27 +11208,27 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -11102,32 +11325,32 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "observeNewItem",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -11172,65 +11395,18 @@
         }
       ]
     },
-    "Social": {
+    "Terminated": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "Social.new",
+          "name": "Terminated.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "StoryCommentCreated": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "StoryCommentCreated.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "StoryCreated": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "StoryCreated.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
+          "name": "error",
+          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -11256,6 +11432,42 @@
         }
       ]
     },
+    "AmityStoryGetQueryBuilder": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
+        {
+          "name": "AmityStoryGetQueryBuilder.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "build",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "orderBy",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetId",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targetType",
+          "kind": "func",
+          "overridden_depth": 0
+        },
+        {
+          "name": "targets",
+          "kind": "func",
+          "overridden_depth": 0
+        }
+      ]
+    },
     "StoryLiveCollection": {
       "kind": "class",
       "language": "dart",
@@ -11268,57 +11480,16 @@
         {
           "name": "getData",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "isFetching",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "load",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "onError",
           "kind": "func",
           "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "reset",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "StoryReacted": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "StoryReacted.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -11335,36 +11506,16 @@
         {
           "name": "getData",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
-          "kind": "func",
-          "overridden_depth": 1
-        },
-        {
-          "name": "isFetching",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "load",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "onError",
           "kind": "func",
           "overridden_depth": 0
         },
         {
           "name": "request",
           "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "reset",
-          "kind": "func",
           "overridden_depth": 0
         }
       ]
@@ -11412,17 +11563,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -11443,17 +11594,17 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
@@ -11462,123 +11613,83 @@
         }
       ]
     },
-    "SubmitPollCreateQueryBuilder": {
+    "AmitySubChannelRepository": {
       "kind": "class",
       "language": "dart",
       "members": [
         {
-          "name": "SubmitPollCreateQueryBuilder.new",
+          "name": "AmitySubChannelRepository.new",
           "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "answerType",
+          "name": "createSubChannel",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "closedIn",
+          "name": "getSubChannel",
           "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "create",
+          "name": "getSubChannels",
           "kind": "func",
           "overridden_depth": 0
-        }
-      ]
-    },
-    "Terminated": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
+        },
         {
-          "name": "Terminated.new",
-          "kind": "constructor",
+          "name": "hardDeleteSubChannel",
+          "kind": "func",
           "overridden_depth": 0
         },
         {
-          "name": "error",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "TextData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "TextData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "text",
+          "name": "live",
           "kind": "getter",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "softDeleteSubChannel",
           "kind": "func",
-          "overridden_depth": 2
-        }
-      ]
-    },
-    "UnknownCommentTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UnknownCommentTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "UnknownStoryData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UnknownStoryData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "UnknownTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UnknownTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "UserCommentTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UserCommentTarget.new",
-          "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "toString",
+          "name": "updateeditSubChannelSubChannel",
           "kind": "func",
-          "overridden_depth": 1
-        },
+          "overridden_depth": 0
+        }
+      ]
+    },
+    "AmityUploadEndpoint": {
+      "kind": "class",
+      "language": "dart",
+      "members": [
         {
-          "name": "type",
-          "kind": "getter",
+          "name": "AmityUploadEndpoint.custom",
+          "kind": "constructor",
           "overridden_depth": 0
         },
         {
-          "name": "userId",
+          "name": "AmityUploadEndpoint.new",
+          "kind": "constructor",
+          "overridden_depth": 0
+        },
+        {
+          "name": "EU",
+          "kind": "const",
+          "overridden_depth": 0
+        },
+        {
+          "name": "SG",
+          "kind": "const",
+          "overridden_depth": 0
+        },
+        {
+          "name": "US",
+          "kind": "const",
+          "overridden_depth": 0
+        },
+        {
+          "name": "endpoint",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -11632,66 +11743,30 @@
         {
           "name": "getFirstPageRequest",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getHash",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNextPageRequestInternal",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getNonce",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "getStreamController",
           "kind": "func",
-          "overridden_depth": 1
+          "overridden_depth": 0
         },
         {
           "name": "request",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "UserNotificationModifier": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UserNotificationModifier.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "eventName",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "excludedRoles",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "includedRoles",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "isEnabled",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "rolesFilter",
           "kind": "getter",
           "overridden_depth": 0
         }
@@ -11753,32 +11828,6 @@
         }
       ]
     },
-    "UserTarget": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "UserTarget.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetUser",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "targetUserId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "toString",
-          "kind": "func",
-          "overridden_depth": 1
-        }
-      ]
-    },
     "UserUpdateQueryBuilder": {
       "kind": "class",
       "language": "dart",
@@ -11821,95 +11870,6 @@
         {
           "name": "update",
           "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "VideoData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "VideoData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "thumbnail",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "VideoStoryData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "VideoStoryData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "rawData",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "storyId",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "thumbnail",
-          "kind": "getter",
-          "overridden_depth": 0
-        },
-        {
-          "name": "video",
-          "kind": "getter",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "VideoStreaming": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "VideoStreaming.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "disable",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "enable",
-          "kind": "func",
-          "overridden_depth": 0
-        }
-      ]
-    },
-    "WatcherData": {
-      "kind": "class",
-      "language": "dart",
-      "members": [
-        {
-          "name": "WatcherData.new",
-          "kind": "constructor",
-          "overridden_depth": 0
-        },
-        {
-          "name": "getUrl",
-          "kind": "func",
-          "overridden_depth": 0
-        },
-        {
-          "name": "watcherData",
-          "kind": "getter",
           "overridden_depth": 0
         }
       ]
@@ -11982,6 +11942,19 @@
       ]
     },
     {
+      "name": "AmityChannelMembershipExtension",
+      "members": [
+        {
+          "name": "enumOf",
+          "kind": "func"
+        },
+        {
+          "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
       "name": "AmityChannelMemberTypeExtension",
       "members": [
         {
@@ -11995,19 +11968,6 @@
         {
           "name": "memberships",
           "kind": "getter"
-        },
-        {
-          "name": "value",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
-      "name": "AmityChannelMembershipExtension",
-      "members": [
-        {
-          "name": "enumOf",
-          "kind": "func"
         },
         {
           "name": "value",
@@ -12122,19 +12082,6 @@
       ]
     },
     {
-      "name": "AmityCommnunityMembershipFilterExtension",
-      "members": [
-        {
-          "name": "apiKey",
-          "kind": "getter"
-        },
-        {
-          "name": "memberships",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
       "name": "AmityCommunityCategorySortOptionExtension",
       "members": [
         {
@@ -12181,6 +12128,19 @@
         },
         {
           "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
+      "name": "AmityCommnunityMembershipFilterExtension",
+      "members": [
+        {
+          "name": "apiKey",
+          "kind": "getter"
+        },
+        {
+          "name": "memberships",
           "kind": "getter"
         }
       ]
@@ -12272,6 +12232,32 @@
       ]
     },
     {
+      "name": "AmityImageSizeExtension",
+      "members": [
+        {
+          "name": "enumOf",
+          "kind": "func"
+        },
+        {
+          "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
+      "name": "AmityVideoQualityExtension",
+      "members": [
+        {
+          "name": "enumOf",
+          "kind": "func"
+        },
+        {
+          "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
       "name": "AmityFlagTypeExtension",
       "members": [
         {
@@ -12345,19 +12331,6 @@
       ]
     },
     {
-      "name": "AmityImageSizeExtension",
-      "members": [
-        {
-          "name": "enumOf",
-          "kind": "func"
-        },
-        {
-          "name": "value",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
       "name": "AmityMembershipSortingOrderExtension",
       "members": [
         {
@@ -12381,19 +12354,6 @@
     },
     {
       "name": "AmityMentionTypeExtension",
-      "members": [
-        {
-          "name": "enumOf",
-          "kind": "func"
-        },
-        {
-          "name": "value",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
-      "name": "AmityMessageDataTypeExtension",
       "members": [
         {
           "name": "enumOf",
@@ -12468,12 +12428,43 @@
       ]
     },
     {
+      "name": "AmityStringToMessageSyncStateExtension",
+      "members": [
+        {
+          "name": "toAmityMessageSyncState",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
+      "name": "AmityMessageDataTypeExtension",
+      "members": [
+        {
+          "name": "enumOf",
+          "kind": "func"
+        },
+        {
+          "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
       "name": "AmityPermissionExtension",
       "members": [
         {
           "name": "enumOf",
           "kind": "func"
         },
+        {
+          "name": "value",
+          "kind": "getter"
+        }
+      ]
+    },
+    {
+      "name": "PinPlacementValue",
+      "members": [
         {
           "name": "value",
           "kind": "getter"
@@ -12774,15 +12765,6 @@
       ]
     },
     {
-      "name": "AmityStringToMessageSyncStateExtension",
-      "members": [
-        {
-          "name": "toAmityMessageSyncState",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
       "name": "AmityUploadCompleteExtension",
       "members": [
         {
@@ -12886,19 +12868,6 @@
       ]
     },
     {
-      "name": "AmityVideoQualityExtension",
-      "members": [
-        {
-          "name": "enumOf",
-          "kind": "func"
-        },
-        {
-          "name": "value",
-          "kind": "getter"
-        }
-      ]
-    },
-    {
       "name": "AmityVideoResolutionExtension",
       "members": [
         {
@@ -12936,89 +12905,80 @@
           "kind": "getter"
         }
       ]
-    },
-    {
-      "name": "PinPlacementValue",
-      "members": [
-        {
-          "name": "value",
-          "kind": "getter"
-        }
-      ]
     }
   ],
   "global_funcs": [],
   "global_consts": [],
   "typedefs": [
     {
-      "name": "PageFuture"
+      "name": "RequestBuilder"
     },
     {
-      "name": "RequestBuilder"
+      "name": "PageFuture"
     }
   ],
   "unhandled": [],
   "merge_notes": [
-    "ADDED_ENUM_VALUES: AmityWatcherDataFormat +3",
-    "ADDED_ENUM_VALUES: AmityCommentReferenceType +3",
-    "ADDED_ENUM_VALUES: AmityFlagType +2",
-    "ADDED_ENUM_VALUES: AmityCommunityMembershipFilter +3",
-    "ADDED_ENUM_VALUES: AmityImageSize +4",
-    "ADDED_ENUM_VALUES: PinPlacement +2",
-    "ADDED_ENUM_VALUES: AmityStorySortingOrder +2",
-    "ADDED_ENUM_VALUES: AmityChannelMembership +3",
-    "ADDED_ENUM_VALUES: AmityCommentTargetType +4",
-    "ADDED_ENUM_VALUES: AmityPostSortOption +2",
-    "ADDED_ENUM_VALUES: AmityGlobalStoryTargetsQueryOption +4",
-    "ADDED_ENUM_VALUES: AmityVideoResolution +5",
-    "ADDED_ENUM_VALUES: AmityPinSortByOptions +1",
-    "ADDED_ENUM_VALUES: AmityMembershipSortOption +2",
-    "ADDED_ENUM_VALUES: AmityMessageDataType +6",
-    "ADDED_ENUM_VALUES: AmityUserFeedSortOption +2",
-    "ADDED_ENUM_VALUES: AmityMessageSyncState +5",
-    "ADDED_ENUM_VALUES: AmityCommunityEvents +5",
-    "ADDED_ENUM_VALUES: AmityCommentEvents +1",
-    "ADDED_ENUM_VALUES: AmityStoryTargetType +3",
-    "ADDED_ENUM_VALUES: AmityUserSortOption +3",
-    "ADDED_ENUM_VALUES: AmityPermission +30",
-    "ADDED_ENUM_VALUES: AmityStoryDataType +3",
-    "ADDED_ENUM_VALUES: AmityFollowStatusFilter +3",
-    "ADDED_ENUM_VALUES: AmityChannelType +4",
     "ADDED_ENUM_VALUES: AmityCommentSortOption +4",
-    "ADDED_ENUM_VALUES: AmityContentFlagReasonType +9",
-    "ADDED_ENUM_VALUES: AmityFollowStatus +4",
-    "ADDED_ENUM_VALUES: AmityPostTargetType +2",
     "ADDED_ENUM_VALUES: AmityStoryImageDisplayMode +2",
-    "ADDED_ENUM_VALUES: AmityStorySyncState +5",
-    "ADDED_ENUM_VALUES: AmityUserEvents +4",
-    "ADDED_ENUM_VALUES: AmityChannelSortOption +1",
-    "ADDED_ENUM_VALUES: AmityMentionType +2",
-    "ADDED_ENUM_VALUES: AmityCommunityFilter +3",
-    "ADDED_ENUM_VALUES: AmityEndpoint +3",
-    "ADDED_ENUM_VALUES: AmityQuerySortingOrder +2",
-    "ADDED_ENUM_VALUES: AmityStreamStatus +4",
-    "ADDED_ENUM_VALUES: AmityAdPlacement +5",
-    "ADDED_ENUM_VALUES: AmityVideoQuality +4",
-    "ADDED_ENUM_VALUES: AmityCommunityPostSettings +5",
-    "ADDED_ENUM_VALUES: AmityRecordingDataFormat +3",
-    "ADDED_ENUM_VALUES: AmityUserSearchMatchType +2",
-    "ADDED_ENUM_VALUES: NotificationMode +3",
-    "ADDED_ENUM_VALUES: AmityContentFeedType +4",
-    "ADDED_ENUM_VALUES: AmityPostEvents +2",
-    "ADDED_ENUM_VALUES: AmityMembershipType +3",
-    "ADDED_ENUM_VALUES: AmityDataType +7",
-    "ADDED_ENUM_VALUES: AmityFeedType +3",
-    "ADDED_ENUM_VALUES: AmityPollStatus +3",
-    "ADDED_ENUM_VALUES: AmityChannelFilter +3",
-    "ADDED_ENUM_VALUES: AmityFollowEvents +2",
-    "ADDED_ENUM_VALUES: AmityCommunityCategorySortOption +3",
-    "ADDED_ENUM_VALUES: AmityViewedType +2",
-    "ADDED_ENUM_VALUES: AmityReactionReferenceType +4",
-    "ADDED_ENUM_VALUES: AmityChannelMembershipFilter +3",
-    "ADDED_ENUM_VALUES: AmityPollAnswerType +3",
+    "ADDED_ENUM_VALUES: AmityWatcherDataFormat +3",
+    "ADDED_ENUM_VALUES: AmityCommunityEvents +5",
+    "ADDED_ENUM_VALUES: PinPlacement +2",
     "ADDED_ENUM_VALUES: AmityCommunityMembershipSortOption +2",
+    "ADDED_ENUM_VALUES: AmityChannelSortOption +1",
+    "ADDED_ENUM_VALUES: AmityStorySortingOrder +2",
+    "ADDED_ENUM_VALUES: AmityContentFlagReasonType +9",
+    "ADDED_ENUM_VALUES: AmityReactionReferenceType +4",
+    "ADDED_ENUM_VALUES: AmityCommunitySortOption +3",
+    "ADDED_ENUM_VALUES: AmityStoryDataType +3",
+    "ADDED_ENUM_VALUES: AmityMentionType +2",
+    "ADDED_ENUM_VALUES: AmityPollStatus +3",
+    "ADDED_ENUM_VALUES: AmityCommunityFilter +3",
+    "ADDED_ENUM_VALUES: AmityMessageDataType +6",
+    "ADDED_ENUM_VALUES: AmityCommentTargetType +4",
+    "ADDED_ENUM_VALUES: AmityChannelMembershipFilter +3",
+    "ADDED_ENUM_VALUES: AmityChannelFilter +3",
+    "ADDED_ENUM_VALUES: AmityUserEvents +4",
+    "ADDED_ENUM_VALUES: AmityDataType +7",
+    "ADDED_ENUM_VALUES: AmityCommentEvents +1",
+    "ADDED_ENUM_VALUES: AmityCommunityCategorySortOption +3",
+    "ADDED_ENUM_VALUES: AmityCommunityMembershipFilter +3",
+    "ADDED_ENUM_VALUES: AmityMessageSyncState +5",
+    "ADDED_ENUM_VALUES: AmityFollowStatus +4",
+    "ADDED_ENUM_VALUES: AmityVideoResolution +5",
+    "ADDED_ENUM_VALUES: AmityMembershipType +3",
+    "ADDED_ENUM_VALUES: AmityUserFeedSortOption +2",
+    "ADDED_ENUM_VALUES: AmityFeedType +3",
+    "ADDED_ENUM_VALUES: AmityUserSearchMatchType +2",
+    "ADDED_ENUM_VALUES: AmityFollowStatusFilter +3",
+    "ADDED_ENUM_VALUES: AmityStorySyncState +5",
+    "ADDED_ENUM_VALUES: AmityPollAnswerType +3",
+    "ADDED_ENUM_VALUES: AmityChannelType +4",
+    "ADDED_ENUM_VALUES: NotificationMode +3",
+    "ADDED_ENUM_VALUES: AmityVideoQuality +4",
+    "ADDED_ENUM_VALUES: AmityViewedType +2",
+    "ADDED_ENUM_VALUES: AmityPostTargetType +2",
+    "ADDED_ENUM_VALUES: AmityImageSize +4",
+    "ADDED_ENUM_VALUES: AmityEndpoint +3",
+    "ADDED_ENUM_VALUES: AmityAdPlacement +5",
     "ADDED_ENUM_VALUES: AmityPollAnswerDataType +2",
-    "ADDED_ENUM_VALUES: AmityCommunitySortOption +3"
+    "ADDED_ENUM_VALUES: AmityChannelMembership +3",
+    "ADDED_ENUM_VALUES: AmityGlobalStoryTargetsQueryOption +4",
+    "ADDED_ENUM_VALUES: AmityUserSortOption +3",
+    "ADDED_ENUM_VALUES: AmityCommentReferenceType +3",
+    "ADDED_ENUM_VALUES: AmityRecordingDataFormat +3",
+    "ADDED_ENUM_VALUES: AmityPostSortOption +2",
+    "ADDED_ENUM_VALUES: AmityCommunityPostSettings +5",
+    "ADDED_ENUM_VALUES: AmityContentFeedType +4",
+    "ADDED_ENUM_VALUES: AmityStreamStatus +4",
+    "ADDED_ENUM_VALUES: AmityPostEvents +2",
+    "ADDED_ENUM_VALUES: AmityFollowEvents +2",
+    "ADDED_ENUM_VALUES: AmityMembershipSortOption +2",
+    "ADDED_ENUM_VALUES: AmityQuerySortingOrder +2",
+    "ADDED_ENUM_VALUES: AmityPermission +30",
+    "ADDED_ENUM_VALUES: AmityPinSortByOptions +1",
+    "ADDED_ENUM_VALUES: AmityStoryTargetType +3",
+    "ADDED_ENUM_VALUES: AmityFlagType +2"
   ],
   "stats": {
     "types": 336,
@@ -13027,7 +12987,7 @@
     "mixins": 0,
     "extensions": 69,
     "typedefs": 2,
-    "members_total": 2022,
+    "members_total": 2014,
     "extension_members_total": 171,
     "enum_values_total": 281,
     "global_funcs": 0,

--- a/.docs-ops/sdk-surface/ios-from-docc.json
+++ b/.docs-ops/sdk-surface/ios-from-docc.json
@@ -1,7 +1,7 @@
 {
   "extractor_version": "0.2.0-abi",
   "extractor": "ios-docc-extractor.py",
-  "extracted_at": "2026-05-19T13:33:04.343802+00:00",
+  "extracted_at": "2026-07-06T04:51:06.807698+00:00",
   "sdk_product": "AmitySDK",
   "sdk_docc_archive": "/Users/admin/Documents/GitHub/sp-sdks/social-plus-docs/.docs-ops/integration-tests/ios/vendor/AmitySDK.xcframework/ios-arm64_x86_64-simulator/AmitySDK.framework/Modules/AmitySDK.swiftmodule/x86_64-apple-ios-simulator.abi.json",
   "source_format": "swiftmodule-abi-json",
@@ -154,6 +154,22 @@
           "line": null,
           "signature": {
             "parameters": [],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "markAsMeaningfullyViewed",
+          "kind": "func",
+          "printed_name": "markAsMeaningfullyViewed(feedRenderPosition:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "feedRenderPosition",
+                "type": "Swift.Int?"
+              }
+            ],
             "returns": "()"
           }
         }
@@ -309,6 +325,208 @@
       ],
       "nested_types": [],
       "conformances": [],
+      "extensions": []
+    },
+    "AmityAutoSubscription": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "chat",
+          "kind": "case",
+          "printed_name": "chat",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "network",
+          "kind": "case",
+          "printed_name": "network",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "livestream",
+          "kind": "case",
+          "printed_name": "livestream",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "block",
+          "kind": "case",
+          "printed_name": "block",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isSystem",
+          "kind": "var",
+          "printed_name": "isSystem",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "topicCount",
+          "kind": "var",
+          "printed_name": "topicCount",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "==",
+          "kind": "func",
+          "printed_name": "==(_:_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityAutoSubscription"
+              },
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityAutoSubscription"
+              }
+            ],
+            "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "allCases",
+          "kind": "var",
+          "printed_name": "allCases",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "hashValue",
+          "kind": "var",
+          "printed_name": "hashValue",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "hash",
+          "kind": "func",
+          "printed_name": "hash(into:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "into",
+                "type": "Swift.Hasher"
+              }
+            ],
+            "returns": "()"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "CaseIterable",
+        "Hashable"
+      ],
+      "extensions": []
+    },
+    "AmityAutoSubscriptionState": {
+      "kind": "struct",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "feature",
+          "kind": "var",
+          "printed_name": "feature",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isActive",
+          "kind": "var",
+          "printed_name": "isActive",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isSystem",
+          "kind": "var",
+          "printed_name": "isSystem",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "topicCount",
+          "kind": "var",
+          "printed_name": "topicCount",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
+      "extensions": []
+    },
+    "AmitySearchOrderBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "descending",
+          "kind": "case",
+          "printed_name": "descending",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "ascending",
+          "kind": "case",
+          "printed_name": "ascending",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmitySearchOrderBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable",
+        "SendableMetatype"
+      ],
       "extensions": []
     },
     "AmityChannelQueryFilter": {
@@ -642,6 +860,20 @@
           "line": null
         },
         {
+          "name": "visitorUsageLimitExceeded",
+          "kind": "case",
+          "printed_name": "visitorUsageLimitExceeded",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "maxBlockedUsersReached",
+          "kind": "case",
+          "printed_name": "maxBlockedUsersReached",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "conflict",
           "kind": "case",
           "printed_name": "conflict",
@@ -666,6 +898,13 @@
           "name": "notificationDisabled",
           "kind": "case",
           "printed_name": "notificationDisabled",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "forYouFeedDisabled",
+          "kind": "case",
+          "printed_name": "forYouFeedDisabled",
           "file": "",
           "line": null
         },
@@ -2375,11 +2614,11 @@
       ],
       "nested_types": [],
       "conformances": [
+        "Equatable",
         "Hashable",
         "RawRepresentable",
         "CaseIterable",
-        "SendableMetatype",
-        "Equatable"
+        "SendableMetatype"
       ],
       "extensions": []
     },
@@ -3139,12 +3378,12 @@
       ],
       "nested_types": [],
       "conformances": [
+        "OptionSet",
         "RawRepresentable",
         "SetAlgebra",
         "SendableMetatype",
         "Equatable",
-        "ExpressibleByArrayLiteral",
-        "OptionSet"
+        "ExpressibleByArrayLiteral"
       ],
       "extensions": []
     },
@@ -5521,6 +5760,13 @@
           }
         },
         {
+          "name": "visitorUsageLimitReachedPublisher",
+          "kind": "var",
+          "printed_name": "visitorUsageLimitReachedPublisher",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "user",
           "kind": "var",
           "printed_name": "user",
@@ -5843,6 +6089,49 @@
           }
         },
         {
+          "name": "enableAutoSubscriptions",
+          "kind": "func",
+          "printed_name": "enableAutoSubscriptions(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "[AmitySDK.AmityAutoSubscription]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "disableAutoSubscriptions",
+          "kind": "func",
+          "printed_name": "disableAutoSubscriptions(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "[AmitySDK.AmityAutoSubscription]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "autoSubscriptions",
+          "kind": "func",
+          "printed_name": "autoSubscriptions()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[AmitySDK.AmityAutoSubscriptionState]"
+          }
+        },
+        {
           "name": "setUploadedFileAccessType",
           "kind": "func",
           "printed_name": "setUploadedFileAccessType(type:)",
@@ -5961,6 +6250,17 @@
           "signature": {
             "parameters": [],
             "returns": "AmitySDK.AmityProductCatalogueSetting"
+          }
+        },
+        {
+          "name": "getForYouFeedSetting",
+          "kind": "func",
+          "printed_name": "getForYouFeedSetting()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityForYouFeedSetting"
           }
         },
         {
@@ -6117,6 +6417,80 @@
       "conformances": [],
       "extensions": []
     },
+    "AmitySharableContentType": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "post",
+          "kind": "case",
+          "printed_name": "post",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "community",
+          "kind": "case",
+          "printed_name": "community",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "user",
+          "kind": "case",
+          "printed_name": "user",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "livestream",
+          "kind": "case",
+          "printed_name": "livestream",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "event",
+          "kind": "case",
+          "printed_name": "event",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmitySharableContentType?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
     "AmityShareableLinkConfiguration": {
       "kind": "struct",
       "primary_decl": {
@@ -6137,6 +6511,58 @@
           "printed_name": "patterns",
           "file": "",
           "line": null
+        },
+        {
+          "name": "isEnabled",
+          "kind": "func",
+          "printed_name": "isEnabled(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              }
+            ],
+            "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "getPattern",
+          "kind": "func",
+          "printed_name": "getPattern(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              }
+            ],
+            "returns": "Swift.String?"
+          }
+        },
+        {
+          "name": "generateLink",
+          "kind": "func",
+          "printed_name": "generateLink(_:referenceId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              },
+              {
+                "label": "referenceId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "Swift.String?"
+          }
         }
       ],
       "nested_types": [],
@@ -6854,11 +7280,11 @@
       ],
       "nested_types": [],
       "conformances": [
+        "Equatable",
         "Hashable",
         "RawRepresentable",
         "CaseIterable",
-        "SendableMetatype",
-        "Equatable"
+        "SendableMetatype"
       ],
       "extensions": []
     },
@@ -8927,11 +9353,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -10673,12 +11099,12 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CocoaMQTTSocketProtocol",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "CocoaMQTTSocketProtocol"
       ],
       "extensions": []
     },
@@ -11454,8 +11880,8 @@
         }
       ],
       "conformances": [
-        "CocoaMQTTWebSocketConnectionDelegate",
-        "CocoaMQTTSocketProtocol"
+        "CocoaMQTTSocketProtocol",
+        "CocoaMQTTWebSocketConnectionDelegate"
       ],
       "extensions": []
     },
@@ -11515,11 +11941,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11614,11 +12040,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11691,11 +12117,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11768,11 +12194,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11901,11 +12327,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11978,11 +12404,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12055,11 +12481,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12132,11 +12558,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12209,11 +12635,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12356,11 +12782,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12766,11 +13192,11 @@
       "nested_types": [],
       "conformances": [
         "Engine",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -13903,8 +14329,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "HeaderValidator",
-        "CertificatePinning"
+        "CertificatePinning",
+        "HeaderValidator"
       ],
       "extensions": []
     },
@@ -15013,11 +15439,11 @@
       "nested_types": [],
       "conformances": [
         "Transport",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -15849,8 +16275,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
       "extensions": []
     },
@@ -15918,8 +16344,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
       "extensions": []
     },
@@ -16116,9 +16542,141 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
+      "extensions": []
+    },
+    "AmityChannelSearchSortBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "relevance",
+          "kind": "case",
+          "printed_name": "relevance",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "lastActivity",
+          "kind": "case",
+          "printed_name": "lastActivity",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityChannelSearchSortBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
+    "AmityChannelSearchOptions": {
+      "kind": "class",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "query",
+          "kind": "var",
+          "printed_name": "query",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "exactMatch",
+          "kind": "var",
+          "printed_name": "exactMatch",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "types",
+          "kind": "var",
+          "printed_name": "types",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isMemberOnly",
+          "kind": "var",
+          "printed_name": "isMemberOnly",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "limit",
+          "kind": "var",
+          "printed_name": "limit",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "orderBy",
+          "kind": "var",
+          "printed_name": "orderBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "sortBy",
+          "kind": "var",
+          "printed_name": "sortBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityChannelSearchOptions"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
       "extensions": []
     },
     "AmityChannelUpdateOptions": {
@@ -16210,6 +16768,22 @@
               {
                 "label": "_",
                 "type": "[Swift.String]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "setNotificationMode",
+          "kind": "func",
+          "printed_name": "setNotificationMode(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityChannelNotificationMode"
               }
             ],
             "returns": "()"
@@ -16364,6 +16938,13 @@
           "name": "isPublic",
           "kind": "var",
           "printed_name": "isPublic",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "notificationMode",
+          "kind": "var",
+          "printed_name": "notificationMode",
           "file": "",
           "line": null
         },
@@ -16625,9 +17206,16 @@
           "line": null
         },
         {
+          "name": "excludeArchives",
+          "kind": "var",
+          "printed_name": "excludeArchives",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(types:filter:includingTags:excludingTags:includeDeleted:)",
+          "printed_name": "init(types:filter:includingTags:excludingTags:includeDeleted:excludeArchives:)",
           "file": "",
           "line": null,
           "signature": {
@@ -16650,6 +17238,10 @@
               },
               {
                 "label": "includeDeleted",
+                "type": "Swift.Bool"
+              },
+              {
+                "label": "excludeArchives",
                 "type": "Swift.Bool"
               }
             ],
@@ -17047,6 +17639,73 @@
       "conformances": [],
       "extensions": []
     },
+    "AmityChannelNotificationMode": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "default",
+          "kind": "case",
+          "printed_name": "default",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "subscribe",
+          "kind": "case",
+          "printed_name": "subscribe",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "silent",
+          "kind": "case",
+          "printed_name": "silent",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "unknown",
+          "kind": "case",
+          "printed_name": "unknown",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityChannelNotificationMode?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
     "AmityChannelRepository": {
       "kind": "class",
       "primary_decl": {
@@ -17238,6 +17897,76 @@
               }
             ],
             "returns": "()"
+          }
+        },
+        {
+          "name": "searchChannels",
+          "kind": "func",
+          "printed_name": "searchChannels(options:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "options",
+                "type": "AmitySDK.AmityChannelSearchOptions"
+              }
+            ],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityChannel>"
+          }
+        },
+        {
+          "name": "archiveChannel",
+          "kind": "func",
+          "printed_name": "archiveChannel(channelId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "channelId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "unarchiveChannel",
+          "kind": "func",
+          "printed_name": "unarchiveChannel(channelId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "channelId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "getArchivedChannelIds",
+          "kind": "func",
+          "printed_name": "getArchivedChannelIds()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[Swift.String]"
+          }
+        },
+        {
+          "name": "getArchivedChannels",
+          "kind": "func",
+          "printed_name": "getArchivedChannels()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityChannel>"
           }
         }
       ],
@@ -19431,9 +20160,16 @@
           "line": null
         },
         {
+          "name": "excludeBlockUserComments",
+          "kind": "var",
+          "printed_name": "excludeBlockUserComments",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(referenceId:referenceType:filterByParentId:dataTypes:parentId:orderBy:includeDeleted:pageSize:)",
+          "printed_name": "init(referenceId:referenceType:filterByParentId:dataTypes:parentId:orderBy:includeDeleted:pageSize:excludeBlockUserComments:)",
           "file": "",
           "line": null,
           "signature": {
@@ -19469,6 +20205,10 @@
               {
                 "label": "pageSize",
                 "type": "Swift.Int"
+              },
+              {
+                "label": "excludeBlockUserComments",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCommentQueryOptions"
@@ -21409,9 +22149,16 @@
           "line": null
         },
         {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(filter:sortBy:categoryId:includeDeleted:includeDiscoverablePrivateCommunity:)",
+          "printed_name": "init(filter:sortBy:categoryId:includeDeleted:includeDiscoverablePrivateCommunity:tags:)",
           "file": "",
           "line": null,
           "signature": {
@@ -21435,6 +22182,10 @@
               {
                 "label": "includeDiscoverablePrivateCommunity",
                 "type": "Swift.Bool?"
+              },
+              {
+                "label": "tags",
+                "type": "[Swift.String]?"
               }
             ],
             "returns": "AmitySDK.AmityCommunityQueryOptions"
@@ -23963,6 +24714,43 @@
       ],
       "extensions": []
     },
+    "AmityForYouFeedSetting": {
+      "kind": "struct",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "enabled",
+          "kind": "var",
+          "printed_name": "enabled",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(from:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "from",
+                "type": "any Swift.Decoder"
+              }
+            ],
+            "returns": "AmitySDK.AmityForYouFeedSetting"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Decodable"
+      ],
+      "extensions": []
+    },
     "AmityPinnedPost": {
       "kind": "class",
       "primary_decl": {
@@ -24842,7 +25630,7 @@
         {
           "name": "getUserFeed",
           "kind": "func",
-          "printed_name": "getUserFeed(_:feedSources:dataTypes:sortBy:includeDeleted:matchingOnlyParentPost:includeMixedStructure:untilAt:)",
+          "printed_name": "getUserFeed(_:feedSources:dataTypes:sortBy:includeDeleted:matchingOnlyParentPost:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -24878,6 +25666,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
@@ -24920,9 +25712,20 @@
           }
         },
         {
+          "name": "getForYouFeed",
+          "kind": "func",
+          "printed_name": "getForYouFeed()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
+          }
+        },
+        {
           "name": "getCommunityFeed",
           "kind": "func",
-          "printed_name": "getCommunityFeed(withCommunityId:sortBy:includeDeleted:feedType:tags:includeMixedStructure:untilAt:)",
+          "printed_name": "getCommunityFeed(withCommunityId:sortBy:includeDeleted:feedType:tags:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -24954,6 +25757,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
@@ -25318,6 +26125,13 @@
           "line": null
         },
         {
+          "name": "excludeBlockUserPosts",
+          "kind": "var",
+          "printed_name": "excludeBlockUserPosts",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
           "printed_name": "init(targetType:targetId:sortBy:deletedOption:filterPostTypes:includeMixedStructure:)",
@@ -25356,7 +26170,7 @@
         {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(targetType:targetId:sortBy:deletedOption:dataTypes:feedType:tags:includeMixedStructure:untilAt:)",
+          "printed_name": "init(targetType:targetId:sortBy:deletedOption:dataTypes:feedType:tags:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -25396,6 +26210,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityPostQueryOptions"
@@ -27315,12 +28133,12 @@
       ],
       "nested_types": [],
       "conformances": [
-        "Comparable",
         "Equatable",
         "Hashable",
         "RawRepresentable",
         "Decodable",
-        "Encodable"
+        "Encodable",
+        "Comparable"
       ],
       "extensions": []
     },
@@ -27740,6 +28558,22 @@
               {
                 "label": "progress",
                 "type": "(Swift.Double) -> ()"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "cancelUpload",
+          "kind": "func",
+          "printed_name": "cancelUpload(forUploadId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "forUploadId",
+                "type": "Swift.String"
               }
             ],
             "returns": "()"
@@ -30060,6 +30894,150 @@
       ],
       "extensions": []
     },
+    "AmityMessageSearchSortBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "relevance",
+          "kind": "case",
+          "printed_name": "relevance",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "createdAt",
+          "kind": "case",
+          "printed_name": "createdAt",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityMessageSearchSortBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
+    "AmityMessageSearchOptions": {
+      "kind": "class",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "query",
+          "kind": "var",
+          "printed_name": "query",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "exactMatch",
+          "kind": "var",
+          "printed_name": "exactMatch",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "channelId",
+          "kind": "var",
+          "printed_name": "channelId",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "messageFeedId",
+          "kind": "var",
+          "printed_name": "messageFeedId",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "userIds",
+          "kind": "var",
+          "printed_name": "userIds",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "types",
+          "kind": "var",
+          "printed_name": "types",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "orderBy",
+          "kind": "var",
+          "printed_name": "orderBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "sortBy",
+          "kind": "var",
+          "printed_name": "sortBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(query:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "query",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityMessageSearchOptions"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
+      "extensions": []
+    },
     "AmityContentFlagReason": {
       "kind": "enum",
       "primary_decl": {
@@ -30465,6 +31443,22 @@
               }
             ],
             "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "searchMessages",
+          "kind": "func",
+          "printed_name": "searchMessages(options:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "options",
+                "type": "AmitySDK.AmityMessageSearchOptions"
+              }
+            ],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityMessage>"
           }
         }
       ],
@@ -34123,9 +35117,31 @@
           }
         },
         {
+          "name": "getBlockingUsers",
+          "kind": "func",
+          "printed_name": "getBlockingUsers()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityUser>"
+          }
+        },
+        {
           "name": "getAllBlockedUsers",
           "kind": "func",
           "printed_name": "getAllBlockedUsers()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[AmitySDK.AmityUser]"
+          }
+        },
+        {
+          "name": "getAllBlockingUsers",
+          "kind": "func",
+          "printed_name": "getAllBlockingUsers()",
           "file": "",
           "line": null,
           "signature": {
@@ -34272,27 +35288,27 @@
       ],
       "nested_types": [],
       "conformances": [
-        "ContiguousBytes",
-        "DataProtocol",
-        "DecodableWithConfiguration",
-        "EncodableWithConfiguration",
-        "MutableDataProtocol",
+        "Equatable",
+        "RandomAccessCollection",
+        "MutableCollection",
         "BidirectionalCollection",
-        "CVarArg",
         "Collection",
-        "CustomDebugStringConvertible",
+        "Sequence",
+        "ExpressibleByArrayLiteral",
+        "RangeReplaceableCollection",
         "CustomReflectable",
         "CustomStringConvertible",
-        "Decodable",
-        "Encodable",
-        "Equatable",
-        "ExpressibleByArrayLiteral",
+        "CustomDebugStringConvertible",
         "Hashable",
-        "MutableCollection",
-        "RandomAccessCollection",
-        "RangeReplaceableCollection",
         "SendableMetatype",
-        "Sequence",
+        "Encodable",
+        "Decodable",
+        "DataProtocol",
+        "MutableDataProtocol",
+        "ContiguousBytes",
+        "EncodableWithConfiguration",
+        "DecodableWithConfiguration",
+        "CVarArg",
         "Content",
         "ContentWithFormatDescription"
       ],
@@ -34308,12 +35324,12 @@
       "nested_types": [],
       "conformances": [
         "ReferenceConvertible",
-        "CustomDebugStringConvertible",
-        "CustomReflectable",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "CustomReflectable"
       ],
       "extensions": []
     },
@@ -34326,11 +35342,11 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -34344,31 +35360,31 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Transferable",
-        "BidirectionalCollection",
-        "CVarArg",
-        "CodingKeyRepresentable",
-        "Collection",
-        "Comparable",
-        "CustomDebugStringConvertible",
-        "CustomReflectable",
-        "CustomStringConvertible",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByExtendedGraphemeClusterLiteral",
-        "ExpressibleByStringInterpolation",
-        "ExpressibleByStringLiteral",
-        "ExpressibleByUnicodeScalarLiteral",
-        "Hashable",
-        "LosslessStringConvertible",
-        "MirrorPath",
-        "RangeReplaceableCollection",
-        "SendableMetatype",
-        "Sequence",
-        "StringProtocol",
+        "CodingKeyRepresentable",
+        "CustomReflectable",
         "TextOutputStream",
-        "TextOutputStreamable"
+        "TextOutputStreamable",
+        "Hashable",
+        "SendableMetatype",
+        "ExpressibleByStringLiteral",
+        "ExpressibleByExtendedGraphemeClusterLiteral",
+        "ExpressibleByUnicodeScalarLiteral",
+        "CustomDebugStringConvertible",
+        "CustomStringConvertible",
+        "BidirectionalCollection",
+        "Collection",
+        "Sequence",
+        "Equatable",
+        "Comparable",
+        "StringProtocol",
+        "ExpressibleByStringInterpolation",
+        "LosslessStringConvertible",
+        "RangeReplaceableCollection",
+        "MirrorPath",
+        "CVarArg",
+        "Transferable"
       ],
       "extensions": []
     },
@@ -34400,15 +35416,15 @@
       ],
       "nested_types": [],
       "conformances": [
-        "Transferable",
-        "ReferenceConvertible",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
-        "Decodable",
-        "Encodable",
         "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "ReferenceConvertible",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "Decodable",
+        "Encodable",
+        "Transferable"
       ],
       "extensions": []
     },
@@ -34421,15 +35437,15 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "ReferenceConvertible",
+        "Hashable",
+        "Equatable",
+        "SendableMetatype",
+        "CustomStringConvertible",
         "CustomDebugStringConvertible",
         "CustomReflectable",
-        "CustomStringConvertible",
+        "ReferenceConvertible",
         "Decodable",
-        "Encodable",
-        "Equatable",
-        "Hashable",
-        "SendableMetatype"
+        "Encodable"
       ],
       "extensions": []
     },
@@ -34442,9 +35458,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
+        "SendableMetatype",
         "TopLevelDecoder",
-        "NetworkDecoder",
-        "SendableMetatype"
+        "NetworkDecoder"
       ],
       "extensions": []
     },
@@ -34457,9 +35473,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
+        "SendableMetatype",
         "TopLevelDecoder",
-        "NetworkDecoder",
-        "SendableMetatype"
+        "NetworkDecoder"
       ],
       "extensions": []
     },
@@ -34472,11 +35488,11 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -34490,8 +35506,8 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
-        "Hashable"
+        "Hashable",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34504,8 +35520,8 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
-        "Hashable"
+        "Hashable",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34518,9 +35534,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34533,27 +35549,27 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "NetworkFixedWidthInteger",
-        "AdditiveArithmetic",
+        "FixedWidthInteger",
+        "SignedInteger",
         "BinaryInteger",
-        "BitwiseCopyable",
-        "CVarArg",
-        "Comparable",
-        "CustomReflectable",
+        "LosslessStringConvertible",
+        "SignedNumeric",
         "CustomStringConvertible",
+        "Numeric",
+        "Strideable",
+        "AdditiveArithmetic",
+        "ExpressibleByIntegerLiteral",
+        "Comparable",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByIntegerLiteral",
-        "FixedWidthInteger",
+        "CustomReflectable",
+        "CVarArg",
         "Hashable",
-        "LosslessStringConvertible",
-        "Numeric",
-        "SIMDScalar",
+        "Equatable",
         "SendableMetatype",
-        "SignedInteger",
-        "SignedNumeric",
-        "Strideable",
+        "SIMDScalar",
+        "BitwiseCopyable",
+        "NetworkFixedWidthInteger",
         "AtomicRepresentable"
       ],
       "extensions": []
@@ -34583,27 +35599,27 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "MyWSArrayType",
-        "NetworkFixedWidthInteger",
-        "AdditiveArithmetic",
+        "FixedWidthInteger",
+        "UnsignedInteger",
         "BinaryInteger",
-        "BitwiseCopyable",
-        "CVarArg",
-        "Comparable",
-        "CustomReflectable",
+        "LosslessStringConvertible",
         "CustomStringConvertible",
+        "Numeric",
+        "Strideable",
+        "AdditiveArithmetic",
+        "ExpressibleByIntegerLiteral",
+        "Comparable",
+        "MyWSArrayType",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByIntegerLiteral",
-        "FixedWidthInteger",
+        "CustomReflectable",
+        "CVarArg",
         "Hashable",
-        "LosslessStringConvertible",
-        "Numeric",
-        "SIMDScalar",
+        "Equatable",
         "SendableMetatype",
-        "Strideable",
-        "UnsignedInteger",
+        "SIMDScalar",
+        "BitwiseCopyable",
+        "NetworkFixedWidthInteger",
         "AtomicRepresentable"
       ],
       "extensions": []
@@ -36709,11 +37725,11 @@
   "global_consts": [],
   "global_typealiases": [],
   "stats": {
-    "types_total": 393,
+    "types_total": 403,
     "protocols_total": 37,
-    "members_total": 2766,
+    "members_total": 2854,
     "nested_types_total": 8,
-    "enum_cases_total": 633,
+    "enum_cases_total": 655,
     "global_funcs": 5,
     "global_consts": 0,
     "global_typealiases": 0,

--- a/.docs-ops/sdk-surface/ios.json
+++ b/.docs-ops/sdk-surface/ios.json
@@ -1,7 +1,7 @@
 {
   "extractor_version": "0.2.0-abi",
   "extractor": "ios-docc-extractor.py",
-  "extracted_at": "2026-05-19T13:22:33.971996+00:00",
+  "extracted_at": "2026-07-06T04:51:06.807698+00:00",
   "sdk_product": "AmitySDK",
   "sdk_docc_archive": "/Users/admin/Documents/GitHub/sp-sdks/social-plus-docs/.docs-ops/integration-tests/ios/vendor/AmitySDK.xcframework/ios-arm64_x86_64-simulator/AmitySDK.framework/Modules/AmitySDK.swiftmodule/x86_64-apple-ios-simulator.abi.json",
   "source_format": "swiftmodule-abi-json",
@@ -154,6 +154,22 @@
           "line": null,
           "signature": {
             "parameters": [],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "markAsMeaningfullyViewed",
+          "kind": "func",
+          "printed_name": "markAsMeaningfullyViewed(feedRenderPosition:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "feedRenderPosition",
+                "type": "Swift.Int?"
+              }
+            ],
             "returns": "()"
           }
         }
@@ -309,6 +325,208 @@
       ],
       "nested_types": [],
       "conformances": [],
+      "extensions": []
+    },
+    "AmityAutoSubscription": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "chat",
+          "kind": "case",
+          "printed_name": "chat",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "network",
+          "kind": "case",
+          "printed_name": "network",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "livestream",
+          "kind": "case",
+          "printed_name": "livestream",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "block",
+          "kind": "case",
+          "printed_name": "block",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isSystem",
+          "kind": "var",
+          "printed_name": "isSystem",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "topicCount",
+          "kind": "var",
+          "printed_name": "topicCount",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "==",
+          "kind": "func",
+          "printed_name": "==(_:_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityAutoSubscription"
+              },
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityAutoSubscription"
+              }
+            ],
+            "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "allCases",
+          "kind": "var",
+          "printed_name": "allCases",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "hashValue",
+          "kind": "var",
+          "printed_name": "hashValue",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "hash",
+          "kind": "func",
+          "printed_name": "hash(into:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "into",
+                "type": "Swift.Hasher"
+              }
+            ],
+            "returns": "()"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "CaseIterable",
+        "Hashable"
+      ],
+      "extensions": []
+    },
+    "AmityAutoSubscriptionState": {
+      "kind": "struct",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "feature",
+          "kind": "var",
+          "printed_name": "feature",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isActive",
+          "kind": "var",
+          "printed_name": "isActive",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isSystem",
+          "kind": "var",
+          "printed_name": "isSystem",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "topicCount",
+          "kind": "var",
+          "printed_name": "topicCount",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
+      "extensions": []
+    },
+    "AmitySearchOrderBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "descending",
+          "kind": "case",
+          "printed_name": "descending",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "ascending",
+          "kind": "case",
+          "printed_name": "ascending",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmitySearchOrderBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable",
+        "SendableMetatype"
+      ],
       "extensions": []
     },
     "AmityChannelQueryFilter": {
@@ -642,6 +860,20 @@
           "line": null
         },
         {
+          "name": "visitorUsageLimitExceeded",
+          "kind": "case",
+          "printed_name": "visitorUsageLimitExceeded",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "maxBlockedUsersReached",
+          "kind": "case",
+          "printed_name": "maxBlockedUsersReached",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "conflict",
           "kind": "case",
           "printed_name": "conflict",
@@ -666,6 +898,13 @@
           "name": "notificationDisabled",
           "kind": "case",
           "printed_name": "notificationDisabled",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "forYouFeedDisabled",
+          "kind": "case",
+          "printed_name": "forYouFeedDisabled",
           "file": "",
           "line": null
         },
@@ -2375,11 +2614,11 @@
       ],
       "nested_types": [],
       "conformances": [
+        "Equatable",
         "Hashable",
         "RawRepresentable",
         "CaseIterable",
-        "SendableMetatype",
-        "Equatable"
+        "SendableMetatype"
       ],
       "extensions": []
     },
@@ -3139,12 +3378,12 @@
       ],
       "nested_types": [],
       "conformances": [
+        "OptionSet",
         "RawRepresentable",
         "SetAlgebra",
         "SendableMetatype",
         "Equatable",
-        "ExpressibleByArrayLiteral",
-        "OptionSet"
+        "ExpressibleByArrayLiteral"
       ],
       "extensions": []
     },
@@ -5521,6 +5760,13 @@
           }
         },
         {
+          "name": "visitorUsageLimitReachedPublisher",
+          "kind": "var",
+          "printed_name": "visitorUsageLimitReachedPublisher",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "user",
           "kind": "var",
           "printed_name": "user",
@@ -5843,6 +6089,49 @@
           }
         },
         {
+          "name": "enableAutoSubscriptions",
+          "kind": "func",
+          "printed_name": "enableAutoSubscriptions(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "[AmitySDK.AmityAutoSubscription]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "disableAutoSubscriptions",
+          "kind": "func",
+          "printed_name": "disableAutoSubscriptions(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "[AmitySDK.AmityAutoSubscription]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "autoSubscriptions",
+          "kind": "func",
+          "printed_name": "autoSubscriptions()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[AmitySDK.AmityAutoSubscriptionState]"
+          }
+        },
+        {
           "name": "setUploadedFileAccessType",
           "kind": "func",
           "printed_name": "setUploadedFileAccessType(type:)",
@@ -5961,6 +6250,17 @@
           "signature": {
             "parameters": [],
             "returns": "AmitySDK.AmityProductCatalogueSetting"
+          }
+        },
+        {
+          "name": "getForYouFeedSetting",
+          "kind": "func",
+          "printed_name": "getForYouFeedSetting()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityForYouFeedSetting"
           }
         },
         {
@@ -6117,6 +6417,80 @@
       "conformances": [],
       "extensions": []
     },
+    "AmitySharableContentType": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "post",
+          "kind": "case",
+          "printed_name": "post",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "community",
+          "kind": "case",
+          "printed_name": "community",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "user",
+          "kind": "case",
+          "printed_name": "user",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "livestream",
+          "kind": "case",
+          "printed_name": "livestream",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "event",
+          "kind": "case",
+          "printed_name": "event",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmitySharableContentType?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
     "AmityShareableLinkConfiguration": {
       "kind": "struct",
       "primary_decl": {
@@ -6137,6 +6511,58 @@
           "printed_name": "patterns",
           "file": "",
           "line": null
+        },
+        {
+          "name": "isEnabled",
+          "kind": "func",
+          "printed_name": "isEnabled(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              }
+            ],
+            "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "getPattern",
+          "kind": "func",
+          "printed_name": "getPattern(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              }
+            ],
+            "returns": "Swift.String?"
+          }
+        },
+        {
+          "name": "generateLink",
+          "kind": "func",
+          "printed_name": "generateLink(_:referenceId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmitySharableContentType"
+              },
+              {
+                "label": "referenceId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "Swift.String?"
+          }
         }
       ],
       "nested_types": [],
@@ -6854,11 +7280,11 @@
       ],
       "nested_types": [],
       "conformances": [
+        "Equatable",
         "Hashable",
         "RawRepresentable",
         "CaseIterable",
-        "SendableMetatype",
-        "Equatable"
+        "SendableMetatype"
       ],
       "extensions": []
     },
@@ -8927,11 +9353,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -10673,12 +11099,12 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CocoaMQTTSocketProtocol",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "CocoaMQTTSocketProtocol"
       ],
       "extensions": []
     },
@@ -11454,8 +11880,8 @@
         }
       ],
       "conformances": [
-        "CocoaMQTTWebSocketConnectionDelegate",
-        "CocoaMQTTSocketProtocol"
+        "CocoaMQTTSocketProtocol",
+        "CocoaMQTTWebSocketConnectionDelegate"
       ],
       "extensions": []
     },
@@ -11515,11 +11941,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11614,11 +12040,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11691,11 +12117,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11768,11 +12194,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11901,11 +12327,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -11978,11 +12404,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12055,11 +12481,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12132,11 +12558,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12209,11 +12635,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12356,11 +12782,11 @@
       ],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -12766,11 +13192,11 @@
       "nested_types": [],
       "conformances": [
         "Engine",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -13903,8 +14329,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "HeaderValidator",
-        "CertificatePinning"
+        "CertificatePinning",
+        "HeaderValidator"
       ],
       "extensions": []
     },
@@ -15013,11 +15439,11 @@
       "nested_types": [],
       "conformances": [
         "Transport",
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
-        "Hashable"
+        "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible"
       ],
       "extensions": []
     },
@@ -15849,8 +16275,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
       "extensions": []
     },
@@ -15918,8 +16344,8 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
       "extensions": []
     },
@@ -16116,9 +16542,141 @@
       ],
       "nested_types": [],
       "conformances": [
-        "AmityBuilder",
-        "AmityChannelCreateOptions"
+        "AmityChannelCreateOptions",
+        "AmityBuilder"
       ],
+      "extensions": []
+    },
+    "AmityChannelSearchSortBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "relevance",
+          "kind": "case",
+          "printed_name": "relevance",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "lastActivity",
+          "kind": "case",
+          "printed_name": "lastActivity",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityChannelSearchSortBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
+    "AmityChannelSearchOptions": {
+      "kind": "class",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "query",
+          "kind": "var",
+          "printed_name": "query",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "exactMatch",
+          "kind": "var",
+          "printed_name": "exactMatch",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "types",
+          "kind": "var",
+          "printed_name": "types",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "isMemberOnly",
+          "kind": "var",
+          "printed_name": "isMemberOnly",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "limit",
+          "kind": "var",
+          "printed_name": "limit",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "orderBy",
+          "kind": "var",
+          "printed_name": "orderBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "sortBy",
+          "kind": "var",
+          "printed_name": "sortBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityChannelSearchOptions"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
       "extensions": []
     },
     "AmityChannelUpdateOptions": {
@@ -16210,6 +16768,22 @@
               {
                 "label": "_",
                 "type": "[Swift.String]"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "setNotificationMode",
+          "kind": "func",
+          "printed_name": "setNotificationMode(_:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "_",
+                "type": "AmitySDK.AmityChannelNotificationMode"
               }
             ],
             "returns": "()"
@@ -16364,6 +16938,13 @@
           "name": "isPublic",
           "kind": "var",
           "printed_name": "isPublic",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "notificationMode",
+          "kind": "var",
+          "printed_name": "notificationMode",
           "file": "",
           "line": null
         },
@@ -16625,9 +17206,16 @@
           "line": null
         },
         {
+          "name": "excludeArchives",
+          "kind": "var",
+          "printed_name": "excludeArchives",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(types:filter:includingTags:excludingTags:includeDeleted:)",
+          "printed_name": "init(types:filter:includingTags:excludingTags:includeDeleted:excludeArchives:)",
           "file": "",
           "line": null,
           "signature": {
@@ -16650,6 +17238,10 @@
               },
               {
                 "label": "includeDeleted",
+                "type": "Swift.Bool"
+              },
+              {
+                "label": "excludeArchives",
                 "type": "Swift.Bool"
               }
             ],
@@ -17047,6 +17639,73 @@
       "conformances": [],
       "extensions": []
     },
+    "AmityChannelNotificationMode": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "default",
+          "kind": "case",
+          "printed_name": "default",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "subscribe",
+          "kind": "case",
+          "printed_name": "subscribe",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "silent",
+          "kind": "case",
+          "printed_name": "silent",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "unknown",
+          "kind": "case",
+          "printed_name": "unknown",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityChannelNotificationMode?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
     "AmityChannelRepository": {
       "kind": "class",
       "primary_decl": {
@@ -17238,6 +17897,76 @@
               }
             ],
             "returns": "()"
+          }
+        },
+        {
+          "name": "searchChannels",
+          "kind": "func",
+          "printed_name": "searchChannels(options:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "options",
+                "type": "AmitySDK.AmityChannelSearchOptions"
+              }
+            ],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityChannel>"
+          }
+        },
+        {
+          "name": "archiveChannel",
+          "kind": "func",
+          "printed_name": "archiveChannel(channelId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "channelId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "unarchiveChannel",
+          "kind": "func",
+          "printed_name": "unarchiveChannel(channelId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "channelId",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "getArchivedChannelIds",
+          "kind": "func",
+          "printed_name": "getArchivedChannelIds()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[Swift.String]"
+          }
+        },
+        {
+          "name": "getArchivedChannels",
+          "kind": "func",
+          "printed_name": "getArchivedChannels()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityChannel>"
           }
         }
       ],
@@ -19431,9 +20160,16 @@
           "line": null
         },
         {
+          "name": "excludeBlockUserComments",
+          "kind": "var",
+          "printed_name": "excludeBlockUserComments",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(referenceId:referenceType:filterByParentId:dataTypes:parentId:orderBy:includeDeleted:pageSize:)",
+          "printed_name": "init(referenceId:referenceType:filterByParentId:dataTypes:parentId:orderBy:includeDeleted:pageSize:excludeBlockUserComments:)",
           "file": "",
           "line": null,
           "signature": {
@@ -19469,6 +20205,10 @@
               {
                 "label": "pageSize",
                 "type": "Swift.Int"
+              },
+              {
+                "label": "excludeBlockUserComments",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCommentQueryOptions"
@@ -21409,9 +22149,16 @@
           "line": null
         },
         {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(filter:sortBy:categoryId:includeDeleted:includeDiscoverablePrivateCommunity:)",
+          "printed_name": "init(filter:sortBy:categoryId:includeDeleted:includeDiscoverablePrivateCommunity:tags:)",
           "file": "",
           "line": null,
           "signature": {
@@ -21435,6 +22182,10 @@
               {
                 "label": "includeDiscoverablePrivateCommunity",
                 "type": "Swift.Bool?"
+              },
+              {
+                "label": "tags",
+                "type": "[Swift.String]?"
               }
             ],
             "returns": "AmitySDK.AmityCommunityQueryOptions"
@@ -23963,6 +24714,43 @@
       ],
       "extensions": []
     },
+    "AmityForYouFeedSetting": {
+      "kind": "struct",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "enabled",
+          "kind": "var",
+          "printed_name": "enabled",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(from:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "from",
+                "type": "any Swift.Decoder"
+              }
+            ],
+            "returns": "AmitySDK.AmityForYouFeedSetting"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Decodable"
+      ],
+      "extensions": []
+    },
     "AmityPinnedPost": {
       "kind": "class",
       "primary_decl": {
@@ -24842,7 +25630,7 @@
         {
           "name": "getUserFeed",
           "kind": "func",
-          "printed_name": "getUserFeed(_:feedSources:dataTypes:sortBy:includeDeleted:matchingOnlyParentPost:includeMixedStructure:untilAt:)",
+          "printed_name": "getUserFeed(_:feedSources:dataTypes:sortBy:includeDeleted:matchingOnlyParentPost:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -24878,6 +25666,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
@@ -24920,9 +25712,20 @@
           }
         },
         {
+          "name": "getForYouFeed",
+          "kind": "func",
+          "printed_name": "getForYouFeed()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
+          }
+        },
+        {
           "name": "getCommunityFeed",
           "kind": "func",
-          "printed_name": "getCommunityFeed(withCommunityId:sortBy:includeDeleted:feedType:tags:includeMixedStructure:untilAt:)",
+          "printed_name": "getCommunityFeed(withCommunityId:sortBy:includeDeleted:feedType:tags:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -24954,6 +25757,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityCollection<AmitySDK.AmityPost>"
@@ -25318,6 +26125,13 @@
           "line": null
         },
         {
+          "name": "excludeBlockUserPosts",
+          "kind": "var",
+          "printed_name": "excludeBlockUserPosts",
+          "file": "",
+          "line": null
+        },
+        {
           "name": "init",
           "kind": "init",
           "printed_name": "init(targetType:targetId:sortBy:deletedOption:filterPostTypes:includeMixedStructure:)",
@@ -25356,7 +26170,7 @@
         {
           "name": "init",
           "kind": "init",
-          "printed_name": "init(targetType:targetId:sortBy:deletedOption:dataTypes:feedType:tags:includeMixedStructure:untilAt:)",
+          "printed_name": "init(targetType:targetId:sortBy:deletedOption:dataTypes:feedType:tags:includeMixedStructure:untilAt:excludeBlockUserPosts:)",
           "file": "",
           "line": null,
           "signature": {
@@ -25396,6 +26210,10 @@
               {
                 "label": "untilAt",
                 "type": "Foundation.Date?"
+              },
+              {
+                "label": "excludeBlockUserPosts",
+                "type": "Swift.Bool"
               }
             ],
             "returns": "AmitySDK.AmityPostQueryOptions"
@@ -27315,12 +28133,12 @@
       ],
       "nested_types": [],
       "conformances": [
-        "Comparable",
         "Equatable",
         "Hashable",
         "RawRepresentable",
         "Decodable",
-        "Encodable"
+        "Encodable",
+        "Comparable"
       ],
       "extensions": []
     },
@@ -27740,6 +28558,22 @@
               {
                 "label": "progress",
                 "type": "(Swift.Double) -> ()"
+              }
+            ],
+            "returns": "()"
+          }
+        },
+        {
+          "name": "cancelUpload",
+          "kind": "func",
+          "printed_name": "cancelUpload(forUploadId:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "forUploadId",
+                "type": "Swift.String"
               }
             ],
             "returns": "()"
@@ -30060,6 +30894,150 @@
       ],
       "extensions": []
     },
+    "AmityMessageSearchSortBy": {
+      "kind": "enum",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "relevance",
+          "kind": "case",
+          "printed_name": "relevance",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "createdAt",
+          "kind": "case",
+          "printed_name": "createdAt",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(rawValue:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "rawValue",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityMessageSearchSortBy?"
+          }
+        },
+        {
+          "name": "rawValue",
+          "kind": "var",
+          "printed_name": "rawValue",
+          "file": "",
+          "line": null
+        }
+      ],
+      "nested_types": [],
+      "conformances": [
+        "Equatable",
+        "Hashable",
+        "RawRepresentable"
+      ],
+      "extensions": []
+    },
+    "AmityMessageSearchOptions": {
+      "kind": "class",
+      "primary_decl": {
+        "file": "",
+        "line": null
+      },
+      "members": [
+        {
+          "name": "query",
+          "kind": "var",
+          "printed_name": "query",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "exactMatch",
+          "kind": "var",
+          "printed_name": "exactMatch",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "channelId",
+          "kind": "var",
+          "printed_name": "channelId",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "messageFeedId",
+          "kind": "var",
+          "printed_name": "messageFeedId",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "userIds",
+          "kind": "var",
+          "printed_name": "userIds",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "tags",
+          "kind": "var",
+          "printed_name": "tags",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "types",
+          "kind": "var",
+          "printed_name": "types",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "orderBy",
+          "kind": "var",
+          "printed_name": "orderBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "sortBy",
+          "kind": "var",
+          "printed_name": "sortBy",
+          "file": "",
+          "line": null
+        },
+        {
+          "name": "init",
+          "kind": "init",
+          "printed_name": "init(query:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "query",
+                "type": "Swift.String"
+              }
+            ],
+            "returns": "AmitySDK.AmityMessageSearchOptions"
+          }
+        }
+      ],
+      "nested_types": [],
+      "conformances": [],
+      "extensions": []
+    },
     "AmityContentFlagReason": {
       "kind": "enum",
       "primary_decl": {
@@ -30465,6 +31443,22 @@
               }
             ],
             "returns": "Swift.Bool"
+          }
+        },
+        {
+          "name": "searchMessages",
+          "kind": "func",
+          "printed_name": "searchMessages(options:)",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [
+              {
+                "label": "options",
+                "type": "AmitySDK.AmityMessageSearchOptions"
+              }
+            ],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityMessage>"
           }
         }
       ],
@@ -34123,9 +35117,31 @@
           }
         },
         {
+          "name": "getBlockingUsers",
+          "kind": "func",
+          "printed_name": "getBlockingUsers()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "AmitySDK.AmityCollection<AmitySDK.AmityUser>"
+          }
+        },
+        {
           "name": "getAllBlockedUsers",
           "kind": "func",
           "printed_name": "getAllBlockedUsers()",
+          "file": "",
+          "line": null,
+          "signature": {
+            "parameters": [],
+            "returns": "[AmitySDK.AmityUser]"
+          }
+        },
+        {
+          "name": "getAllBlockingUsers",
+          "kind": "func",
+          "printed_name": "getAllBlockingUsers()",
           "file": "",
           "line": null,
           "signature": {
@@ -34272,27 +35288,27 @@
       ],
       "nested_types": [],
       "conformances": [
-        "ContiguousBytes",
-        "DataProtocol",
-        "DecodableWithConfiguration",
-        "EncodableWithConfiguration",
-        "MutableDataProtocol",
+        "Equatable",
+        "RandomAccessCollection",
+        "MutableCollection",
         "BidirectionalCollection",
-        "CVarArg",
         "Collection",
-        "CustomDebugStringConvertible",
+        "Sequence",
+        "ExpressibleByArrayLiteral",
+        "RangeReplaceableCollection",
         "CustomReflectable",
         "CustomStringConvertible",
-        "Decodable",
-        "Encodable",
-        "Equatable",
-        "ExpressibleByArrayLiteral",
+        "CustomDebugStringConvertible",
         "Hashable",
-        "MutableCollection",
-        "RandomAccessCollection",
-        "RangeReplaceableCollection",
         "SendableMetatype",
-        "Sequence",
+        "Encodable",
+        "Decodable",
+        "DataProtocol",
+        "MutableDataProtocol",
+        "ContiguousBytes",
+        "EncodableWithConfiguration",
+        "DecodableWithConfiguration",
+        "CVarArg",
         "Content",
         "ContentWithFormatDescription"
       ],
@@ -34308,12 +35324,12 @@
       "nested_types": [],
       "conformances": [
         "ReferenceConvertible",
-        "CustomDebugStringConvertible",
-        "CustomReflectable",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "CustomReflectable"
       ],
       "extensions": []
     },
@@ -34326,11 +35342,11 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -34344,31 +35360,31 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Transferable",
-        "BidirectionalCollection",
-        "CVarArg",
-        "CodingKeyRepresentable",
-        "Collection",
-        "Comparable",
-        "CustomDebugStringConvertible",
-        "CustomReflectable",
-        "CustomStringConvertible",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByExtendedGraphemeClusterLiteral",
-        "ExpressibleByStringInterpolation",
-        "ExpressibleByStringLiteral",
-        "ExpressibleByUnicodeScalarLiteral",
-        "Hashable",
-        "LosslessStringConvertible",
-        "MirrorPath",
-        "RangeReplaceableCollection",
-        "SendableMetatype",
-        "Sequence",
-        "StringProtocol",
+        "CodingKeyRepresentable",
+        "CustomReflectable",
         "TextOutputStream",
-        "TextOutputStreamable"
+        "TextOutputStreamable",
+        "Hashable",
+        "SendableMetatype",
+        "ExpressibleByStringLiteral",
+        "ExpressibleByExtendedGraphemeClusterLiteral",
+        "ExpressibleByUnicodeScalarLiteral",
+        "CustomDebugStringConvertible",
+        "CustomStringConvertible",
+        "BidirectionalCollection",
+        "Collection",
+        "Sequence",
+        "Equatable",
+        "Comparable",
+        "StringProtocol",
+        "ExpressibleByStringInterpolation",
+        "LosslessStringConvertible",
+        "RangeReplaceableCollection",
+        "MirrorPath",
+        "CVarArg",
+        "Transferable"
       ],
       "extensions": []
     },
@@ -34400,15 +35416,15 @@
       ],
       "nested_types": [],
       "conformances": [
-        "Transferable",
-        "ReferenceConvertible",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
-        "Decodable",
-        "Encodable",
         "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "ReferenceConvertible",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
+        "Decodable",
+        "Encodable",
+        "Transferable"
       ],
       "extensions": []
     },
@@ -34421,15 +35437,15 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "ReferenceConvertible",
+        "Hashable",
+        "Equatable",
+        "SendableMetatype",
+        "CustomStringConvertible",
         "CustomDebugStringConvertible",
         "CustomReflectable",
-        "CustomStringConvertible",
+        "ReferenceConvertible",
         "Decodable",
-        "Encodable",
-        "Equatable",
-        "Hashable",
-        "SendableMetatype"
+        "Encodable"
       ],
       "extensions": []
     },
@@ -34442,9 +35458,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
+        "SendableMetatype",
         "TopLevelDecoder",
-        "NetworkDecoder",
-        "SendableMetatype"
+        "NetworkDecoder"
       ],
       "extensions": []
     },
@@ -34457,9 +35473,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
+        "SendableMetatype",
         "TopLevelDecoder",
-        "NetworkDecoder",
-        "SendableMetatype"
+        "NetworkDecoder"
       ],
       "extensions": []
     },
@@ -34472,11 +35488,11 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "CVarArg",
-        "CustomDebugStringConvertible",
-        "CustomStringConvertible",
         "Equatable",
         "Hashable",
+        "CVarArg",
+        "CustomStringConvertible",
+        "CustomDebugStringConvertible",
         "SendableMetatype"
       ],
       "extensions": []
@@ -34490,8 +35506,8 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
-        "Hashable"
+        "Hashable",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34504,8 +35520,8 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
-        "Hashable"
+        "Hashable",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34518,9 +35534,9 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "Equatable",
         "Hashable",
-        "SendableMetatype"
+        "SendableMetatype",
+        "Equatable"
       ],
       "extensions": []
     },
@@ -34533,27 +35549,27 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "NetworkFixedWidthInteger",
-        "AdditiveArithmetic",
+        "FixedWidthInteger",
+        "SignedInteger",
         "BinaryInteger",
-        "BitwiseCopyable",
-        "CVarArg",
-        "Comparable",
-        "CustomReflectable",
+        "LosslessStringConvertible",
+        "SignedNumeric",
         "CustomStringConvertible",
+        "Numeric",
+        "Strideable",
+        "AdditiveArithmetic",
+        "ExpressibleByIntegerLiteral",
+        "Comparable",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByIntegerLiteral",
-        "FixedWidthInteger",
+        "CustomReflectable",
+        "CVarArg",
         "Hashable",
-        "LosslessStringConvertible",
-        "Numeric",
-        "SIMDScalar",
+        "Equatable",
         "SendableMetatype",
-        "SignedInteger",
-        "SignedNumeric",
-        "Strideable",
+        "SIMDScalar",
+        "BitwiseCopyable",
+        "NetworkFixedWidthInteger",
         "AtomicRepresentable"
       ],
       "extensions": []
@@ -34583,27 +35599,27 @@
       "members": [],
       "nested_types": [],
       "conformances": [
-        "MyWSArrayType",
-        "NetworkFixedWidthInteger",
-        "AdditiveArithmetic",
+        "FixedWidthInteger",
+        "UnsignedInteger",
         "BinaryInteger",
-        "BitwiseCopyable",
-        "CVarArg",
-        "Comparable",
-        "CustomReflectable",
+        "LosslessStringConvertible",
         "CustomStringConvertible",
+        "Numeric",
+        "Strideable",
+        "AdditiveArithmetic",
+        "ExpressibleByIntegerLiteral",
+        "Comparable",
+        "MyWSArrayType",
         "Decodable",
         "Encodable",
-        "Equatable",
-        "ExpressibleByIntegerLiteral",
-        "FixedWidthInteger",
+        "CustomReflectable",
+        "CVarArg",
         "Hashable",
-        "LosslessStringConvertible",
-        "Numeric",
-        "SIMDScalar",
+        "Equatable",
         "SendableMetatype",
-        "Strideable",
-        "UnsignedInteger",
+        "SIMDScalar",
+        "BitwiseCopyable",
+        "NetworkFixedWidthInteger",
         "AtomicRepresentable"
       ],
       "extensions": []
@@ -36709,11 +37725,11 @@
   "global_consts": [],
   "global_typealiases": [],
   "stats": {
-    "types_total": 393,
+    "types_total": 403,
     "protocols_total": 37,
-    "members_total": 2766,
+    "members_total": 2854,
     "nested_types_total": 8,
-    "enum_cases_total": 633,
+    "enum_cases_total": 655,
     "global_funcs": 5,
     "global_consts": 0,
     "global_typealiases": 0,

--- a/.docs-ops/sdk-surface/typescript.json
+++ b/.docs-ops/sdk-surface/typescript.json
@@ -1,2578 +1,6853 @@
 {
-  "extractor_version": "0.1.3",
-  "extractor": "typescript-extractor.py",
-  "extracted_at": "2026-05-17T00:00:00Z",
+  "extractor_version": "0.3.0-hybrid",
+  "extractor": "typescript-hybrid-extractor.py",
+  "extracted_at": "2026-07-06T04:34:13.570747+00:00",
   "sdk_package": "@amityco/ts-sdk",
-  "sdk_source_root": "AmityTypescriptSDK/packages/sdk",
-  "barrel": "AmityTypescriptSDK/packages/sdk/src/index.ts",
+  "sources": {
+    "typedoc_json_path": "/private/tmp/typedoc-output.json",
+    "at_types_glob": "/Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK/packages/sdk/src/@types/**/*.ts",
+    "typedoc_note": "24 namespaced exports; @hidden/@private/@internal honored natively",
+    "at_types_note": "Amity global namespace from declare global{} augmentations"
+  },
+  "merge_notes": [],
   "namespaces": {
-    "Client": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/client/index.ts",
-      "member_count": 38,
+    "AdRepository": {
+      "source_module": "adRepository/index.ts",
+      "member_count": 1,
       "members": [
         {
-          "name": "getActiveUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/activeUser.ts",
-          "line": 12
-        },
-        {
-          "name": "setActiveUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/activeUser.ts",
-          "line": 25
-        },
-        {
-          "name": "createClient",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/createClient.ts",
-          "line": 41
-        },
-        {
-          "name": "login",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/login.ts",
-          "line": 53
-        },
-        {
-          "name": "TokenPayload",
-          "kind": "interface",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/loginWithAccessToken.ts",
-          "line": 13
-        },
-        {
-          "name": "loginWithAccessToken",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/loginWithAccessToken.ts",
-          "line": 49
-        },
-        {
-          "name": "logout",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/logout.ts",
-          "line": 20
-        },
-        {
-          "name": "secureLogout",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/secureLogout.ts",
-          "line": 20
-        },
-        {
-          "name": "resumeSession",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/resumeSession.ts",
-          "line": 76
-        },
-        {
-          "name": "isConnected",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/isConnected.ts",
-          "line": 15
-        },
-        {
-          "name": "getFeedSettings",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getFeedSettings.ts",
-          "line": 17
-        },
-        {
-          "name": "renewal",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/renewal.ts",
-          "line": 22
-        },
-        {
-          "name": "enableUnreadCount",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/enableUnreadCount.ts",
-          "line": 1
-        },
-        {
-          "name": "setUploadedFileAccessType",
+          "name": "getNetworkAds",
           "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/setUploadedFileAccessType.ts",
-          "line": 3
-        },
-        {
-          "name": "fetchLinkPreview",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/fetchLinkPreview.ts",
-          "line": 20
-        },
-        {
-          "name": "getLinkPreviewMetadata",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getLinkPreviewMetadata.ts",
-          "line": 16
-        },
-        {
-          "name": "getSocialSettings",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getSocialSettings.ts",
-          "line": 16
-        },
-        {
-          "name": "getShareableLinkConfiguration",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getShareableLinkConfiguration.ts",
-          "line": 27
-        },
-        {
-          "name": "getProductCatalogueSetting",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getProductCatalogueSetting.ts",
-          "line": 19
-        },
-        {
-          "name": "loginAsVisitor",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/loginAsVisitor.ts",
-          "line": 51
-        },
-        {
-          "name": "loginAsBot",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/loginAsBot.ts",
-          "line": 49
-        },
-        {
-          "name": "getCurrentUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getCurrentUser.ts",
-          "line": 9
-        },
-        {
-          "name": "getCurrentUserType",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getCurrentUserType.ts",
-          "line": 8
-        },
-        {
-          "name": "setCurrentUserType",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getCurrentUserType.ts",
-          "line": 21
-        },
-        {
-          "name": "setAccessTokenHandler",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/setAccessTokenHandler.ts",
-          "line": 35
-        },
-        {
-          "name": "getChatSettings",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/getChatSettings.ts",
-          "line": 16
-        },
-        {
-          "name": "notifications",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/api/notifications.ts",
-          "line": 202
-        },
-        {
-          "name": "onConnectionError",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onConnectionError.ts",
-          "line": 30
-        },
-        {
-          "name": "onClientDisconnected",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onClientDisconnected.ts",
-          "line": 18
-        },
-        {
-          "name": "onClientBanned",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onClientBanned.ts",
-          "line": 20
-        },
-        {
-          "name": "onSessionStateChange",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onSessionStateChange.ts",
-          "line": 18
-        },
-        {
-          "name": "onNetworkActivities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onNetworkActivities.ts",
-          "line": 12
-        },
-        {
-          "name": "onVisitorUsageLimitReached",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/events/onVisitorUsageLimitReached.ts",
-          "line": 24
-        },
-        {
-          "name": "getUserUnread",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/observers/getUserUnread.ts",
-          "line": 32
-        },
-        {
-          "name": "startMarkerSync",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/utils/markerSyncEngine.ts",
-          "line": 180
-        },
-        {
-          "name": "startUnreadSync",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/utils/markerSyncEngine.ts",
-          "line": 193
-        },
-        {
-          "name": "stopUnreadSync",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/utils/markerSyncEngine.ts",
-          "line": 205
-        },
-        {
-          "name": "getMarkerSyncConsistentMode",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/client/utils/markerSyncEngine.ts",
-          "line": 217
+          "file": "adRepository/api/getNetworkAds.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<NetworkAds>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
-    "UserRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/userRepository/index.ts",
-      "member_count": 17,
+    "CategoryRepository": {
+      "source_module": "categoryRepository/index.ts",
+      "member_count": 2,
       "members": [
         {
-          "name": "getUserByIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/getUserByIds.ts",
-          "line": 26
+          "name": "getCategories",
+          "kind": "function",
+          "file": "categoryRepository/observers/getCategories.ts",
+          "line": 41,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CategoryLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Category>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
         },
         {
-          "name": "updateUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/updateUser.ts",
-          "line": 25
-        },
-        {
-          "name": "flagUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/flagUser.ts",
-          "line": 22
-        },
-        {
-          "name": "unflagUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/unflagUser.ts",
-          "line": 22
-        },
-        {
-          "name": "isUserFlaggedByMe",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/isUserFlaggedByMe.ts",
-          "line": 19
-        },
-        {
-          "name": "getAllBlockedUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/api/getAllBlockedUsers.ts",
-          "line": 22
-        },
-        {
-          "name": "onUserUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/events/onUserUpdated.ts",
-          "line": 18
-        },
-        {
-          "name": "onUserDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/events/onUserDeleted.ts",
-          "line": 18
-        },
-        {
-          "name": "onUserFlagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/events/onUserFlagged.ts",
-          "line": 18
-        },
-        {
-          "name": "onUserUnflagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/events/onUserUnflagged.ts",
-          "line": 18
-        },
-        {
-          "name": "onUserFlagCleared",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/events/onUserFlagCleared.ts",
-          "line": 18
-        },
-        {
-          "name": "getUser",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/observers/getUser.ts",
-          "line": 35
-        },
-        {
-          "name": "getUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/observers/getUsers.ts",
-          "line": 27
-        },
-        {
-          "name": "getBlockedUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/observers/getBlockedUsers.ts",
-          "line": 24
-        },
-        {
-          "name": "searchUserByDisplayName",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/observers/searchUserByDisplayName.ts",
-          "line": 27
-        },
-        {
-          "name": "getReachedUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/observers/getReachedUsers.ts",
-          "line": 8
-        },
-        {
-          "name": "AmityUserSearchMatchType",
-          "kind": "enum",
-          "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/constants/index.ts",
-          "line": 1
-        }
-      ],
-      "sub_namespaces": {
-        "Relationship": {
-          "source_module": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/index.ts",
-          "member_count": 23,
-          "members": [
-            {
-              "name": "blockUser",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/block/api/blockUser.ts",
-              "line": 24
-            },
-            {
-              "name": "unBlockUser",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/block/api/unBlockUser.ts",
-              "line": 24
-            },
-            {
-              "name": "follow",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/api/follow.ts",
-              "line": 23
-            },
-            {
-              "name": "unfollow",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/api/unfollow.ts",
-              "line": 23
-            },
-            {
-              "name": "acceptMyFollower",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/api/acceptMyFollower.ts",
-              "line": 23
-            },
-            {
-              "name": "declineMyFollower",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/api/declineMyFollower.ts",
-              "line": 23
-            },
-            {
-              "name": "onUserFollowed",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onUserFollowed.ts",
-              "line": 18
-            },
-            {
-              "name": "onUserUnfollowed",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onUserUnfollowed.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowerDeleted",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowerDeleted.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowerRequested",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowerRequested.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowRequestCanceled",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowRequestCanceled.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowRequestAccepted",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowRequestAccepted.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowRequestDeclined",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowRequestDeclined.ts",
-              "line": 18
-            },
-            {
-              "name": "onFollowInfoUpdated",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onFollowInfoUpdated.ts",
-              "line": 19
-            },
-            {
-              "name": "onLocalUserFollowed",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onLocalUserFollowed.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalUserUnfollowed",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onLocalUserUnfollowed.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalFollowerRequested",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onLocalFollowerRequested.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalFollowRequestAccepted",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onLocalFollowRequestAccepted.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalFollowRequestDeclined",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/events/onLocalFollowRequestDeclined.ts",
-              "line": 3
-            },
-            {
-              "name": "getFollowers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/observers/getFollowers.ts",
-              "line": 29
-            },
-            {
-              "name": "getFollowings",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/observers/getFollowings.ts",
-              "line": 27
-            },
-            {
-              "name": "getFollowInfo",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/observers/getFollowInfo.ts",
-              "line": 27
-            },
-            {
-              "name": "getMyFollowInfo",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/userRepository/relationship/follow/observers/getMyFollowInfo.ts",
-              "line": 27
-            }
-          ],
-          "sub_namespaces": {}
-        }
-      }
-    },
-    "FileRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/fileRepository/index.ts",
-      "member_count": 9,
-      "members": [
-        {
-          "name": "getFile",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/getFile.ts",
-          "line": 23
-        },
-        {
-          "name": "uploadFile",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/uploadFile.ts",
-          "line": 24
-        },
-        {
-          "name": "deleteFile",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/deleteFile.ts",
-          "line": 22
-        },
-        {
-          "name": "fileUrlWithSize",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/fileUrlWithSize.ts",
-          "line": 8
-        },
-        {
-          "name": "uploadVideo",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/uploadVideo.ts",
-          "line": 25
-        },
-        {
-          "name": "uploadImage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/uploadImage.ts",
-          "line": 26
-        },
-        {
-          "name": "updateAltText",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/updateAltText.ts",
-          "line": 22
-        },
-        {
-          "name": "uploadClip",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/uploadClip.ts",
-          "line": 23
-        },
-        {
-          "name": "uploadAudio",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/fileRepository/api/uploadAudio.ts",
-          "line": 23
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "ReactionRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/index.ts",
-      "member_count": 7,
-      "members": [
-        {
-          "name": "addReaction",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/api/addReaction.ts",
-          "line": 29
-        },
-        {
-          "name": "removeReaction",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/api/removeReaction.ts",
-          "line": 30
-        },
-        {
-          "name": "onReactionAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/events/onReactionAdded.ts",
-          "line": 27
-        },
-        {
-          "name": "onReactionRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/events/onReactionRemoved.ts",
-          "line": 27
-        },
-        {
-          "name": "onReactorAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/events/onReactorAdded.ts",
-          "line": 23
-        },
-        {
-          "name": "onReactorRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/events/onReactorRemoved.ts",
-          "line": 23
-        },
-        {
-          "name": "getReactions",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/reactionRepository/observers/getReactions/getReactions.ts",
-          "line": 30
+          "name": "getCategory",
+          "kind": "function",
+          "file": "categoryRepository/api/getCategory.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "categoryId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Category>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
     "ChannelRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/channelRepository/index.ts",
-      "member_count": 34,
+      "source_module": "channelRepository/index.ts",
+      "member_count": 35,
       "members": [
-        {
-          "name": "getChannelByIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/getChannelByIds.ts",
-          "line": 28
-        },
-        {
-          "name": "createChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/createChannel.ts",
-          "line": 25
-        },
-        {
-          "name": "updateChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/updateChannel.ts",
-          "line": 26
-        },
-        {
-          "name": "deleteChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/deleteChannel.ts",
-          "line": 20
-        },
-        {
-          "name": "joinChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/joinChannel.ts",
-          "line": 24
-        },
-        {
-          "name": "leaveChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/leaveChannel.ts",
-          "line": 24
-        },
-        {
-          "name": "muteChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/muteChannel.ts",
-          "line": 23
-        },
-        {
-          "name": "unmuteChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/unmuteChannel.ts",
-          "line": 21
-        },
-        {
-          "name": "archiveChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/archiveChannel.ts",
-          "line": 23
-        },
-        {
-          "name": "unarchiveChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/unarchiveChannel.ts",
-          "line": 22
-        },
-        {
-          "name": "getArchivedChannelIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/api/getArchivedChannelIds.ts",
-          "line": 18
-        },
-        {
-          "name": "onChannelCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelCreated.ts",
-          "line": 22
-        },
-        {
-          "name": "onChannelUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelUpdated.ts",
-          "line": 21
-        },
-        {
-          "name": "onChannelDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelDeleted.ts",
-          "line": 25
-        },
-        {
-          "name": "onChannelJoined",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelJoined.ts",
-          "line": 25
-        },
-        {
-          "name": "onChannelLeft",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelLeft.ts",
-          "line": 28
-        },
-        {
-          "name": "onChannelSetMuted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelSetMuted.ts",
-          "line": 19
-        },
-        {
-          "name": "onChannelMemberAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberAdded.ts",
-          "line": 24
-        },
-        {
-          "name": "onChannelMemberRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberRemoved.ts",
-          "line": 25
-        },
-        {
-          "name": "onChannelMemberBanned",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberBanned.ts",
-          "line": 27
-        },
-        {
-          "name": "onChannelMemberUnbanned",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberUnbanned.ts",
-          "line": 25
-        },
-        {
-          "name": "onChannelMemberRoleAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberRoleAdded.ts",
-          "line": 21
-        },
-        {
-          "name": "onChannelMemberRoleRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelMemberRoleRemoved.ts",
-          "line": 21
-        },
-        {
-          "name": "onChannelArchived",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelArchived.ts",
-          "line": 12
-        },
-        {
-          "name": "onChannelUnarchived",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/events/onChannelUnarchived.ts",
-          "line": 13
-        },
-        {
-          "name": "getChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/observers/getChannel.ts",
-          "line": 61
-        },
-        {
-          "name": "getChannels",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/observers/getChannels/getChannels.ts",
-          "line": 29
-        },
-        {
-          "name": "getTotalChannelsUnread",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/observers/getTotalChannelsUnread.ts",
-          "line": 36
-        },
-        {
-          "name": "getArchivedChannels",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/observers/getArchivedChannels/getArchivedChannels.ts",
-          "line": 27
-        },
         {
           "name": "MARKER_INCLUDED_CHANNEL_TYPE",
           "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/utils/prepareChannelPayload.ts",
+          "file": "channelRepository/utils/prepareChannelPayload.ts",
           "line": 12
         },
         {
-          "name": "isUnreadCountSupport",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/utils/prepareChannelPayload.ts",
-          "line": 13
+          "name": "archiveChannel",
+          "kind": "function",
+          "file": "channelRepository/api/archiveChannel.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
         },
         {
           "name": "convertFromRaw",
           "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/utils/prepareChannelPayload.ts",
-          "line": 16
+          "file": "channelRepository/utils/prepareChannelPayload.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channel",
+                "type": "RawChannel"
+              },
+              {
+                "name": "options",
+                "type": "{}"
+              }
+            ],
+            "returns": "StaticInternalChannel"
+          }
         },
         {
-          "name": "preUpdateChannelCache",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/utils/prepareChannelPayload.ts",
-          "line": 40
+          "name": "createChannel",
+          "kind": "function",
+          "file": "channelRepository/api/createChannel.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "{} & Pick<Channel<T>, 'displayName' | 'avatarFileId' | 'isPublic' | 'metadata' | 'tags'>"
+              }
+            ],
+            "returns": "Promise<Cached<Channel<T>>>"
+          }
+        },
+        {
+          "name": "deleteChannel",
+          "kind": "function",
+          "file": "channelRepository/api/deleteChannel.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<InternalChannel<any>>"
+          }
+        },
+        {
+          "name": "getArchivedChannelIds",
+          "kind": "function",
+          "file": "channelRepository/api/getArchivedChannelIds.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<string[]>"
+          }
+        },
+        {
+          "name": "getArchivedChannels",
+          "kind": "function",
+          "file": "channelRepository/observers/getArchivedChannels/getArchivedChannels.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ArchivedChannelLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Channel<any>>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getChannel",
+          "kind": "function",
+          "file": "channelRepository/observers/getChannel.ts",
+          "line": 61,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Channel<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getChannelByIds",
+          "kind": "function",
+          "file": "channelRepository/api/getChannelByIds.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<Channel<any>[]>>"
+          }
+        },
+        {
+          "name": "getChannels",
+          "kind": "function",
+          "file": "channelRepository/observers/getChannels/getChannels.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ChannelLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Channel<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getTotalChannelsUnread",
+          "kind": "function",
+          "file": "channelRepository/observers/getTotalChannelsUnread.ts",
+          "line": 36,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<UserUnread | undefined>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "isUnreadCountSupport",
+          "kind": "function",
+          "file": "channelRepository/utils/prepareChannelPayload.ts",
+          "line": 13,
+          "signature": {
+            "parameters": [
+              {
+                "name": "__namedParameters",
+                "type": "Pick<Amity.RawChannel, 'type'>"
+              }
+            ],
+            "returns": "boolean"
+          }
+        },
+        {
+          "name": "joinChannel",
+          "kind": "function",
+          "file": "channelRepository/api/joinChannel.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "leaveChannel",
+          "kind": "function",
+          "file": "channelRepository/api/leaveChannel.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "muteChannel",
+          "kind": "function",
+          "file": "channelRepository/api/muteChannel.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              },
+              {
+                "name": "mutePeriod",
+                "type": "number"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "onChannelArchived",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelArchived.ts",
+          "line": 12,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<ArchivedChannelPayload>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onChannelCreated",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelCreated.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<StaticInternalChannel<any>>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelDeleted",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelDeleted.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<StaticInternalChannel<any>>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelJoined",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelJoined.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelLeft",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelLeft.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelMemberAdded",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberAdded.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onChannelMemberBanned",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberBanned.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelMemberRemoved",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberRemoved.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelMemberRoleAdded",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberRoleAdded.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onChannelMemberRoleRemoved",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberRoleRemoved.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onChannelMemberUnbanned",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelMemberUnbanned.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelSetMuted",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelSetMuted.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<StaticInternalChannel<any>>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onChannelUnarchived",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelUnarchived.ts",
+          "line": 13,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<ArchivedChannelPayload>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onChannelUpdated",
+          "kind": "function",
+          "file": "channelRepository/events/onChannelUpdated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<StaticInternalChannel<any>>"
+              }
+            ],
+            "returns": "{}"
+          }
         },
         {
           "name": "prepareChannelPayload",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/utils/prepareChannelPayload.ts",
-          "line": 122
+          "kind": "function",
+          "file": "channelRepository/utils/prepareChannelPayload.ts",
+          "line": 122,
+          "signature": {
+            "parameters": [
+              {
+                "name": "rawPayload",
+                "type": "ChannelPayload"
+              },
+              {
+                "name": "options",
+                "type": "{}"
+              }
+            ],
+            "returns": "Promise<ProcessedChannelPayload<any>>"
+          }
+        },
+        {
+          "name": "preUpdateChannelCache",
+          "kind": "function",
+          "file": "channelRepository/utils/prepareChannelPayload.ts",
+          "line": 40,
+          "signature": {
+            "parameters": [
+              {
+                "name": "rawPayload",
+                "type": "ChannelPayload"
+              },
+              {
+                "name": "options",
+                "type": "{}"
+              }
+            ],
+            "returns": "void"
+          }
+        },
+        {
+          "name": "searchChannels",
+          "kind": "function",
+          "file": "channelRepository/observers/searchChannels.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SearchChannelLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Channel<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "unarchiveChannel",
+          "kind": "function",
+          "file": "channelRepository/api/unarchiveChannel.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "unmuteChannel",
+          "kind": "function",
+          "file": "channelRepository/api/unmuteChannel.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "updateChannel",
+          "kind": "function",
+          "file": "channelRepository/api/updateChannel.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "channelId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Channel, 'displayName' | 'avatarFileId' | 'tags' | 'metadata' | 'notificationMode'>"
+              }
+            ],
+            "returns": "Promise<Cached<InternalChannel<any>>>"
+          }
         }
       ],
       "sub_namespaces": {
         "Membership": {
-          "source_module": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelMembership/index.ts",
-          "member_count": 4,
+          "source_module": "channelRepository/channelMembership/index.ts",
+          "member_count": 5,
           "members": [
             {
               "name": "addMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelMembership/api/addMembers.ts",
-              "line": 26
+              "kind": "function",
+              "file": "channelRepository/channelMembership/api/addMembers.ts",
+              "line": 26,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             },
             {
-              "name": "removeMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelMembership/api/removeMembers.ts",
-              "line": 26
+              "name": "applyFilter",
+              "kind": "function",
+              "file": "channelRepository/channelMembership/observers/getMembers/getMembers.ts",
+              "line": 17,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "data",
+                    "type": "T[]"
+                  },
+                  {
+                    "name": "params",
+                    "type": "ChannelMembersLiveCollection"
+                  }
+                ],
+                "returns": "T[]"
+              }
             },
             {
               "name": "getMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelMembership/observers/getMembers/getMembers.ts",
-              "line": 71
+              "kind": "function",
+              "file": "channelRepository/channelMembership/observers/getMembers/getMembers.ts",
+              "line": 71,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "ChannelMembersLiveCollection"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<Membership<'channel'>>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "{}"
+              }
+            },
+            {
+              "name": "removeMembers",
+              "kind": "function",
+              "file": "channelRepository/channelMembership/api/removeMembers.ts",
+              "line": 26,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             },
             {
               "name": "searchMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelMembership/observers/searchMembers.ts",
-              "line": 26
+              "kind": "function",
+              "file": "channelRepository/channelMembership/observers/searchMembers.ts",
+              "line": 26,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "SearchChannelMembers"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<Membership<'channel'>>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "{}"
+              }
             }
           ],
           "sub_namespaces": {}
         },
         "Moderation": {
-          "source_module": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/index.ts",
+          "source_module": "channelRepository/channelModeration/index.ts",
           "member_count": 6,
           "members": [
             {
               "name": "addRole",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/addRole.ts",
-              "line": 27
-            },
-            {
-              "name": "removeRole",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/removeRole.ts",
-              "line": 27
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/addRole.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "roleId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             },
             {
               "name": "banMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/banMembers.ts",
-              "line": 25
-            },
-            {
-              "name": "unbanMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/unbanMembers.ts",
-              "line": 25
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/banMembers.ts",
+              "line": 25,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<Cached<Membership<'channel'>[]>>"
+              }
             },
             {
               "name": "muteMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/muteMembers.ts",
-              "line": 24
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/muteMembers.ts",
+              "line": 24,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  },
+                  {
+                    "name": "mutePeriod",
+                    "type": "number"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             },
             {
-              "name": "unmuteMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/channelRepository/channelModeration/api/unmuteMembers.ts",
-              "line": 21
-            }
-          ],
-          "sub_namespaces": {}
-        }
-      }
-    },
-    "MessageRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/messageRepository/index.ts",
-      "member_count": 28,
-      "members": [
-        {
-          "name": "createMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/createMessage.ts",
-          "line": 118
-        },
-        {
-          "name": "updateMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/updateMessage.ts",
-          "line": 30
-        },
-        {
-          "name": "editMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/editMessage.ts",
-          "line": 30
-        },
-        {
-          "name": "deleteMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/deleteMessage.ts",
-          "line": 20
-        },
-        {
-          "name": "softDeleteMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/softDeleteMessage.ts",
-          "line": 25
-        },
-        {
-          "name": "markAsDelivered",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/markAsDelivered.ts",
-          "line": 20
-        },
-        {
-          "name": "getReadUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/getReadUsers.ts",
-          "line": 25
-        },
-        {
-          "name": "getDeliveredUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/getDeliveredUsers.ts",
-          "line": 24
-        },
-        {
-          "name": "flagMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/flagMessage.ts",
-          "line": 23
-        },
-        {
-          "name": "unflagMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/unflagMessage.ts",
-          "line": 23
-        },
-        {
-          "name": "isMessageFlaggedByMe",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/api/isMessageFlaggedByMe.ts",
-          "line": 18
-        },
-        {
-          "name": "onMessageCreatedMqtt",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageCreated.ts",
-          "line": 27
-        },
-        {
-          "name": "onMessageCreatedLocal",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageCreated.ts",
-          "line": 102
-        },
-        {
-          "name": "onMessageUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageUpdated.ts",
-          "line": 23
-        },
-        {
-          "name": "onMessageDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageDeleted.ts",
-          "line": 22
-        },
-        {
-          "name": "onMessageFlagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageFlagged.ts",
-          "line": 22
-        },
-        {
-          "name": "onMessageUnflagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageUnflagged.ts",
-          "line": 21
-        },
-        {
-          "name": "onMessageFlagCleared",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageFlagCleared.ts",
-          "line": 21
-        },
-        {
-          "name": "onMessageReactionAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageReactionAdded.ts",
-          "line": 22
-        },
-        {
-          "name": "onMessageReactionRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageReactionRemoved.ts",
-          "line": 22
-        },
-        {
-          "name": "onMessageFetched",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/events/onMessageFetched.ts",
-          "line": 21
-        },
-        {
-          "name": "getMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/observers/getMessage.ts",
-          "line": 40
-        },
-        {
-          "name": "getMessages",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/observers/getMessages/getMessages.ts",
-          "line": 28
-        },
-        {
-          "name": "searchMessage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/observers/searchMessage/searchMessage.ts",
-          "line": 31
-        },
-        {
-          "name": "convertFromRaw",
-          "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/utils/prepareMessagePayload.ts",
-          "line": 29
-        },
-        {
-          "name": "prepareMessagePayload",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/utils/prepareMessagePayload.ts",
-          "line": 113
-        },
-        {
-          "name": "convertParams",
-          "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/utils/prepareMessagePayload.ts",
-          "line": 187
-        },
-        {
-          "name": "convertQueryParams",
-          "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/messageRepository/utils/prepareMessagePayload.ts",
-          "line": 209
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "SubChannelRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/index.ts",
-      "member_count": 12,
-      "members": [
-        {
-          "name": "createSubChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/api/createSubChannel.ts",
-          "line": 23
-        },
-        {
-          "name": "updateSubChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/api/updateSubChannel.ts",
-          "line": 24
-        },
-        {
-          "name": "hardDeleteSubChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/api/hardDeleteSubChannel.ts",
-          "line": 21
-        },
-        {
-          "name": "softDeleteSubChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/api/softDeleteSubChannel.ts",
-          "line": 21
-        },
-        {
-          "name": "onSubChannelCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/events/onSubChannelCreated.ts",
-          "line": 22
-        },
-        {
-          "name": "onSubChannelUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/events/onSubChannelUpdated.ts",
-          "line": 22
-        },
-        {
-          "name": "onSubChannelDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/events/onSubChannelDeleted.ts",
-          "line": 23
-        },
-        {
-          "name": "getSubChannel",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/observers/getSubChannel.ts",
-          "line": 47
-        },
-        {
-          "name": "getSubChannels",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/observers/getSubChannels/getSubChannels.ts",
-          "line": 29
-        },
-        {
-          "name": "markReadEngineOnLoginHandler",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/utils/markReadEngine.ts",
-          "line": 48
-        },
-        {
-          "name": "startMessageReceiptSync",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/utils/messageReceiptSync.ts",
-          "line": 44
-        },
-        {
-          "name": "stopMessageReceiptSync",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/subChannelRepository/utils/messageReceiptSync.ts",
-          "line": 69
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "CommunityRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/communityRepository/index.ts",
-      "member_count": 16,
-      "members": [
-        {
-          "name": "createCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/api/createCommunity.ts",
-          "line": 26
-        },
-        {
-          "name": "updateCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/api/updateCommunity.ts",
-          "line": 28
-        },
-        {
-          "name": "deleteCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/api/deleteCommunity.ts",
-          "line": 24
-        },
-        {
-          "name": "joinCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/api/joinCommunity.ts",
-          "line": 27
-        },
-        {
-          "name": "leaveCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/api/leaveCommunity.ts",
-          "line": 24
-        },
-        {
-          "name": "onCommunityCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/events/onCommunityCreated.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommunityUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/events/onCommunityUpdated.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommunityDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/events/onCommunityDeleted.ts",
-          "line": 18
-        },
-        {
-          "name": "searchCommunities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/searchCommunities.ts",
-          "line": 27
-        },
-        {
-          "name": "getCommunities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/getCommunities.ts",
-          "line": 27
-        },
-        {
-          "name": "getCommunity",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/getCommunity.ts",
-          "line": 39
-        },
-        {
-          "name": "getTrendingCommunities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/getTrendingCommunities.ts",
-          "line": 29
-        },
-        {
-          "name": "getRecommendedCommunities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/getRecommendedCommunities.ts",
-          "line": 29
-        },
-        {
-          "name": "semanticSearchCommunities",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/semanticSearchCommunities.ts",
-          "line": 14
-        },
-        {
-          "name": "getJoinRequestList",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/observers/getJoinRequestList.ts",
-          "line": 19
-        },
-        {
-          "name": "AmityCommunityMemberStatusFilter",
-          "kind": "enum",
-          "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/constants/index.ts",
-          "line": 1
-        }
-      ],
-      "sub_namespaces": {
-        "Moderation": {
-          "source_module": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityModeration/index.ts",
-          "member_count": 4,
-          "members": [
-            {
-              "name": "addRoles",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityModeration/api/addRoles.ts",
-              "line": 26
-            },
-            {
-              "name": "removeRoles",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityModeration/api/removeRoles.ts",
-              "line": 26
-            },
-            {
-              "name": "banMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityModeration/api/banMembers.ts",
-              "line": 24
+              "name": "removeRole",
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/removeRole.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "roleId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             },
             {
               "name": "unbanMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityModeration/api/unbanMembers.ts",
-              "line": 24
-            }
-          ],
-          "sub_namespaces": {}
-        },
-        "Membership": {
-          "source_module": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/index.ts",
-          "member_count": 18,
-          "members": [
-            {
-              "name": "addMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/api/addMembers.ts",
-              "line": 25
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/unbanMembers.ts",
+              "line": 25,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<Cached<Membership<'channel'>[]>>"
+              }
             },
             {
-              "name": "removeMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/api/removeMembers.ts",
-              "line": 25
-            },
-            {
-              "name": "getMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/observers/getMembers.ts",
-              "line": 59
-            },
-            {
-              "name": "searchMembers",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/observers/searchMembers.ts",
-              "line": 27
-            },
-            {
-              "name": "onCommunityUserAdded",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserAdded.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserRemoved",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserRemoved.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserBanned",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserBanned.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserChanged",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserChanged.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserUnbanned",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserUnbanned.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserRoleAdded",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserRoleAdded.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityUserRoleRemoved",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityUserRoleRemoved.ts",
-              "line": 18
-            },
-            {
-              "name": "onLocalCommunityUserAdded",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onLocalCommunityUserAdded.ts",
-              "line": 18
-            },
-            {
-              "name": "onLocalCommunityUserRemoved",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onLocalCommunityUserRemoved.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityJoined",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityJoined.ts",
-              "line": 18
-            },
-            {
-              "name": "onCommunityLeft",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onCommunityLeft.ts",
-              "line": 18
-            },
-            {
-              "name": "onLocalCommunityJoined",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onLocalCommunityJoined.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalCommunityLeft",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onLocalCommunityLeft.ts",
-              "line": 3
-            },
-            {
-              "name": "onLocalCommunityJoin",
-              "kind": "const",
-              "file": "AmityTypescriptSDK/packages/sdk/src/communityRepository/communityMembership/events/onLocalCommunityJoin.ts",
-              "line": 4
+              "name": "unmuteMembers",
+              "kind": "function",
+              "file": "channelRepository/channelModeration/api/unmuteMembers.ts",
+              "line": 21,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "channelId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
             }
           ],
           "sub_namespaces": {}
         }
       }
     },
-    "CategoryRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/categoryRepository/index.ts",
-      "member_count": 2,
+    "Client": {
+      "source_module": "client/index.ts",
+      "member_count": 43,
       "members": [
         {
-          "name": "getCategory",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/categoryRepository/api/getCategory.ts",
-          "line": 24
+          "name": "TokenPayload",
+          "kind": "interface",
+          "file": "client/api/loginWithAccessToken.ts",
+          "line": 13
         },
         {
-          "name": "getCategories",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/categoryRepository/observers/getCategories.ts",
-          "line": 41
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "FeedRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/feedRepository/index.ts",
-      "member_count": 7,
-      "members": [
-        {
-          "name": "queryGlobalFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/api/queryGlobalFeed.ts",
-          "line": 30
+          "name": "autoSubscriptions",
+          "kind": "function",
+          "file": "client/api/autoSubscription.ts",
+          "line": 67,
+          "signature": {
+            "parameters": [],
+            "returns": "AutoSubscriptionState[]"
+          }
         },
         {
-          "name": "getCustomRankingGlobalFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/observers/getCustomRankingGlobalFeed.ts",
-          "line": 30
+          "name": "createClient",
+          "kind": "function",
+          "file": "client/api/createClient.ts",
+          "line": 44,
+          "signature": {
+            "parameters": [
+              {
+                "name": "apiKey",
+                "type": "string"
+              },
+              {
+                "name": "apiRegion",
+                "type": "'eu' | 'sg' | 'us'"
+              },
+              {
+                "name": "apiEndpoint",
+                "type": "{}"
+              }
+            ],
+            "returns": "Client"
+          }
         },
         {
-          "name": "getGlobalFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/observers/getGlobalFeed.ts",
-          "line": 30
+          "name": "disableAutoSubscriptions",
+          "kind": "function",
+          "file": "client/api/autoSubscription.ts",
+          "line": 45,
+          "signature": {
+            "parameters": [
+              {
+                "name": "features",
+                "type": "AmityAutoSubscription[]"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "getUserFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/observers/getUserFeed.ts",
-          "line": 30
+          "name": "enableAutoSubscriptions",
+          "kind": "function",
+          "file": "client/api/autoSubscription.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "features",
+                "type": "AmityAutoSubscription[]"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "getCommunityFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/observers/getCommunityFeed.ts",
-          "line": 41
+          "name": "enableUnreadCount",
+          "kind": "function",
+          "file": "client/api/enableUnreadCount.ts",
+          "line": 1,
+          "signature": {
+            "parameters": [],
+            "returns": "boolean"
+          }
         },
         {
-          "name": "getForYouFeed",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/observers/getForYouFeed.ts",
-          "line": 26
+          "name": "fetchLinkPreview",
+          "kind": "function",
+          "file": "client/api/fetchLinkPreview.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "url",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<LinkPreview>"
+          }
         },
         {
-          "name": "AmityForYouFeedDisabledError",
-          "kind": "class",
-          "file": "AmityTypescriptSDK/packages/sdk/src/feedRepository/errors/AmityForYouFeedDisabledError.ts",
-          "line": 10
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "PostRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/postRepository/index.ts",
-      "member_count": 34,
-      "members": [
-        {
-          "name": "getPostByIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/getPostByIds.ts",
-          "line": 27
+          "name": "getActiveUser",
+          "kind": "function",
+          "file": "client/api/activeUser.ts",
+          "line": 12,
+          "signature": {
+            "parameters": [],
+            "returns": "ActiveUser"
+          }
         },
         {
-          "name": "createPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/createPost.ts",
-          "line": 30
+          "name": "getChatSettings",
+          "kind": "function",
+          "file": "client/api/getChatSettings.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<ChatSettings>"
+          }
         },
         {
-          "name": "editPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/editPost.ts",
-          "line": 29
+          "name": "getCoreUserSettings",
+          "kind": "function",
+          "file": "client/api/getCoreUserSettings.ts",
+          "line": 17,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<CoreUserSettings>"
+          }
         },
         {
-          "name": "softDeletePost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/softDeletePost.ts",
-          "line": 23
+          "name": "getCurrentUser",
+          "kind": "function",
+          "file": "client/api/getCurrentUser.ts",
+          "line": 9,
+          "signature": {
+            "parameters": [],
+            "returns": "User | None"
+          }
         },
         {
-          "name": "hardDeletePost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/hardDeletePost.ts",
-          "line": 23
+          "name": "getCurrentUserType",
+          "kind": "function",
+          "file": "client/api/getCurrentUserType.ts",
+          "line": 8,
+          "signature": {
+            "parameters": [],
+            "returns": "'signed-in' | 'visitor' | 'bot'"
+          }
         },
         {
-          "name": "approvePost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/approvePost.ts",
-          "line": 26
+          "name": "getFeedSettings",
+          "kind": "function",
+          "file": "client/api/getFeedSettings.ts",
+          "line": 17,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<FeedSettings>"
+          }
         },
         {
-          "name": "declinePost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/declinePost.ts",
-          "line": 26
+          "name": "getForYouFeedSetting",
+          "kind": "function",
+          "file": "client/api/getForYouFeedSetting.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<ForYouFeedSetting>"
+          }
         },
         {
-          "name": "flagPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/flagPost.ts",
-          "line": 23
+          "name": "getLinkPreviewMetadata",
+          "kind": "function",
+          "file": "client/api/getLinkPreviewMetadata.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "url",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<LinkPreviewMetadata>"
+          }
         },
         {
-          "name": "unflagPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/unflagPost.ts",
-          "line": 23
+          "name": "getMarkerSyncConsistentMode",
+          "kind": "function",
+          "file": "client/utils/markerSyncEngine.ts",
+          "line": 217,
+          "signature": {
+            "parameters": [],
+            "returns": "boolean"
+          }
         },
         {
-          "name": "isPostFlaggedByMe",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/isPostFlaggedByMe.ts",
-          "line": 18
+          "name": "getProductCatalogueSetting",
+          "kind": "function",
+          "file": "client/api/getProductCatalogueSetting.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<ProductCatalogueSetting>"
+          }
         },
         {
-          "name": "createClipPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/createClipPost.ts",
-          "line": 32
+          "name": "getShareableLinkConfiguration",
+          "kind": "function",
+          "file": "client/api/getShareableLinkConfiguration.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<ShareableLinkConfiguration>"
+          }
         },
         {
-          "name": "createAudioPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/createAudioPost.ts",
-          "line": 30
+          "name": "getSocialSettings",
+          "kind": "function",
+          "file": "client/api/getSocialSettings.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<SocialSettings>"
+          }
         },
         {
-          "name": "createMixedMediaPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/createMixedMediaPost.ts",
-          "line": 35
+          "name": "getUserUnread",
+          "kind": "function",
+          "file": "client/observers/getUserUnread.ts",
+          "line": 32,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<UserUnread | undefined>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "createRoomPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/createRoomPost.ts",
-          "line": 29
+          "name": "isConnected",
+          "kind": "function",
+          "file": "client/api/isConnected.ts",
+          "line": 15,
+          "signature": {
+            "parameters": [],
+            "returns": "boolean"
+          }
         },
         {
-          "name": "pinProduct",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/pinProduct.ts",
-          "line": 23
+          "name": "login",
+          "kind": "function",
+          "file": "client/api/login.ts",
+          "line": 53,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ConnectClientParams"
+              },
+              {
+                "name": "sessionHandler",
+                "type": "SessionHandler"
+              },
+              {
+                "name": "config",
+                "type": "ConnectClientConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "unpinProduct",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/unpinProduct.ts",
-          "line": 22
+          "name": "loginAsBot",
+          "kind": "function",
+          "file": "client/api/loginAsBot.ts",
+          "line": 49,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "{}"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "updateProductTags",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/api/updateProductTags.ts",
-          "line": 23
+          "name": "loginAsVisitor",
+          "kind": "function",
+          "file": "client/api/loginAsVisitor.ts",
+          "line": 51,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ConnectClientAsVisitorParams & {}"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onPostCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostCreated.ts",
-          "line": 18
+          "name": "loginWithAccessToken",
+          "kind": "function",
+          "file": "client/api/loginWithAccessToken.ts",
+          "line": 49,
+          "signature": {
+            "parameters": [
+              {
+                "name": "accessToken",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onPostUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostUpdated.ts",
-          "line": 18
+          "name": "logout",
+          "kind": "function",
+          "file": "client/api/logout.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onPostDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostDeleted.ts",
-          "line": 18
+          "name": "notifications",
+          "kind": "function",
+          "file": "client/api/notifications.ts",
+          "line": 202,
+          "signature": {
+            "parameters": [],
+            "returns": "Notifications"
+          }
         },
         {
-          "name": "onPostApproved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostApproved.ts",
-          "line": 18
+          "name": "onClientBanned",
+          "kind": "function",
+          "file": "client/events/onClientBanned.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<UserPayload>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onPostDeclined",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostDeclined.ts",
-          "line": 18
+          "name": "onClientDisconnected",
+          "kind": "function",
+          "file": "client/events/onClientDisconnected.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<void>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onPostFlagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostFlagged.ts",
-          "line": 18
+          "name": "onConnectionError",
+          "kind": "function",
+          "file": "client/events/onConnectionError.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<ASCError>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onPostUnflagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostUnflagged.ts",
-          "line": 18
+          "name": "onNetworkActivities",
+          "kind": "function",
+          "file": "client/events/onNetworkActivities.ts",
+          "line": 12,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "{}"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onPostReactionAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostReactionAdded.ts",
-          "line": 22
+          "name": "onSessionStateChange",
+          "kind": "function",
+          "file": "client/events/onSessionStateChange.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<SessionStates, TokenTerminationReason>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onPostReactionRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/events/onPostReactionRemoved.ts",
-          "line": 22
+          "name": "onVisitorUsageLimitReached",
+          "kind": "function",
+          "file": "client/events/onVisitorUsageLimitReached.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<undefined>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "getPost",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getPost.ts",
-          "line": 45
+          "name": "renewal",
+          "kind": "function",
+          "file": "client/api/renewal.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [],
+            "returns": "AccessTokenRenewal"
+          }
         },
         {
-          "name": "getPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getPosts.ts",
-          "line": 31
+          "name": "resumeSession",
+          "kind": "function",
+          "file": "client/api/resumeSession.ts",
+          "line": 76,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "Params"
+              },
+              {
+                "name": "sessionHandler",
+                "type": "SessionHandler"
+              },
+              {
+                "name": "config",
+                "type": "ConnectClientConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "getPinnedPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getPinnedPosts.ts",
-          "line": 16
+          "name": "secureLogout",
+          "kind": "function",
+          "file": "client/api/secureLogout.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "getGlobalPinnedPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getGlobalPinnedPosts.ts",
-          "line": 14
+          "name": "setAccessTokenHandler",
+          "kind": "function",
+          "file": "client/api/setAccessTokenHandler.ts",
+          "line": 35,
+          "signature": {
+            "parameters": [
+              {
+                "name": "accessTokenHandler",
+                "type": "AccessTokenHandler"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "semanticSearchPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/semanticSearchPosts.ts",
-          "line": 14
+          "name": "setActiveUser",
+          "kind": "function",
+          "file": "client/api/activeUser.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "user",
+                "type": "Amity.ActiveUser"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "searchPostsByHashtag",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/searchPostsByHashtag.ts",
-          "line": 30
+          "name": "setCurrentUserType",
+          "kind": "function",
+          "file": "client/api/getCurrentUserType.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userType",
+                "type": "'signed-in' | 'visitor' | 'bot'"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "getLiveRoomPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getLiveRoomPosts.ts",
-          "line": 31
+          "name": "setUploadedFileAccessType",
+          "kind": "function",
+          "file": "client/api/setUploadedFileAccessType.ts",
+          "line": 3,
+          "signature": {
+            "parameters": [
+              {
+                "name": "accessType",
+                "type": "'public' | 'network'"
+              }
+            ],
+            "returns": "void"
+          }
         },
         {
-          "name": "getCommunityLiveRoomPosts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/postRepository/observers/getCommunityLiveRoomPosts.ts",
-          "line": 30
+          "name": "startMarkerSync",
+          "kind": "function",
+          "file": "client/utils/markerSyncEngine.ts",
+          "line": 180,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "startUnreadSync",
+          "kind": "function",
+          "file": "client/utils/markerSyncEngine.ts",
+          "line": 193,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "stopUnreadSync",
+          "kind": "function",
+          "file": "client/utils/markerSyncEngine.ts",
+          "line": 205
         }
       ],
       "sub_namespaces": {}
     },
     "CommentRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/commentRepository/index.ts",
+      "source_module": "commentRepository/index.ts",
       "member_count": 18,
       "members": [
         {
-          "name": "getCommentByIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/getCommentByIds.ts",
-          "line": 26
-        },
-        {
           "name": "createComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/createComment.ts",
-          "line": 106
-        },
-        {
-          "name": "updateComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/updateComment.ts",
-          "line": 27
+          "kind": "function",
+          "file": "commentRepository/api/createComment.ts",
+          "line": 106,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "CreateCommentBundle"
+              }
+            ],
+            "returns": "Promise<Cached<Comment<any>>>"
+          }
         },
         {
           "name": "deleteComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/deleteComment.ts",
-          "line": 32
-        },
-        {
-          "name": "softDeleteComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/softDeleteComment.ts",
-          "line": 22
-        },
-        {
-          "name": "hardDeleteComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/hardDeleteComment.ts",
-          "line": 22
+          "kind": "function",
+          "file": "commentRepository/api/deleteComment.ts",
+          "line": 32,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              },
+              {
+                "name": "permanent",
+                "type": "boolean"
+              }
+            ],
+            "returns": "Promise<Comment<any>>"
+          }
         },
         {
           "name": "flagComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/flagComment.ts",
-          "line": 23
-        },
-        {
-          "name": "unflagComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/unflagComment.ts",
-          "line": 22
-        },
-        {
-          "name": "isCommentFlaggedByMe",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/api/isCommentFlaggedByMe.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentCreated.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentUpdated.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentDeleted.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentFlagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentFlagged.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentUnflagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentUnflagged.ts",
-          "line": 18
-        },
-        {
-          "name": "onCommentReactionAdded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentReactionAdded.ts",
-          "line": 23
-        },
-        {
-          "name": "onCommentReactionRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/events/onCommentReactionRemoved.ts",
-          "line": 24
+          "kind": "function",
+          "file": "commentRepository/api/flagComment.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              },
+              {
+                "name": "reason",
+                "type": "ContentFlagReason",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
           "name": "getComment",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/observers/getComment.ts",
-          "line": 39
+          "kind": "function",
+          "file": "commentRepository/observers/getComment.ts",
+          "line": 39,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Comment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getCommentByIds",
+          "kind": "function",
+          "file": "commentRepository/api/getCommentByIds.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<Comment<any>[]>>"
+          }
         },
         {
           "name": "getComments",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/commentRepository/observers/getComments.ts",
-          "line": 29
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "StreamRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/streamRepository/index.ts",
-      "member_count": 14,
-      "members": [
-        {
-          "name": "createStream",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/api/createStream.ts",
-          "line": 23
-        },
-        {
-          "name": "updateStream",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/api/updateStream.ts",
-          "line": 28
-        },
-        {
-          "name": "deleteStream",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/api/deleteStream.ts",
-          "line": 26
-        },
-        {
-          "name": "disposeStream",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/api/disposeStream.ts",
-          "line": 20
-        },
-        {
-          "name": "editStream",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/api/editStream.ts",
-          "line": 26
-        },
-        {
-          "name": "onStreamStarted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamStarted.ts",
-          "line": 21
-        },
-        {
-          "name": "onStreamStopped",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamStopped.ts",
-          "line": 21
-        },
-        {
-          "name": "onStreamRecorded",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamRecorded.ts",
-          "line": 21
-        },
-        {
-          "name": "onStreamFlagged",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamFlagged.ts",
-          "line": 21
-        },
-        {
-          "name": "onStreamTerminated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamTerminated.ts",
-          "line": 21
-        },
-        {
-          "name": "onStreamViewerBanned",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamViewerBanned.ts",
-          "line": 20
-        },
-        {
-          "name": "onStreamViewerUnbanned",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/events/onStreamViewerUnbanned.ts",
-          "line": 21
-        },
-        {
-          "name": "getStreamById",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/observers/getStreamById.ts",
-          "line": 32
-        },
-        {
-          "name": "getStreams",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/streamRepository/observers/getStreams/getStreams.ts",
-          "line": 6
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "RoomRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/roomRepository/index.ts",
-      "member_count": 36,
-      "members": [
-        {
-          "name": "createRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/createRoom.ts",
-          "line": 25
-        },
-        {
-          "name": "updateRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/updateRoom.ts",
-          "line": 24
-        },
-        {
-          "name": "deleteRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/deleteRoom.ts",
-          "line": 21
-        },
-        {
-          "name": "stopRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/stopRoom.ts",
-          "line": 23
-        },
-        {
-          "name": "getBroadcasterData",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/getBroadcasterData.ts",
-          "line": 20
-        },
-        {
-          "name": "getRecordedUrl",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/getRecordedUrl.ts",
-          "line": 20
-        },
-        {
-          "name": "removeParticipant",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/removeParticipant.ts",
-          "line": 22
-        },
-        {
-          "name": "leaveRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/leaveRoom.ts",
-          "line": 21
-        },
-        {
-          "name": "AmityRoomAnalytics",
-          "kind": "class",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/analytics/AmityRoomAnalytics.ts",
-          "line": 53
-        },
-        {
-          "name": "WatchSessionStorage",
-          "kind": "class",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/analytics/WatchSessionStorage.ts",
-          "line": 5
-        },
-        {
-          "name": "getWatchSessionStorage",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/analytics/WatchSessionStorage.ts",
-          "line": 68
-        },
-        {
-          "name": "syncWatchSessions",
           "kind": "function",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/analytics/syncWatchSessions.ts",
-          "line": 9
+          "file": "commentRepository/observers/getComments.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CommentLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Comment<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "updateCohostPermission",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/api/updateCohostPermission.ts",
-          "line": 25
+          "name": "hardDeleteComment",
+          "kind": "function",
+          "file": "commentRepository/api/hardDeleteComment.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Comment<any>>"
+          }
         },
         {
-          "name": "onRoomStartBroadcasting",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomStartBroadcasting.ts",
-          "line": 21
+          "name": "isCommentFlaggedByMe",
+          "kind": "function",
+          "file": "commentRepository/api/isCommentFlaggedByMe.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onRoomWaitingReconnect",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomWaitingReconnect.ts",
-          "line": 21
+          "name": "onCommentCreated",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomEndBroadcasting",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomEndBroadcasting.ts",
-          "line": 21
+          "name": "onCommentDeleted",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomRecordedAvailable",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomRecordedAvailable.ts",
-          "line": 21
+          "name": "onCommentFlagged",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentFlagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomCoHostInvited",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomCoHostInvited.ts",
-          "line": 22
+          "name": "onCommentReactionAdded",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentReactionAdded.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomCoHostInviteAccepted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomCoHostInviteAccepted.ts",
-          "line": 23
+          "name": "onCommentReactionRemoved",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentReactionRemoved.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomCoHostInviteRejected",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomCoHostInviteRejected.ts",
-          "line": 22
+          "name": "onCommentUnflagged",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentUnflagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomCoHostInviteCanceled",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomCoHostInviteCanceled.ts",
-          "line": 22
+          "name": "onCommentUpdated",
+          "kind": "function",
+          "file": "commentRepository/events/onCommentUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalComment<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRoomParticipantJoined",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomParticipantJoined.ts",
-          "line": 22
+          "name": "softDeleteComment",
+          "kind": "function",
+          "file": "commentRepository/api/softDeleteComment.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Comment<any>>"
+          }
         },
         {
-          "name": "onRoomParticipantLeft",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomParticipantLeft.ts",
-          "line": 22
+          "name": "unflagComment",
+          "kind": "function",
+          "file": "commentRepository/api/unflagComment.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onRoomParticipantStageLeft",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomParticipantStageLeft.ts",
-          "line": 22
-        },
-        {
-          "name": "onRoomParticipantStageJoined",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomParticipantStageJoined.ts",
-          "line": 22
-        },
-        {
-          "name": "onRoomTerminated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomTerminated.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomDidUpdate",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomDidUpdate.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomCreated.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomUpdated.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomDeleted.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomStopped",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomStopped.ts",
-          "line": 21
-        },
-        {
-          "name": "onRoomParticipantRemoved",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomParticipantRemoved.ts",
-          "line": 22
-        },
-        {
-          "name": "onRoomLeft",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onRoomLeft.ts",
-          "line": 21
-        },
-        {
-          "name": "onLocalRoomDidUpdate",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/events/onLocalRoomDidUpdate.ts",
-          "line": 21
-        },
-        {
-          "name": "getRoom",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/observers/getRoom.ts",
-          "line": 22
-        },
-        {
-          "name": "getRooms",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomRepository/observers/getRooms.ts",
-          "line": 37
+          "name": "updateComment",
+          "kind": "function",
+          "file": "commentRepository/api/updateComment.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "commentId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Comment, 'data' | 'metadata' | 'mentionees' | 'links'>"
+              }
+            ],
+            "returns": "Promise<Cached<Comment<any>>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
-    "RoomPresenceRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/roomPresenceRepository/index.ts",
-      "member_count": 4,
+    "CommunityRepository": {
+      "source_module": "communityRepository/index.ts",
+      "member_count": 20,
       "members": [
         {
-          "name": "getRoomOnlineUsers",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomPresenceRepository/api/getRoomOnlineUsers.ts",
-          "line": 23
+          "name": "AmityCommunityMemberStatusFilter",
+          "kind": "enum",
+          "file": "communityRepository/constants/index.ts",
+          "line": 1
         },
         {
-          "name": "getRoomUserCount",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomPresenceRepository/api/getRoomUserCount.ts",
-          "line": 23
+          "name": "AmityCommunityMemberStatusFilter.ALL",
+          "kind": "enum_member",
+          "file": "communityRepository/constants/index.ts",
+          "line": 2
         },
         {
-          "name": "startHeartbeat",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomPresenceRepository/api/startHeartbeat.ts",
-          "line": 19
-        },
-        {
-          "name": "stopHeartbeat",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/roomPresenceRepository/api/stopHeartbeat.ts",
-          "line": 22
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "PollRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/pollRepository/index.ts",
-      "member_count": 8,
-      "members": [
-        {
-          "name": "createPoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/api/createPoll.ts",
-          "line": 30
-        },
-        {
-          "name": "closePoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/api/closePoll.ts",
-          "line": 24
-        },
-        {
-          "name": "deletePoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/api/deletePoll.ts",
-          "line": 25
-        },
-        {
-          "name": "votePoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/api/votePoll.ts",
-          "line": 25
-        },
-        {
-          "name": "unvotePoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/api/unvotePoll.ts",
-          "line": 23
-        },
-        {
-          "name": "onPollUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/events/onPollUpdated.ts",
-          "line": 21
-        },
-        {
-          "name": "onPollDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/events/onPollDeleted.ts",
-          "line": 21
-        },
-        {
-          "name": "getPoll",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/pollRepository/observers/getPoll.ts",
-          "line": 27
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "LiveStreamPlayer": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/liveStreamPlayer/index.ts",
-      "member_count": 1,
-      "members": [
-        {
-          "name": "getPlayer",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/liveStreamPlayer/api/getPlayer.ts",
-          "line": 16
-        }
-      ],
-      "sub_namespaces": {}
-    },
-    "StoryRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/storyRepository/index.ts",
-      "member_count": 10,
-      "members": [
-        {
-          "name": "createImageStory",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/api/createImageStory.ts",
-          "line": 26
-        },
-        {
-          "name": "createVideoStory",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/api/createVideoStory.ts",
-          "line": 26
-        },
-        {
-          "name": "hardDeleteStory",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/api/hardDeleteStory.ts",
+          "name": "AmityCommunityMemberStatusFilter.MEMBER",
+          "kind": "enum_member",
+          "file": "communityRepository/constants/index.ts",
           "line": 3
         },
         {
-          "name": "softDeleteStory",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/api/softDeleteStory.ts",
-          "line": 3
+          "name": "AmityCommunityMemberStatusFilter.NOT_MEMBER",
+          "kind": "enum_member",
+          "file": "communityRepository/constants/index.ts",
+          "line": 4
         },
         {
-          "name": "getActiveStoriesByTarget",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getActiveStoriesByTarget.ts",
-          "line": 51
+          "name": "createCommunity",
+          "kind": "function",
+          "file": "communityRepository/api/createCommunity.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Community, 'displayName' | 'avatarFileId' | 'isPublic' | 'metadata' | 'tags' | 'description' | 'isOfficial' | 'isDiscoverable' | 'requiresJoinApproval' | 'postSetting'> & CommunityStorySettings & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Community>>"
+          }
         },
         {
-          "name": "getStoryByStoryId",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getStoryByStoryId.ts",
-          "line": 21
+          "name": "deleteCommunity",
+          "kind": "function",
+          "file": "communityRepository/api/deleteCommunity.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Community>"
+          }
         },
         {
-          "name": "getTargetById",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getTargetById.ts",
-          "line": 5
+          "name": "getCommunities",
+          "kind": "function",
+          "file": "communityRepository/observers/getCommunities.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CommunityLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Community>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
         },
         {
-          "name": "getTargetsByTargetIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getTargetsByTargetIds.ts",
-          "line": 9
+          "name": "getCommunity",
+          "kind": "function",
+          "file": "communityRepository/observers/getCommunity.ts",
+          "line": 39,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Community>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "getStoriesByTargetIds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getStoriesByTargetIds/getStoriesByTargetIds.ts",
-          "line": 6
+          "name": "getCommunityByIds",
+          "kind": "function",
+          "file": "communityRepository/api/getCommunities.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityIds",
+                "type": "string[]"
+              },
+              {
+                "name": "includeDiscoverablePrivateCommunity",
+                "type": "boolean",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<Community[]>>"
+          }
         },
         {
-          "name": "getGlobalStoryTargets",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/storyRepository/observers/getGlobalStoryTargets/getGlobalStoryTargets.ts",
-          "line": 6
+          "name": "getJoinRequestList",
+          "kind": "function",
+          "file": "communityRepository/observers/getJoinRequestList.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "JoinRequestListLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<JoinRequest>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getRecommendedCommunities",
+          "kind": "function",
+          "file": "communityRepository/observers/getRecommendedCommunities.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "RecommendedCommunityLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Community>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getTrendingCommunities",
+          "kind": "function",
+          "file": "communityRepository/observers/getTrendingCommunities.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "TrendingCommunityLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Community>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "joinCommunity",
+          "kind": "function",
+          "file": "communityRepository/api/joinCommunity.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "leaveCommunity",
+          "kind": "function",
+          "file": "communityRepository/api/leaveCommunity.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "onCommunityCreated",
+          "kind": "function",
+          "file": "communityRepository/events/onCommunityCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalCommunity>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onCommunityDeleted",
+          "kind": "function",
+          "file": "communityRepository/events/onCommunityDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalCommunity>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onCommunityUpdated",
+          "kind": "function",
+          "file": "communityRepository/events/onCommunityUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalCommunity>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "searchCommunities",
+          "kind": "function",
+          "file": "communityRepository/observers/searchCommunities.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SearchCommunityLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Community>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "semanticSearchCommunities",
+          "kind": "function",
+          "file": "communityRepository/observers/semanticSearchCommunities.ts",
+          "line": 14,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "LiveCollectionParams<SemanticSearchCommunityLiveCollection>"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Community>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "updateCommunity",
+          "kind": "function",
+          "file": "communityRepository/api/updateCommunity.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "communityId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Partial<Pick<Community, 'displayName' | 'avatarFileId' | 'isPublic' | 'metadata' | 'tags' | 'description' | 'categoryIds' | 'isDiscoverable' | 'requiresJoinApproval' | 'postSetting'>> & CommunityStorySettings"
+              }
+            ],
+            "returns": "Promise<Cached<Community>>"
+          }
+        }
+      ],
+      "sub_namespaces": {
+        "Membership": {
+          "source_module": "communityRepository/communityMembership/index.ts",
+          "member_count": 19,
+          "members": [
+            {
+              "name": "addMembers",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/api/addMembers.ts",
+              "line": 25,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "applyFilter",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/observers/getMembers.ts",
+              "line": 11,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "data",
+                    "type": "T[]"
+                  },
+                  {
+                    "name": "params",
+                    "type": "CommunityMemberLiveCollection"
+                  }
+                ],
+                "returns": "T[]"
+              }
+            },
+            {
+              "name": "getMembers",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/observers/getMembers.ts",
+              "line": 59,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "CommunityMemberLiveCollection"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<Membership<'community'>>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "{}"
+              }
+            },
+            {
+              "name": "onCommunityJoined",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityJoined.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityLeft",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityLeft.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserAdded",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserAdded.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserBanned",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserBanned.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserChanged",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserChanged.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserRemoved",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserRemoved.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserRoleAdded",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserRoleAdded.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserRoleRemoved",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserRoleRemoved.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onCommunityUserUnbanned",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onCommunityUserUnbanned.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalCommunityJoin",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onLocalCommunityJoin.ts",
+              "line": 4,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "{}"
+              }
+            },
+            {
+              "name": "onLocalCommunityJoined",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onLocalCommunityJoined.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalCommunityLeft",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onLocalCommunityLeft.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalCommunityUserAdded",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onLocalCommunityUserAdded.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalCommunityUserRemoved",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/events/onLocalCommunityUserRemoved.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "{}"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "removeMembers",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/api/removeMembers.ts",
+              "line": 25,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "searchMembers",
+              "kind": "function",
+              "file": "communityRepository/communityMembership/observers/searchMembers.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "SearchCommunityMemberLiveCollection"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<Membership<'community'>>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "{}"
+              }
+            }
+          ],
+          "sub_namespaces": {}
+        },
+        "Moderation": {
+          "source_module": "communityRepository/communityModeration/index.ts",
+          "member_count": 4,
+          "members": [
+            {
+              "name": "addRoles",
+              "kind": "function",
+              "file": "communityRepository/communityModeration/api/addRoles.ts",
+              "line": 26,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "roleIds",
+                    "type": "string[]"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "banMembers",
+              "kind": "function",
+              "file": "communityRepository/communityModeration/api/banMembers.ts",
+              "line": 24,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<Cached<Membership<'community'>[]>>"
+              }
+            },
+            {
+              "name": "removeRoles",
+              "kind": "function",
+              "file": "communityRepository/communityModeration/api/removeRoles.ts",
+              "line": 26,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "roleIds",
+                    "type": "string[]"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "unbanMembers",
+              "kind": "function",
+              "file": "communityRepository/communityModeration/api/unbanMembers.ts",
+              "line": 24,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "communityId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "userIds",
+                    "type": "string[]"
+                  }
+                ],
+                "returns": "Promise<Cached<Membership<'community'>[]>>"
+              }
+            }
+          ],
+          "sub_namespaces": {}
+        }
+      }
+    },
+    "EventRepository": {
+      "source_module": "eventRepository/index.ts",
+      "member_count": 17,
+      "members": [
+        {
+          "name": "createEvent",
+          "kind": "function",
+          "file": "eventRepository/api/createEvent.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Amity.EventCreateOptions"
+              }
+            ],
+            "returns": "Promise<Cached<Event>>"
+          }
+        },
+        {
+          "name": "deleteEvent",
+          "kind": "function",
+          "file": "eventRepository/api/deleteEvent.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "eventId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "getEvent",
+          "kind": "function",
+          "file": "eventRepository/observers/getEvent.ts",
+          "line": 33,
+          "signature": {
+            "parameters": [
+              {
+                "name": "eventId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Event>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getEvents",
+          "kind": "function",
+          "file": "eventRepository/observers/getEvents.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "EventLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Event>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getMyEvents",
+          "kind": "function",
+          "file": "eventRepository/observers/getMyEvents.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "MyEventLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Event>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getRSVPs",
+          "kind": "function",
+          "file": "eventRepository/observers/getRSVPs.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "RSVPLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<EventResponse>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onEventCreated",
+          "kind": "function",
+          "file": "eventRepository/events/onEventCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onEventDeleted",
+          "kind": "function",
+          "file": "eventRepository/events/onEventDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onEventUpdated",
+          "kind": "function",
+          "file": "eventRepository/events/onEventUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalEventCreated",
+          "kind": "function",
+          "file": "eventRepository/events/onLocalEventCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalEventDeleted",
+          "kind": "function",
+          "file": "eventRepository/events/onLocalEventDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalEventUpdated",
+          "kind": "function",
+          "file": "eventRepository/events/onLocalEventUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalRSVPCreated",
+          "kind": "function",
+          "file": "eventRepository/events/onLocalRSVPCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEventResponse>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalRSVPUpdated",
+          "kind": "function",
+          "file": "eventRepository/events/onLocalRSVPUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEventResponse>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRSVPCreated",
+          "kind": "function",
+          "file": "eventRepository/events/onRSVPCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEventResponse>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRSVPUpdated",
+          "kind": "function",
+          "file": "eventRepository/events/onRSVPUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawEventResponse>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "updateEvent",
+          "kind": "function",
+          "file": "eventRepository/api/updateEvent.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "eventId",
+                "type": "string"
+              },
+              {
+                "name": "bundle",
+                "type": "Amity.EventUpdateOptions"
+              }
+            ],
+            "returns": "Promise<Cached<Event>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
-    "AdRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/adRepository/index.ts",
-      "member_count": 1,
+    "FeedRepository": {
+      "source_module": "feedRepository/index.ts",
+      "member_count": 7,
       "members": [
         {
-          "name": "getNetworkAds",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/adRepository/api/getNetworkAds.ts",
-          "line": 19
+          "name": "AmityForYouFeedDisabledError",
+          "kind": "class",
+          "file": "feedRepository/errors/AmityForYouFeedDisabledError.ts",
+          "line": 10
+        },
+        {
+          "name": "getCommunityFeed",
+          "kind": "function",
+          "file": "feedRepository/observers/getCommunityFeed.ts",
+          "line": 41,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CommunityFeedLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getCustomRankingGlobalFeed",
+          "kind": "function",
+          "file": "feedRepository/observers/getCustomRankingGlobalFeed.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CustomRankingGlobalFeedLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getForYouFeed",
+          "kind": "function",
+          "file": "feedRepository/observers/getForYouFeed.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getGlobalFeed",
+          "kind": "function",
+          "file": "feedRepository/observers/getGlobalFeed.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "GlobalFeedLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getUserFeed",
+          "kind": "function",
+          "file": "feedRepository/observers/getUserFeed.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "UserFeedLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "queryGlobalFeed",
+          "kind": "function",
+          "file": "feedRepository/api/queryGlobalFeed.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "query",
+                "type": "QueryGlobalFeed",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Omit<Cached<{} & Pages<Page<number>> & Pagination>, 'nextPage' | 'prevPage'>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
-    "notificationTray": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/notificationTray/index.ts",
-      "member_count": 5,
+    "FileRepository": {
+      "source_module": "fileRepository/index.ts",
+      "member_count": 9,
       "members": [
         {
-          "name": "getNotificationTraySeen",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/notificationTray/observers/getNotificationTraySeen.ts",
-          "line": 28
+          "name": "deleteFile",
+          "kind": "function",
+          "file": "fileRepository/api/deleteFile.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "fileId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<{}>"
+          }
         },
         {
-          "name": "getNotificationTrayItems",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/notificationTray/observers/getNotificationTrayItems.ts",
-          "line": 16
+          "name": "fileUrlWithSize",
+          "kind": "function",
+          "file": "fileRepository/api/fileUrlWithSize.ts",
+          "line": 8,
+          "signature": {
+            "parameters": [
+              {
+                "name": "fileUrl",
+                "type": "string"
+              },
+              {
+                "name": "size",
+                "type": "'medium' | 'small' | 'large' | 'full'"
+              }
+            ],
+            "returns": "string"
+          }
         },
         {
-          "name": "markItemsSeen",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/notificationTray/api/markItemsSeen.ts",
-          "line": 22
+          "name": "getFile",
+          "kind": "function",
+          "file": "fileRepository/api/getFile.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "fileId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<File<any>>>"
+          }
         },
         {
-          "name": "markTraySeen",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/notificationTray/api/markTraySeen.ts",
-          "line": 25
+          "name": "updateAltText",
+          "kind": "function",
+          "file": "fileRepository/api/updateAltText.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "fileId",
+                "type": "string"
+              },
+              {
+                "name": "altText",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onNotificationTraySeenUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/notificationTray/events/onNotificationTraySeenUpdated.ts",
-          "line": 19
+          "name": "uploadAudio",
+          "kind": "function",
+          "file": "fileRepository/api/uploadAudio.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "onProgress",
+                "type": "{}",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<File<'audio'>[]>>"
+          }
+        },
+        {
+          "name": "uploadClip",
+          "kind": "function",
+          "file": "fileRepository/api/uploadClip.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "feedType",
+                "type": "ContentFeedType",
+                "optional": true
+              },
+              {
+                "name": "onProgress",
+                "type": "{}",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<File<'clip'>[]>>"
+          }
+        },
+        {
+          "name": "uploadFile",
+          "kind": "function",
+          "file": "fileRepository/api/uploadFile.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "onProgress",
+                "type": "{}",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<File<any>[]>>"
+          }
+        },
+        {
+          "name": "uploadImage",
+          "kind": "function",
+          "file": "fileRepository/api/uploadImage.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "onProgress",
+                "type": "{}",
+                "optional": true
+              },
+              {
+                "name": "altText",
+                "type": "string",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<File<'image'>[]>>"
+          }
+        },
+        {
+          "name": "uploadVideo",
+          "kind": "function",
+          "file": "fileRepository/api/uploadVideo.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "feedType",
+                "type": "ContentFeedType",
+                "optional": true
+              },
+              {
+                "name": "onProgress",
+                "type": "{}",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<Cached<File<'video'>[]>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
     "InvitationRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/index.ts",
+      "source_module": "invitationRepository/index.ts",
       "member_count": 6,
       "members": [
         {
           "name": "cancelInvitation",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/api/cancelInvitation.ts",
-          "line": 24
-        },
-        {
-          "name": "onLocalInvitationCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/events/onLocalInvitationCreated.ts",
-          "line": 19
-        },
-        {
-          "name": "onLocalInvitationUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/events/onLocalInvitationUpdated.ts",
-          "line": 19
-        },
-        {
-          "name": "onLocalInvitationCanceled",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/events/onLocalInvitationCanceled.ts",
-          "line": 19
-        },
-        {
-          "name": "getMyCommunityInvitations",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/observers/getMyCommunityInvitations.ts",
-          "line": 17
+          "kind": "function",
+          "file": "invitationRepository/api/cancelInvitation.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "invitationId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
           "name": "getInvitations",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/invitationRepository/observers/getInvitations.ts",
-          "line": 44
+          "kind": "function",
+          "file": "invitationRepository/observers/getInvitations.ts",
+          "line": 44,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "Pick<QueryInvitations, 'targetType' | 'targetId'> & {}"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<Invitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getMyCommunityInvitations",
+          "kind": "function",
+          "file": "invitationRepository/observers/getMyCommunityInvitations.ts",
+          "line": 17,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "MyInvitationsLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Invitation>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onLocalInvitationCanceled",
+          "kind": "function",
+          "file": "invitationRepository/events/onLocalInvitationCanceled.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalInvitationCreated",
+          "kind": "function",
+          "file": "invitationRepository/events/onLocalInvitationCreated.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLocalInvitationUpdated",
+          "kind": "function",
+          "file": "invitationRepository/events/onLocalInvitationUpdated.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         }
       ],
       "sub_namespaces": {}
     },
     "LiveReactionRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/liveReactionRepository/index.ts",
+      "source_module": "liveReactionRepository/index.ts",
       "member_count": 3,
       "members": [
         {
           "name": "createReaction",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/liveReactionRepository/api/createReaction.ts",
-          "line": 32
-        },
-        {
-          "name": "onLiveReactionCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/liveReactionRepository/events/onLiveReactionCreated.ts",
-          "line": 18
+          "kind": "function",
+          "file": "liveReactionRepository/api/createReaction.ts",
+          "line": 32,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceId",
+                "type": "Pick<CreateLiveReactionRequest, 'referenceType' | 'reactionName'> & {}"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
           "name": "getReactions",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/liveReactionRepository/observers/getReactions.ts",
-          "line": 24
+          "kind": "function",
+          "file": "liveReactionRepository/observers/getReactions.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<RawLiveReaction[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onLiveReactionCreated",
+          "kind": "function",
+          "file": "liveReactionRepository/events/onLiveReactionCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawLiveReaction[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         }
       ],
       "sub_namespaces": {}
     },
-    "EventRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/eventRepository/index.ts",
-      "member_count": 17,
+    "LiveStreamPlayer": {
+      "source_module": "liveStreamPlayer/index.ts",
+      "member_count": 1,
       "members": [
         {
-          "name": "createEvent",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/api/createEvent.ts",
-          "line": 24
+          "name": "getPlayer",
+          "kind": "function",
+          "file": "liveStreamPlayer/api/getPlayer.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "parameters",
+                "type": "{}"
+              }
+            ],
+            "returns": "Promise<HTMLVideoElement>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "MessageRepository": {
+      "source_module": "messageRepository/index.ts",
+      "member_count": 28,
+      "members": [
+        {
+          "name": "convertFromRaw",
+          "kind": "function",
+          "file": "messageRepository/utils/prepareMessagePayload.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "message",
+                "type": "RawMessage"
+              },
+              {
+                "name": "reactors",
+                "type": "InternalReactor[]",
+                "optional": true
+              },
+              {
+                "name": "event",
+                "type": "keyof MqttMessageEvents",
+                "optional": true
+              }
+            ],
+            "returns": "InternalMessage"
+          }
         },
         {
-          "name": "updateEvent",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/api/updateEvent.ts",
-          "line": 25
+          "name": "convertParams",
+          "kind": "function",
+          "file": "messageRepository/utils/prepareMessagePayload.ts",
+          "line": 187,
+          "signature": {
+            "parameters": [
+              {
+                "name": "__namedParameters",
+                "type": "Partial<Amity.Message>"
+              }
+            ],
+            "returns": "Record<string, any>"
+          }
         },
         {
-          "name": "deleteEvent",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/api/deleteEvent.ts",
-          "line": 22
+          "name": "convertQueryParams",
+          "kind": "function",
+          "file": "messageRepository/utils/prepareMessagePayload.ts",
+          "line": 209,
+          "signature": {
+            "parameters": [
+              {
+                "name": "__namedParameters",
+                "type": "MessagesLiveCollection"
+              }
+            ],
+            "returns": "RawQueryMessages"
+          }
         },
         {
-          "name": "onEventCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onEventCreated.ts",
-          "line": 18
+          "name": "createMessage",
+          "kind": "function",
+          "file": "messageRepository/api/createMessage.ts",
+          "line": 118,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "createMessageParam<T>"
+              }
+            ],
+            "returns": "Promise<Cached<Message<any>>>"
+          }
         },
         {
-          "name": "onEventUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onEventUpdated.ts",
-          "line": 18
+          "name": "deleteMessage",
+          "kind": "function",
+          "file": "messageRepository/api/deleteMessage.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Message<any>>"
+          }
         },
         {
-          "name": "onEventDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onEventDeleted.ts",
-          "line": 18
+          "name": "editMessage",
+          "kind": "function",
+          "file": "messageRepository/api/editMessage.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Message, 'data' | 'tags' | 'metadata' | 'mentionees'>"
+              }
+            ],
+            "returns": "Promise<Cached<Message<any>>>"
+          }
         },
         {
-          "name": "onLocalEventCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onLocalEventCreated.ts",
-          "line": 18
+          "name": "flagMessage",
+          "kind": "function",
+          "file": "messageRepository/api/flagMessage.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              },
+              {
+                "name": "reason",
+                "type": "ContentFlagReason",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onLocalEventUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onLocalEventUpdated.ts",
-          "line": 18
+          "name": "getDeliveredUsers",
+          "kind": "function",
+          "file": "messageRepository/api/getDeliveredUsers.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "query",
+                "type": "QueryDeliveredUsers"
+              }
+            ],
+            "returns": "Promise<Cached<Paged<InternalUser, Page<number>>>>"
+          }
         },
         {
-          "name": "onLocalEventDeleted",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onLocalEventDeleted.ts",
-          "line": 18
+          "name": "getMessage",
+          "kind": "function",
+          "file": "messageRepository/observers/getMessage.ts",
+          "line": 40,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Message<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRSVPCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onRSVPCreated.ts",
-          "line": 18
+          "name": "getMessages",
+          "kind": "function",
+          "file": "messageRepository/observers/getMessages/getMessages.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "MessagesLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Message<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "onRSVPUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onRSVPUpdated.ts",
-          "line": 18
+          "name": "getReadUsers",
+          "kind": "function",
+          "file": "messageRepository/api/getReadUsers.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "query",
+                "type": "QueryReadUsers"
+              }
+            ],
+            "returns": "Promise<Cached<Paged<InternalUser, Page<number>>>>"
+          }
         },
         {
-          "name": "onLocalRSVPCreated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onLocalRSVPCreated.ts",
-          "line": 18
+          "name": "isMessageFlaggedByMe",
+          "kind": "function",
+          "file": "messageRepository/api/isMessageFlaggedByMe.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "onLocalRSVPUpdated",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/events/onLocalRSVPUpdated.ts",
-          "line": 18
+          "name": "markAsDelivered",
+          "kind": "function",
+          "file": "messageRepository/api/markAsDelivered.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              },
+              {
+                "name": "messageId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
         },
         {
-          "name": "getEvent",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/observers/getEvent.ts",
-          "line": 33
+          "name": "onMessageCreatedLocal",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageCreated.ts",
+          "line": 102,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "getEvents",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/observers/getEvents.ts",
-          "line": 16
+          "name": "onMessageCreatedMqtt",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageCreated.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "getMyEvents",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/observers/getMyEvents.ts",
-          "line": 16
+          "name": "onMessageDeleted",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageDeleted.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
-          "name": "getRSVPs",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/eventRepository/observers/getRSVPs.ts",
-          "line": 16
+          "name": "onMessageFetched",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageFetched.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageFlagCleared",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageFlagCleared.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageFlagged",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageFlagged.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageReactionAdded",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageReactionAdded.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageReactionRemoved",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageReactionRemoved.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageUnflagged",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageUnflagged.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onMessageUpdated",
+          "kind": "function",
+          "file": "messageRepository/events/onMessageUpdated.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "prepareMessagePayload",
+          "kind": "function",
+          "file": "messageRepository/utils/prepareMessagePayload.ts",
+          "line": 113,
+          "signature": {
+            "parameters": [
+              {
+                "name": "payload",
+                "type": "MessagePayload"
+              },
+              {
+                "name": "event",
+                "type": "keyof MqttMessageEvents",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<ProcessedMessagePayload<any>>"
+          }
+        },
+        {
+          "name": "searchMessage",
+          "kind": "function",
+          "file": "messageRepository/observers/searchMessage/searchMessage.ts",
+          "line": 31,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SearchMessageLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Message<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "softDeleteMessage",
+          "kind": "function",
+          "file": "messageRepository/api/softDeleteMessage.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Message<any>>"
+          }
+        },
+        {
+          "name": "unflagMessage",
+          "kind": "function",
+          "file": "messageRepository/api/unflagMessage.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "updateMessage",
+          "kind": "function",
+          "file": "messageRepository/api/updateMessage.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "messageId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Message, 'data' | 'tags' | 'metadata' | 'mentionees'>"
+              }
+            ],
+            "returns": "Promise<Cached<Message<any>>>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "notificationTray": {
+      "source_module": "notificationTray/index.ts",
+      "member_count": 5,
+      "members": [
+        {
+          "name": "getNotificationTrayItems",
+          "kind": "function",
+          "file": "notificationTray/observers/getNotificationTrayItems.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "any"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<NotificationTrayItem>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getNotificationTraySeen",
+          "kind": "function",
+          "file": "notificationTray/observers/getNotificationTraySeen.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<NotificationTraySeen>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "markItemsSeen",
+          "kind": "function",
+          "file": "notificationTray/api/markItemsSeen.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "trayItems",
+                "type": "QueryNotificationItemSeen[]"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "markTraySeen",
+          "kind": "function",
+          "file": "notificationTray/api/markTraySeen.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "lastSeenAt",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<NotificationTraySeenUpdatedPayload>>"
+          }
+        },
+        {
+          "name": "onNotificationTraySeenUpdated",
+          "kind": "function",
+          "file": "notificationTray/events/onNotificationTraySeenUpdated.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalNotificationTraySeen>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "PollRepository": {
+      "source_module": "pollRepository/index.ts",
+      "member_count": 8,
+      "members": [
+        {
+          "name": "closePoll",
+          "kind": "function",
+          "file": "pollRepository/api/closePoll.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "pollId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Poll>>"
+          }
+        },
+        {
+          "name": "createPoll",
+          "kind": "function",
+          "file": "pollRepository/api/createPoll.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Poll, 'title' | 'question' | 'answerType' | 'closedIn'> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Poll>>"
+          }
+        },
+        {
+          "name": "deletePoll",
+          "kind": "function",
+          "file": "pollRepository/api/deletePoll.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "pollId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "getPoll",
+          "kind": "function",
+          "file": "pollRepository/observers/getPoll.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "pollId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Poll>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPollDeleted",
+          "kind": "function",
+          "file": "pollRepository/events/onPollDeleted.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Poll>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPollUpdated",
+          "kind": "function",
+          "file": "pollRepository/events/onPollUpdated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Poll>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "unvotePoll",
+          "kind": "function",
+          "file": "pollRepository/api/unvotePoll.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "pollId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "votePoll",
+          "kind": "function",
+          "file": "pollRepository/api/votePoll.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "pollId",
+                "type": "string"
+              },
+              {
+                "name": "answerIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<Poll>>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "PostRepository": {
+      "source_module": "postRepository/index.ts",
+      "member_count": 34,
+      "members": [
+        {
+          "name": "approvePost",
+          "kind": "function",
+          "file": "postRepository/api/approvePost.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "createAudioPost",
+          "kind": "function",
+          "file": "postRepository/api/createAudioPost.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Post<any>, 'targetType' | 'targetId'> & Partial<Pick<Post<any>, 'metadata' | 'tags' | 'hashtags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "createClipPost",
+          "kind": "function",
+          "file": "postRepository/api/createClipPost.ts",
+          "line": 32,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Post<T>, 'targetType' | 'targetId'> & Partial<Pick<Post<T>, 'metadata' | 'tags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "createMixedMediaPost",
+          "kind": "function",
+          "file": "postRepository/api/createMixedMediaPost.ts",
+          "line": 35,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Post<any>, 'targetType' | 'targetId'> & Partial<Pick<Post<any>, 'metadata' | 'tags' | 'hashtags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "createPost",
+          "kind": "function",
+          "file": "postRepository/api/createPost.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Post<T>, 'targetType' | 'targetId'> & Partial<Pick<Post<T>, 'metadata' | 'tags' | 'hashtags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "createRoomPost",
+          "kind": "function",
+          "file": "postRepository/api/createRoomPost.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Post<T>, 'targetType' | 'targetId'> & Partial<Pick<Post<T>, 'metadata' | 'tags' | 'hashtags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "declinePost",
+          "kind": "function",
+          "file": "postRepository/api/declinePost.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "editPost",
+          "kind": "function",
+          "file": "postRepository/api/editPost.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Partial<Pick<Post<any>, 'metadata' | 'tags' | 'data' | 'hashtags' | 'mentionees'>> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "flagPost",
+          "kind": "function",
+          "file": "postRepository/api/flagPost.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "reason",
+                "type": "ContentFlagReason",
+                "optional": true
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "getCommunityLiveRoomPosts",
+          "kind": "function",
+          "file": "postRepository/observers/getCommunityLiveRoomPosts.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "CommunityLiveRoomPostLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getGlobalPinnedPosts",
+          "kind": "function",
+          "file": "postRepository/observers/getGlobalPinnedPosts.ts",
+          "line": 14,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "LiveCollectionParams<GlobalPinnedPostLiveCollection>"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<PinnedPost>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getLiveRoomPosts",
+          "kind": "function",
+          "file": "postRepository/observers/getLiveRoomPosts.ts",
+          "line": 31,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getPinnedPosts",
+          "kind": "function",
+          "file": "postRepository/observers/getPinnedPosts.ts",
+          "line": 16,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "LiveCollectionParams<PinnedPostLiveCollection>"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<PinnedPost>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getPost",
+          "kind": "function",
+          "file": "postRepository/observers/getPost.ts",
+          "line": 45,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Post<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getPostByIds",
+          "kind": "function",
+          "file": "postRepository/api/getPostByIds.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>[]>>"
+          }
+        },
+        {
+          "name": "getPosts",
+          "kind": "function",
+          "file": "postRepository/observers/getPosts.ts",
+          "line": 31,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "PostLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "hardDeletePost",
+          "kind": "function",
+          "file": "postRepository/api/hardDeletePost.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Post<any>>"
+          }
+        },
+        {
+          "name": "isPostFlaggedByMe",
+          "kind": "function",
+          "file": "postRepository/api/isPostFlaggedByMe.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "onPostApproved",
+          "kind": "function",
+          "file": "postRepository/events/onPostApproved.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostCreated",
+          "kind": "function",
+          "file": "postRepository/events/onPostCreated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostDeclined",
+          "kind": "function",
+          "file": "postRepository/events/onPostDeclined.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostDeleted",
+          "kind": "function",
+          "file": "postRepository/events/onPostDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostFlagged",
+          "kind": "function",
+          "file": "postRepository/events/onPostFlagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostReactionAdded",
+          "kind": "function",
+          "file": "postRepository/events/onPostReactionAdded.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostReactionRemoved",
+          "kind": "function",
+          "file": "postRepository/events/onPostReactionRemoved.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostUnflagged",
+          "kind": "function",
+          "file": "postRepository/events/onPostUnflagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onPostUpdated",
+          "kind": "function",
+          "file": "postRepository/events/onPostUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "pinProduct",
+          "kind": "function",
+          "file": "postRepository/api/pinProduct.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "pinnedProductId",
+                "type": "string | undefined"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "searchPostsByHashtag",
+          "kind": "function",
+          "file": "postRepository/observers/searchPostsByHashtag.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SearchPostWithHashtagLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "semanticSearchPosts",
+          "kind": "function",
+          "file": "postRepository/observers/semanticSearchPosts.ts",
+          "line": 14,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "LiveCollectionParams<SemanticSearchPostLiveCollection>"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Post<any>>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "softDeletePost",
+          "kind": "function",
+          "file": "postRepository/api/softDeletePost.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Post<any>>"
+          }
+        },
+        {
+          "name": "unflagPost",
+          "kind": "function",
+          "file": "postRepository/api/unflagPost.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "unpinProduct",
+          "kind": "function",
+          "file": "postRepository/api/unpinProduct.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
+        },
+        {
+          "name": "updateProductTags",
+          "kind": "function",
+          "file": "postRepository/api/updateProductTags.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "postId",
+                "type": "string"
+              },
+              {
+                "name": "productTags",
+                "type": "ProductTag[]"
+              }
+            ],
+            "returns": "Promise<Cached<Post<any>>>"
+          }
         }
       ],
       "sub_namespaces": {}
     },
     "ProductRepository": {
-      "source_module": "AmityTypescriptSDK/packages/sdk/src/productRepository/index.ts",
+      "source_module": "productRepository/index.ts",
       "member_count": 2,
       "members": [
         {
           "name": "getProduct",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/productRepository/observers/getProduct.ts",
-          "line": 27
+          "kind": "function",
+          "file": "productRepository/observers/getProduct.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "productId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Product>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         },
         {
           "name": "searchProducts",
-          "kind": "const",
-          "file": "AmityTypescriptSDK/packages/sdk/src/productRepository/observers/searchProducts.ts",
-          "line": 33
+          "kind": "function",
+          "file": "productRepository/observers/searchProducts.ts",
+          "line": 33,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ProductLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Product>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
         }
       ],
       "sub_namespaces": {}
     },
+    "ReactionRepository": {
+      "source_module": "reactionRepository/index.ts",
+      "member_count": 7,
+      "members": [
+        {
+          "name": "addReaction",
+          "kind": "function",
+          "file": "reactionRepository/api/addReaction.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "reactionName",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "getReactions",
+          "kind": "function",
+          "file": "reactionRepository/observers/getReactions/getReactions.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ReactionLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Reactor>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onReactionAdded",
+          "kind": "function",
+          "file": "reactionRepository/events/onReactionAdded.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any> | InternalComment<any> | InternalStory | InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onReactionRemoved",
+          "kind": "function",
+          "file": "reactionRepository/events/onReactionRemoved.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<InternalPost<any> | InternalComment<any> | InternalStory | InternalMessage<any>>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onReactorAdded",
+          "kind": "function",
+          "file": "reactionRepository/events/onReactorAdded.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<InternalReactor>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onReactorRemoved",
+          "kind": "function",
+          "file": "reactionRepository/events/onReactorRemoved.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "Listener<InternalReactor>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "removeReaction",
+          "kind": "function",
+          "file": "reactionRepository/api/removeReaction.ts",
+          "line": 30,
+          "signature": {
+            "parameters": [
+              {
+                "name": "referenceType",
+                "type": "ReactableType"
+              },
+              {
+                "name": "referenceId",
+                "type": "string"
+              },
+              {
+                "name": "reactionName",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "RoomPresenceRepository": {
+      "source_module": "roomPresenceRepository/index.ts",
+      "member_count": 4,
+      "members": [
+        {
+          "name": "getRoomOnlineUsers",
+          "kind": "function",
+          "file": "roomPresenceRepository/api/getRoomOnlineUsers.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<User[]>>"
+          }
+        },
+        {
+          "name": "getRoomUserCount",
+          "kind": "function",
+          "file": "roomPresenceRepository/api/getRoomUserCount.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<RoomWatchingCount>"
+          }
+        },
+        {
+          "name": "startHeartbeat",
+          "kind": "function",
+          "file": "roomPresenceRepository/api/startHeartbeat.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "void"
+          }
+        },
+        {
+          "name": "stopHeartbeat",
+          "kind": "function",
+          "file": "roomPresenceRepository/api/stopHeartbeat.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "void"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "RoomRepository": {
+      "source_module": "roomRepository/index.ts",
+      "member_count": 36,
+      "members": [
+        {
+          "name": "AmityRoomAnalytics",
+          "kind": "class",
+          "file": "roomRepository/api/analytics/AmityRoomAnalytics.ts",
+          "line": 53
+        },
+        {
+          "name": "WatchSessionStorage",
+          "kind": "class",
+          "file": "roomRepository/api/analytics/WatchSessionStorage.ts",
+          "line": 5
+        },
+        {
+          "name": "createRoom",
+          "kind": "function",
+          "file": "roomRepository/api/createRoom.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "{}"
+              }
+            ],
+            "returns": "Promise<Cached<Room>>"
+          }
+        },
+        {
+          "name": "deleteRoom",
+          "kind": "function",
+          "file": "roomRepository/api/deleteRoom.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "getBroadcasterData",
+          "kind": "function",
+          "file": "roomRepository/api/getBroadcasterData.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<BroadcasterData>"
+          }
+        },
+        {
+          "name": "getRecordedUrl",
+          "kind": "function",
+          "file": "roomRepository/api/getRecordedUrl.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<{}>"
+          }
+        },
+        {
+          "name": "getRoom",
+          "kind": "function",
+          "file": "roomRepository/observers/getRoom.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Room>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getRooms",
+          "kind": "function",
+          "file": "roomRepository/observers/getRooms.ts",
+          "line": 37,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "RoomLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Room>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getWatchSessionStorage",
+          "kind": "function",
+          "file": "roomRepository/api/analytics/WatchSessionStorage.ts",
+          "line": 68,
+          "signature": {
+            "parameters": [],
+            "returns": "WatchSessionStorage"
+          }
+        },
+        {
+          "name": "leaveRoom",
+          "kind": "function",
+          "file": "roomRepository/api/leaveRoom.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "onLocalRoomDidUpdate",
+          "kind": "function",
+          "file": "roomRepository/events/onLocalRoomDidUpdate.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomCoHostInviteAccepted",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomCoHostInviteAccepted.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomCoHostInviteCanceled",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomCoHostInviteCanceled.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomCoHostInvited",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomCoHostInvited.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomCoHostInviteRejected",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomCoHostInviteRejected.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalInvitation[]>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomCreated",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomCreated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Room>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomDeleted",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomDeleted.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Room>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomDidUpdate",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomDidUpdate.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomEndBroadcasting",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomEndBroadcasting.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomLeft",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomLeft.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomParticipantJoined",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomParticipantJoined.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<CoHostEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomParticipantLeft",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomParticipantLeft.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<CoHostEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomParticipantRemoved",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomParticipantRemoved.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<CoHostEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomParticipantStageJoined",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomParticipantStageJoined.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<CoHostEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomParticipantStageLeft",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomParticipantStageLeft.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<CoHostEvent>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomRecordedAvailable",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomRecordedAvailable.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomStartBroadcasting",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomStartBroadcasting.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomStopped",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomStopped.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Room>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomTerminated",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomTerminated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomUpdated",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomUpdated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<Room>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onRoomWaitingReconnect",
+          "kind": "function",
+          "file": "roomRepository/events/onRoomWaitingReconnect.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawRoom>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "removeParticipant",
+          "kind": "function",
+          "file": "roomRepository/api/removeParticipant.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              },
+              {
+                "name": "participantUserId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<void>"
+          }
+        },
+        {
+          "name": "stopRoom",
+          "kind": "function",
+          "file": "roomRepository/api/stopRoom.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<Room>>"
+          }
+        },
+        {
+          "name": "syncWatchSessions",
+          "kind": "function",
+          "file": "roomRepository/api/analytics/syncWatchSessions.ts",
+          "line": 9,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "updateCohostPermission",
+          "kind": "function",
+          "file": "roomRepository/api/updateCohostPermission.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              },
+              {
+                "name": "cohostId",
+                "type": "string"
+              },
+              {
+                "name": "canManageProductTags",
+                "type": "boolean"
+              }
+            ],
+            "returns": "Promise<Cached<Room>>"
+          }
+        },
+        {
+          "name": "updateRoom",
+          "kind": "function",
+          "file": "roomRepository/api/updateRoom.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "roomId",
+                "type": "string"
+              },
+              {
+                "name": "bundle",
+                "type": "Partial<{}>"
+              }
+            ],
+            "returns": "Promise<Cached<Room>>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "StoryRepository": {
+      "source_module": "storyRepository/index.ts",
+      "member_count": 10,
+      "members": [
+        {
+          "name": "createImageStory",
+          "kind": "function",
+          "file": "storyRepository/api/createImageStory.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "targetType",
+                "type": "StoryTargetType"
+              },
+              {
+                "name": "targetId",
+                "type": "string"
+              },
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "metadata",
+                "type": "Metadata"
+              },
+              {
+                "name": "imageDisplayMode",
+                "type": "ImageDisplayMode"
+              },
+              {
+                "name": "items",
+                "type": "StoryItem[]"
+              }
+            ],
+            "returns": "Promise<Cached<Story | undefined>>"
+          }
+        },
+        {
+          "name": "createVideoStory",
+          "kind": "function",
+          "file": "storyRepository/api/createVideoStory.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "targetType",
+                "type": "StoryTargetType"
+              },
+              {
+                "name": "targetId",
+                "type": "string"
+              },
+              {
+                "name": "formData",
+                "type": "FormData"
+              },
+              {
+                "name": "metadata",
+                "type": "Metadata"
+              },
+              {
+                "name": "items",
+                "type": "StoryItem[]"
+              }
+            ],
+            "returns": "Promise<Cached<Story | undefined>>"
+          }
+        },
+        {
+          "name": "getActiveStoriesByTarget",
+          "kind": "function",
+          "file": "storyRepository/observers/getActiveStoriesByTarget.ts",
+          "line": 51,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "GetStoriesByTargetParam"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Story | undefined>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getGlobalStoryTargets",
+          "kind": "function",
+          "file": "storyRepository/observers/getGlobalStoryTargets/getGlobalStoryTargets.ts",
+          "line": 6,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "LiveCollectionParams<StoryGlobalQuery>"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<StoryTarget>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getStoriesByTargetIds",
+          "kind": "function",
+          "file": "storyRepository/observers/getStoriesByTargetIds/getStoriesByTargetIds.ts",
+          "line": 6,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "{}"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Story>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "getStoryByStoryId",
+          "kind": "function",
+          "file": "storyRepository/observers/getStoryByStoryId.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "storyId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Story>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getTargetById",
+          "kind": "function",
+          "file": "storyRepository/observers/getTargetById.ts",
+          "line": 5,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "StoryTargetQueryParam"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<StoryTarget>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getTargetsByTargetIds",
+          "kind": "function",
+          "file": "storyRepository/observers/getTargetsByTargetIds.ts",
+          "line": 9,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "StoryTargetQueryParam[]"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<StoryTarget | undefined>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "hardDeleteStory",
+          "kind": "function",
+          "file": "storyRepository/api/hardDeleteStory.ts",
+          "line": 3,
+          "signature": {
+            "parameters": [
+              {
+                "name": "storyId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "softDeleteStory",
+          "kind": "function",
+          "file": "storyRepository/api/softDeleteStory.ts",
+          "line": 3,
+          "signature": {
+            "parameters": [
+              {
+                "name": "storyId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "StreamRepository": {
+      "source_module": "streamRepository/index.ts",
+      "member_count": 14,
+      "members": [
+        {
+          "name": "createStream",
+          "kind": "function",
+          "file": "streamRepository/api/createStream.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<RawStream, 'metadata' | 'description' | 'title' | 'thumbnailFileId' | 'channelEnabled' | 'parentStreamId'> & {}"
+              }
+            ],
+            "returns": "Promise<Cached<Stream>>"
+          }
+        },
+        {
+          "name": "deleteStream",
+          "kind": "function",
+          "file": "streamRepository/api/deleteStream.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "streamId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "disposeStream",
+          "kind": "function",
+          "file": "streamRepository/api/disposeStream.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "streamId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<Cached<RawStream>>"
+          }
+        },
+        {
+          "name": "editStream",
+          "kind": "function",
+          "file": "streamRepository/api/editStream.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "streamId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Stream, 'title' | 'thumbnailFileId' | 'description' | 'metadata' | 'channelEnabled'>"
+              }
+            ],
+            "returns": "Promise<Cached<Stream>>"
+          }
+        },
+        {
+          "name": "getStreamById",
+          "kind": "function",
+          "file": "streamRepository/observers/getStreamById.ts",
+          "line": 32,
+          "signature": {
+            "parameters": [
+              {
+                "name": "streamId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<Stream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getStreams",
+          "kind": "function",
+          "file": "streamRepository/observers/getStreams/getStreams.ts",
+          "line": 6,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "StreamLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<Stream>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onStreamFlagged",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamFlagged.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamRecorded",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamRecorded.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamStarted",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamStarted.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamStopped",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamStopped.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamTerminated",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamTerminated.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamViewerBanned",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamViewerBanned.ts",
+          "line": 20,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onStreamViewerUnbanned",
+          "kind": "function",
+          "file": "streamRepository/events/onStreamViewerUnbanned.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<RawStream>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "updateStream",
+          "kind": "function",
+          "file": "streamRepository/api/updateStream.ts",
+          "line": 28,
+          "signature": {
+            "parameters": [
+              {
+                "name": "streamId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.Stream, 'title' | 'thumbnailFileId' | 'description' | 'metadata' | 'channelEnabled'>"
+              }
+            ],
+            "returns": "Promise<Cached<Stream>>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "SubChannelRepository": {
+      "source_module": "subChannelRepository/index.ts",
+      "member_count": 13,
+      "members": [
+        {
+          "name": "createSubChannel",
+          "kind": "function",
+          "file": "subChannelRepository/api/createSubChannel.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "bundle",
+                "type": "Pick<Amity.SubChannel, 'channelId' | 'displayName'>"
+              }
+            ],
+            "returns": "Promise<Cached<SubChannel>>"
+          }
+        },
+        {
+          "name": "getSubChannel",
+          "kind": "function",
+          "file": "subChannelRepository/observers/getSubChannel.ts",
+          "line": 47,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<SubChannel>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getSubChannelByIds",
+          "kind": "function",
+          "file": "subChannelRepository/api/getSubChannels.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<SubChannel[]>>"
+          }
+        },
+        {
+          "name": "getSubChannels",
+          "kind": "function",
+          "file": "subChannelRepository/observers/getSubChannels/getSubChannels.ts",
+          "line": 29,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SubChannelLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<SubChannel>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "hardDeleteSubChannel",
+          "kind": "function",
+          "file": "subChannelRepository/api/hardDeleteSubChannel.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<SubChannel>"
+          }
+        },
+        {
+          "name": "markReadEngineOnLoginHandler",
+          "kind": "function",
+          "file": "subChannelRepository/utils/markReadEngine.ts",
+          "line": 48,
+          "signature": {
+            "parameters": [],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onSubChannelCreated",
+          "kind": "function",
+          "file": "subChannelRepository/events/onSubChannelCreated.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<SubChannel>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onSubChannelDeleted",
+          "kind": "function",
+          "file": "subChannelRepository/events/onSubChannelDeleted.ts",
+          "line": 23,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<SubChannel>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "onSubChannelUpdated",
+          "kind": "function",
+          "file": "subChannelRepository/events/onSubChannelUpdated.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<SubChannel>"
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "softDeleteSubChannel",
+          "kind": "function",
+          "file": "subChannelRepository/api/softDeleteSubChannel.ts",
+          "line": 21,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<SubChannel>"
+          }
+        },
+        {
+          "name": "startMessageReceiptSync",
+          "kind": "function",
+          "file": "subChannelRepository/utils/messageReceiptSync.ts",
+          "line": 44,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "stopMessageReceiptSync",
+          "kind": "function",
+          "file": "subChannelRepository/utils/messageReceiptSync.ts",
+          "line": 69,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              }
+            ],
+            "returns": "boolean"
+          }
+        },
+        {
+          "name": "updateSubChannel",
+          "kind": "function",
+          "file": "subChannelRepository/api/updateSubChannel.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "subChannelId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.SubChannel, 'displayName'>"
+              }
+            ],
+            "returns": "Promise<Cached<SubChannel>>"
+          }
+        }
+      ],
+      "sub_namespaces": {}
+    },
+    "UserRepository": {
+      "source_module": "userRepository/index.ts",
+      "member_count": 21,
+      "members": [
+        {
+          "name": "AmityUserSearchMatchType",
+          "kind": "enum",
+          "file": "userRepository/constants/index.ts",
+          "line": 1
+        },
+        {
+          "name": "AmityUserSearchMatchType.DEFAULT",
+          "kind": "enum_member",
+          "file": "userRepository/constants/index.ts",
+          "line": 2
+        },
+        {
+          "name": "AmityUserSearchMatchType.PARTIAL",
+          "kind": "enum_member",
+          "file": "userRepository/constants/index.ts",
+          "line": 3
+        },
+        {
+          "name": "flagUser",
+          "kind": "function",
+          "file": "userRepository/api/flagUser.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "getAllBlockedUsers",
+          "kind": "function",
+          "file": "userRepository/api/getAllBlockedUsers.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<User[]>"
+          }
+        },
+        {
+          "name": "getAllBlockingUsers",
+          "kind": "function",
+          "file": "userRepository/api/getAllBlockingUsers.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [],
+            "returns": "Promise<User[]>"
+          }
+        },
+        {
+          "name": "getBlockedUsers",
+          "kind": "function",
+          "file": "userRepository/observers/getBlockedUsers.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "BlockedUsersLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<User>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getBlockingUsers",
+          "kind": "function",
+          "file": "userRepository/observers/getBlockingUsers.ts",
+          "line": 24,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<User>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getReachedUsers",
+          "kind": "function",
+          "file": "userRepository/observers/getReachedUsers.ts",
+          "line": 8,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "ViewedUsersLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<User | undefined>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getUser",
+          "kind": "function",
+          "file": "userRepository/observers/getUser.ts",
+          "line": 35,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userId",
+                "type": "string"
+              },
+              {
+                "name": "callback",
+                "type": "LiveObjectCallback<User>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "getUserByIds",
+          "kind": "function",
+          "file": "userRepository/api/getUserByIds.ts",
+          "line": 26,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userIds",
+                "type": "string[]"
+              }
+            ],
+            "returns": "Promise<Cached<User[]>>"
+          }
+        },
+        {
+          "name": "getUsers",
+          "kind": "function",
+          "file": "userRepository/observers/getUsers.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "UserLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<User>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "isUserFlaggedByMe",
+          "kind": "function",
+          "file": "userRepository/api/isUserFlaggedByMe.ts",
+          "line": 19,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "onUserDeleted",
+          "kind": "function",
+          "file": "userRepository/events/onUserDeleted.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalUser>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onUserFlagCleared",
+          "kind": "function",
+          "file": "userRepository/events/onUserFlagCleared.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalUser>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onUserFlagged",
+          "kind": "function",
+          "file": "userRepository/events/onUserFlagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalUser>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onUserUnflagged",
+          "kind": "function",
+          "file": "userRepository/events/onUserUnflagged.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalUser>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "onUserUpdated",
+          "kind": "function",
+          "file": "userRepository/events/onUserUpdated.ts",
+          "line": 18,
+          "signature": {
+            "parameters": [
+              {
+                "name": "callback",
+                "type": "Listener<InternalUser>"
+              }
+            ],
+            "returns": "Unsubscriber"
+          }
+        },
+        {
+          "name": "searchUserByDisplayName",
+          "kind": "function",
+          "file": "userRepository/observers/searchUserByDisplayName.ts",
+          "line": 27,
+          "signature": {
+            "parameters": [
+              {
+                "name": "params",
+                "type": "SearchUserLiveCollection"
+              },
+              {
+                "name": "callback",
+                "type": "LiveCollectionCallback<InternalUser>"
+              },
+              {
+                "name": "config",
+                "type": "LiveCollectionConfig",
+                "optional": true
+              }
+            ],
+            "returns": "{}"
+          }
+        },
+        {
+          "name": "unflagUser",
+          "kind": "function",
+          "file": "userRepository/api/unflagUser.ts",
+          "line": 22,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userId",
+                "type": "string"
+              }
+            ],
+            "returns": "Promise<boolean>"
+          }
+        },
+        {
+          "name": "updateUser",
+          "kind": "function",
+          "file": "userRepository/api/updateUser.ts",
+          "line": 25,
+          "signature": {
+            "parameters": [
+              {
+                "name": "userId",
+                "type": "string"
+              },
+              {
+                "name": "patch",
+                "type": "Patch<Amity.User, 'displayName' | 'description' | 'avatarFileId' | 'avatarCustomUrl' | 'metadata'>"
+              }
+            ],
+            "returns": "Promise<Cached<User>>"
+          }
+        }
+      ],
+      "sub_namespaces": {
+        "Relationship": {
+          "source_module": "userRepository/relationship/index.ts",
+          "member_count": 25,
+          "members": [
+            {
+              "name": "acceptMyFollower",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/api/acceptMyFollower.ts",
+              "line": 23,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "blockUser",
+              "kind": "function",
+              "file": "userRepository/relationship/block/api/blockUser.ts",
+              "line": 24,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<BlockedPayload>"
+              }
+            },
+            {
+              "name": "declineMyFollower",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/api/declineMyFollower.ts",
+              "line": 23,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            },
+            {
+              "name": "follow",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/api/follow.ts",
+              "line": 23,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<Cached<RawFollowStatus>>"
+              }
+            },
+            {
+              "name": "getFollowers",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/observers/getFollowers.ts",
+              "line": 29,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "FollowerLiveCollection"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<RawFollowStatus>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "getFollowInfo",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/observers/getFollowInfo.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveObjectCallback<FollowInfo>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "getFollowings",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/observers/getFollowings.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "params",
+                    "type": "FollowerLiveCollection"
+                  },
+                  {
+                    "name": "callback",
+                    "type": "LiveCollectionCallback<RawFollowStatus>"
+                  },
+                  {
+                    "name": "config",
+                    "type": "LiveCollectionConfig",
+                    "optional": true
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "getMyFollowInfo",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/observers/getMyFollowInfo.ts",
+              "line": 27,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "LiveObjectCallback<FollowInfo>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowerDeleted",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowerDeleted.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowerRequested",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowerRequested.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowInfoUpdated",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowInfoUpdated.ts",
+              "line": 19,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<FollowInfo>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowRequestAccepted",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowRequestAccepted.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowRequestCanceled",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowRequestCanceled.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onFollowRequestDeclined",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onFollowRequestDeclined.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalFollowerRequested",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onLocalFollowerRequested.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalFollowRequestAccepted",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onLocalFollowRequestAccepted.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalFollowRequestDeclined",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onLocalFollowRequestDeclined.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalUserFollowed",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onLocalUserFollowed.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onLocalUserUnfollowed",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onLocalUserUnfollowed.ts",
+              "line": 3,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onUserDidBlock",
+              "kind": "function",
+              "file": "userRepository/relationship/block/events/onUserDidBlock.ts",
+              "line": 21,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onUserDidUnblock",
+              "kind": "function",
+              "file": "userRepository/relationship/block/events/onUserDidUnblock.ts",
+              "line": 21,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onUserFollowed",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onUserFollowed.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "onUserUnfollowed",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/events/onUserUnfollowed.ts",
+              "line": 18,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "callback",
+                    "type": "Listener<RawFollowStatus>"
+                  }
+                ],
+                "returns": "Unsubscriber"
+              }
+            },
+            {
+              "name": "unBlockUser",
+              "kind": "function",
+              "file": "userRepository/relationship/block/api/unBlockUser.ts",
+              "line": 24,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<BlockedPayload>"
+              }
+            },
+            {
+              "name": "unfollow",
+              "kind": "function",
+              "file": "userRepository/relationship/follow/api/unfollow.ts",
+              "line": 23,
+              "signature": {
+                "parameters": [
+                  {
+                    "name": "userId",
+                    "type": "string"
+                  }
+                ],
+                "returns": "Promise<boolean>"
+              }
+            }
+          ],
+          "sub_namespaces": {}
+        }
+      }
+    },
     "Amity": {
       "source_module": "AmityTypescriptSDK/packages/sdk/src/@types",
-      "source_files": [
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/cache.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/linkPreview.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/linkPreviewMetadata.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/live.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/marker.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/model.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/objectResolver.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/paging.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/permissions.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/query.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/readReceipt.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/core/transport.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/ad.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/analytics.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/block.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/category.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/comment.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/community.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/content.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/feed.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/follow.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/group.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/hashtag.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/invitation.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/joinRequest.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/liveReaction.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/liveStreamPlayer.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/marker.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/mention.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/message.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/messagePreview.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/notification.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/notificationSettings.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/partials.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/pin.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/pinnedPost.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/poll.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/product.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/reaction.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/room.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/story.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/stream.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/subChannel.ts",
-        "AmityTypescriptSDK/packages/sdk/src/@types/domains/user.ts"
-      ],
-      "member_count": 977,
+      "member_count": 990,
       "members": [
         {
           "name": "Serializable",
@@ -2806,11 +7081,19 @@
           "line": 29
         },
         {
+          "name": "ServerError.MAX_BLOCKED_USERS_REACHED",
+          "kind": "enum_case",
+          "parent_enum": "ServerError",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
+          "line": 30
+        },
+        {
           "name": "ClientError",
           "kind": "enum",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 32
+          "line": 33
         },
         {
           "name": "ClientError.UNKNOWN_ERROR",
@@ -2818,7 +7101,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 33
+          "line": 34
         },
         {
           "name": "ClientError.INVALID_PARAMETERS",
@@ -2826,7 +7109,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 34
+          "line": 35
         },
         {
           "name": "ClientError.QUERY_IN_PROGRESS",
@@ -2834,7 +7117,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 35
+          "line": 36
         },
         {
           "name": "ClientError.CONNECTION_ERROR",
@@ -2842,7 +7125,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 36
+          "line": 37
         },
         {
           "name": "ClientError.DISCONNECTED",
@@ -2850,7 +7133,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 37
+          "line": 38
         },
         {
           "name": "ClientError.TOKEN_EXPIRED",
@@ -2858,7 +7141,7 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 38
+          "line": 39
         },
         {
           "name": "ClientError.DISALOOW_UNSYNCED_OBJECT",
@@ -2866,14 +7149,14 @@
           "parent_enum": "ClientError",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 39
+          "line": 40
         },
         {
           "name": "ErrorCode",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/errors.ts",
-          "line": 42
+          "line": 43
         },
         {
           "name": "Listener",
@@ -2995,109 +7278,116 @@
           "line": 146
         },
         {
-          "name": "MqttMarkerEvents",
+          "name": "MqttBlockEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
           "line": 156
         },
         {
+          "name": "MqttMarkerEvents",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
+          "line": 161
+        },
+        {
           "name": "MqttRoomEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 163
+          "line": 168
         },
         {
           "name": "MqttEventEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 187
+          "line": 192
         },
         {
           "name": "MqttEventRSVPEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 196
+          "line": 201
         },
         {
           "name": "MqttEventNotificationEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 202
+          "line": 207
         },
         {
           "name": "MqttRTE",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 207
+          "line": 212
         },
         {
           "name": "LocalPostEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 222
+          "line": 228
         },
         {
           "name": "LocalCommentEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 232
+          "line": 238
         },
         {
           "name": "LocalCommunityEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 244
+          "line": 250
         },
         {
           "name": "LocalFollowEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 253
+          "line": 259
         },
         {
           "name": "LocalEventEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 261
+          "line": 267
         },
         {
           "name": "LocalEventRSVPEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 270
+          "line": 276
         },
         {
           "name": "LocalEventNotificationEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 276
+          "line": 282
         },
         {
           "name": "LocalEvents",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 281
+          "line": 287
         },
         {
           "name": "Events",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/events.ts",
-          "line": 374
+          "line": 380
         },
         {
           "name": "LinkPreview",
@@ -3448,371 +7738,371 @@
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 40
+          "line": 41
         },
         {
           "name": "ProcessedUserPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 45
+          "line": 46
         },
         {
           "name": "FeedSettingPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 50
+          "line": 51
         },
         {
           "name": "PresenceSettingPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 57
+          "line": 58
         },
         {
           "name": "AdPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 69
+          "line": 70
         },
         {
           "name": "CreateFilePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 77
+          "line": 78
         },
         {
           "name": "VideoFileExtraPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 79
+          "line": 80
         },
         {
           "name": "FilePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 85
+          "line": 86
         },
         {
           "name": "RolePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 102
+          "line": 103
         },
         {
           "name": "ChannelPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 106
+          "line": 107
         },
         {
           "name": "ProcessedChannelPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 118
+          "line": 119
         },
         {
           "name": "UserMarkerResponse",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 127
+          "line": 128
         },
         {
           "name": "UserEntityMarkerResponse",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 128
+          "line": 129
         },
         {
           "name": "UserFeedMarkerResponse",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 129
+          "line": 130
         },
         {
           "name": "UserMarkerPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 134
+          "line": 135
         },
         {
           "name": "ChannelMarkerPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 138
+          "line": 139
         },
         {
           "name": "SubChannelMarkerPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 143
+          "line": 144
         },
         {
           "name": "UserMessageFeedMarkerPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 150
+          "line": 151
         },
         {
           "name": "MessageMarkerPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 155
+          "line": 156
         },
         {
           "name": "MarkReadPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 161
+          "line": 162
         },
         {
           "name": "MarkerSyncPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 168
+          "line": 169
         },
         {
           "name": "MarkAsReadPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 175
+          "line": 176
         },
         {
           "name": "MarkDeliveredPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 182
+          "line": 183
         },
         {
           "name": "ReadUserPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 189
+          "line": 190
         },
         {
           "name": "DeliveredUserPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 196
+          "line": 197
         },
         {
           "name": "StartReadingPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 203
+          "line": 204
         },
         {
           "name": "ReadingPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 210
+          "line": 211
         },
         {
           "name": "StopReadingPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 217
+          "line": 218
         },
         {
           "name": "MarkedMessagePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 224
+          "line": 225
         },
         {
           "name": "FeedUpdatedPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 229
+          "line": 230
         },
         {
           "name": "UserMarkerSyncPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 234
+          "line": 235
         },
         {
           "name": "UserFeedUpdatedPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 240
+          "line": 241
         },
         {
           "name": "SubChannelPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 245
+          "line": 246
         },
         {
           "name": "ProcessedSubChannelPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 257
+          "line": 258
         },
         {
           "name": "ChannelMembershipPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 264
+          "line": 265
         },
         {
           "name": "ArchivedChannelPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 271
+          "line": 272
         },
         {
           "name": "ProcessedChannelMembershipPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 280
+          "line": 281
         },
         {
           "name": "ProcessedMessagePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 293
+          "line": 294
         },
         {
           "name": "MessagePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 300
+          "line": 301
         },
         {
           "name": "SearchMessagePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 308
+          "line": 309
         },
         {
           "name": "StreamPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 313
+          "line": 314
         },
         {
           "name": "CommunityPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 321
+          "line": 322
         },
         {
           "name": "CommunityJoinRequestPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 330
+          "line": 331
         },
         {
           "name": "RecommendedCommunityPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 336
+          "line": 337
         },
         {
           "name": "TrendingCommunityPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 337
+          "line": 338
         },
         {
           "name": "ProcessedCommunityPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 344
+          "line": 345
         },
         {
           "name": "ProcessedJoinRequestPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 350
+          "line": 351
         },
         {
           "name": "CategoryPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 359
+          "line": 360
         },
         {
           "name": "CommunityMembershipPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 364
+          "line": 365
         },
         {
           "name": "ProcessedCommunityMembershipPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 378
+          "line": 379
         },
         {
           "name": "PostPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 387
+          "line": 388
         },
         {
           "name": "SemanticSearchPostPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 403
+          "line": 404
         },
         {
           "name": "ForYouFeedPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 408
+          "line": 409
         },
         {
           "name": "ProcessedSemanticSearchPostPayload",
@@ -4046,165 +8336,179 @@
           "line": 558
         },
         {
-          "name": "MessagePreviewPayload",
+          "name": "BlockingUserPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
           "line": 562
         },
         {
-          "name": "messageFeedsInfoPayload",
+          "name": "ProcessedBlockingUserPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 576
+          "line": 564
         },
         {
-          "name": "SubChannelMessagePreviewPayload",
+          "name": "MessagePreviewPayload",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
+          "line": 568
+        },
+        {
+          "name": "messageFeedsInfoPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
           "line": 582
         },
         {
+          "name": "SubChannelMessagePreviewPayload",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
+          "line": 588
+        },
+        {
           "name": "InvitationPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 603
+          "line": 609
         },
         {
           "name": "ProcessedInvitationPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 608
+          "line": 614
         },
         {
           "name": "MyInvitationsPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 613
+          "line": 619
         },
         {
           "name": "ProcessedMyInvitationsPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 618
+          "line": 624
         },
         {
           "name": "JoinRequestPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 623
+          "line": 629
         },
         {
           "name": "LiveReactionPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 627
+          "line": 633
         },
         {
           "name": "RawChannelSetMuted",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 631
+          "line": 637
         },
         {
           "name": "ChannelSetMutedPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 638
+          "line": 644
         },
         {
           "name": "RawChannelSetUserMuted",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 640
+          "line": 646
         },
         {
           "name": "RawStreamViewerBan",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 647
+          "line": 653
         },
         {
           "name": "StreamViewerBanPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 655
+          "line": 661
         },
         {
           "name": "StreamViewerUnbanPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 656
+          "line": 662
         },
         {
           "name": "ChannelSetUserMutedPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 658
+          "line": 664
         },
         {
           "name": "RoomPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 660
+          "line": 666
         },
         {
           "name": "EventPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 667
+          "line": 673
         },
         {
           "name": "EventResponsePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 676
+          "line": 682
         },
         {
           "name": "ProcessedEventPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 683
+          "line": 689
         },
         {
           "name": "RoomWatchingUsersPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 692
+          "line": 698
         },
         {
           "name": "ProcessedEventResponsePayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 698
+          "line": 704
         },
         {
           "name": "ProductPayload",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/core/payload.ts",
-          "line": 705
+          "line": 711
         },
         {
           "name": "Permission",
@@ -5209,6 +9513,20 @@
           "line": 16
         },
         {
+          "name": "BlockingUsersLiveCollection",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/block.ts",
+          "line": 24
+        },
+        {
+          "name": "BlockingUserLiveCollectionCache",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/block.ts",
+          "line": 26
+        },
+        {
           "name": "InternalCategory",
           "kind": "type",
           "namespace": "Amity",
@@ -5469,67 +9787,102 @@
           "line": 154
         },
         {
-          "name": "QueryChannelMembers",
+          "name": "QuerySearchChannels",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
           "line": 159
         },
         {
-          "name": "SearchChannelMembers",
+          "name": "SearchChannelLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
           "line": 169
         },
         {
-          "name": "ChannelMembersLiveCollection",
+          "name": "SearchChannelLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
           "line": 171
         },
         {
+          "name": "QueryChannelMembers",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
+          "line": 176
+        },
+        {
+          "name": "SearchChannelMembers",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
+          "line": 186
+        },
+        {
+          "name": "ChannelMembersLiveCollection",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
+          "line": 188
+        },
+        {
           "name": "SearchChannelMembersLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
-          "line": 175
+          "line": 192
         },
         {
           "name": "ChannelMembersLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
-          "line": 179
+          "line": 196
         },
         {
           "name": "ChannelUnread",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
-          "line": 185
+          "line": 202
         },
         {
           "name": "Logger",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 12
+          "line": 19
         },
         {
           "name": "MembershipAcceptanceType",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 14
+          "line": 21
+        },
+        {
+          "name": "AutoSubscription",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
+          "line": 23
+        },
+        {
+          "name": "AutoSubscriptionState",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
+          "line": 25
         },
         {
           "name": "TokenTerminationReason",
           "kind": "enum",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 16
+          "line": 32
         },
         {
           "name": "TokenTerminationReason.GLOBAL_BAN",
@@ -5537,7 +9890,7 @@
           "parent_enum": "TokenTerminationReason",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 17
+          "line": 33
         },
         {
           "name": "TokenTerminationReason.USER_DELETED",
@@ -5545,7 +9898,7 @@
           "parent_enum": "TokenTerminationReason",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 18
+          "line": 34
         },
         {
           "name": "TokenTerminationReason.UNAUTHORIZED",
@@ -5553,14 +9906,14 @@
           "parent_enum": "TokenTerminationReason",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 19
+          "line": 35
         },
         {
           "name": "SessionStates",
           "kind": "enum",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 22
+          "line": 38
         },
         {
           "name": "SessionStates.NOT_LOGGED_IN",
@@ -5568,7 +9921,7 @@
           "parent_enum": "SessionStates",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 23
+          "line": 39
         },
         {
           "name": "SessionStates.ESTABLISHING",
@@ -5576,7 +9929,7 @@
           "parent_enum": "SessionStates",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 25
+          "line": 41
         },
         {
           "name": "SessionStates.ESTABLISHED",
@@ -5584,7 +9937,7 @@
           "parent_enum": "SessionStates",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 26
+          "line": 42
         },
         {
           "name": "SessionStates.TOKEN_EXPIRED",
@@ -5592,7 +9945,7 @@
           "parent_enum": "SessionStates",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 28
+          "line": 44
         },
         {
           "name": "SessionStates.TERMINATED",
@@ -5600,126 +9953,140 @@
           "parent_enum": "SessionStates",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 39
+          "line": 55
         },
         {
           "name": "Client",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 42
+          "line": 58
         },
         {
           "name": "Device",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 92
+          "line": 112
         },
         {
           "name": "Tokens",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 101
+          "line": 121
         },
         {
           "name": "SessionResponse",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 108
+          "line": 128
         },
         {
           "name": "AccessTokenRenewal",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 114
+          "line": 134
         },
         {
           "name": "SessionHandler",
           "kind": "interface",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 125
+          "line": 145
         },
         {
           "name": "AccessTokenHandler",
           "kind": "interface",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 129
+          "line": 149
         },
         {
           "name": "ChatSettings",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 137
+          "line": 157
         },
         {
           "name": "ShareableLinkConfiguration",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 148
+          "line": 168
         },
         {
           "name": "FeedSettings",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 157
+          "line": 177
         },
         {
           "name": "SocialSettings",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 161
+          "line": 181
+        },
+        {
+          "name": "CoreUserSettings",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
+          "line": 200
         },
         {
           "name": "ProductCatalogueSetting",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 180
+          "line": 204
+        },
+        {
+          "name": "ForYouFeedSetting",
+          "kind": "type",
+          "namespace": "Amity",
+          "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
+          "line": 210
         },
         {
           "name": "ConnectClientParams",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 186
+          "line": 216
         },
         {
           "name": "ConnectClientAsVisitorParams",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 193
+          "line": 223
         },
         {
           "name": "ConnectClientConfig",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 198
+          "line": 228
         },
         {
           "name": "ActiveUser",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 202
+          "line": 232
         },
         {
           "name": "UserUnread",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
-          "line": 204
+          "line": 234
         },
         {
           "name": "CommentContentType",
@@ -5782,14 +10149,14 @@
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/comment.ts",
-          "line": 78
+          "line": 79
         },
         {
           "name": "CommentLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/comment.ts",
-          "line": 84
+          "line": 85
         },
         {
           "name": "CommunitySortByEnum",
@@ -8290,98 +12657,98 @@
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 147
+          "line": 148
         },
         {
           "name": "PostLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 158
+          "line": 159
         },
         {
           "name": "SearchPostWithHashtagLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 164
+          "line": 165
         },
         {
           "name": "PostLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 170
+          "line": 171
         },
         {
           "name": "QuerySemanticSearchPosts",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 175
+          "line": 176
         },
         {
           "name": "SemanticSearchPostLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 185
+          "line": 186
         },
         {
           "name": "SemanticSearchPostLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 189
+          "line": 190
         },
         {
           "name": "QueryLiveRoomPosts",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 194
+          "line": 195
         },
         {
           "name": "LiveRoomPostLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 198
+          "line": 199
         },
         {
           "name": "LiveRoomPostLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 200
+          "line": 201
         },
         {
           "name": "QueryCommunityLiveRoomPosts",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 205
+          "line": 206
         },
         {
           "name": "CommunityLiveRoomPostLiveCollection",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 209
+          "line": 210
         },
         {
           "name": "CommunityLiveRoomPostLiveCollectionCache",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 212
+          "line": 213
         },
         {
           "name": "Link",
           "kind": "type",
           "namespace": "Amity",
           "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-          "line": 217
+          "line": 218
         },
         {
           "name": "ProductStatusEnum",
@@ -9671,661 +14038,1851 @@
           "line": 107
         }
       ],
-      "sub_namespaces": {},
-      "notes": "Synthesised from declare global { namespace Amity { ... } } blocks across all @types/ files. v1.2 flattens nested namespaces if present."
+      "sub_namespaces": {}
     }
   },
   "root_exports": [
     {
+      "name": "AmityAutoSubscription.BLOCK",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
+      "line": 14
+    },
+    {
+      "name": "AmityAutoSubscription.CHAT",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
+      "line": 11
+    },
+    {
+      "name": "AmityAutoSubscription.LIVESTREAM",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
+      "line": 13
+    },
+    {
+      "name": "AmityAutoSubscription.NETWORK",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
+      "line": 12
+    },
+    {
+      "name": "AmityAutoSubscription",
+      "kind": "enum",
+      "file": "@types/domains/client.ts",
+      "line": 10
+    },
+    {
+      "name": "AmityChannelNotificationModeEnum.Default",
+      "kind": "enum_member",
+      "file": "@types/domains/channel.ts",
+      "line": 4
+    },
+    {
+      "name": "AmityChannelNotificationModeEnum.Silent",
+      "kind": "enum_member",
+      "file": "@types/domains/channel.ts",
+      "line": 5
+    },
+    {
+      "name": "AmityChannelNotificationModeEnum.Subscribe",
+      "kind": "enum_member",
+      "file": "@types/domains/channel.ts",
+      "line": 6
+    },
+    {
       "name": "AmityChannelNotificationModeEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/channel.ts",
+      "file": "@types/domains/channel.ts",
       "line": 3
     },
     {
-      "name": "CommunityPostSettings",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/community.ts",
-      "line": 3
+      "name": "AmityCommunityType.Default",
+      "kind": "enum_member",
+      "file": "@types/domains/community.ts",
+      "line": 27
     },
     {
-      "name": "CommunityPostSettingMaps",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/community.ts",
-      "line": 9
-    },
-    {
-      "name": "DefaultCommunityPostSetting",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/community.ts",
-      "line": 24
+      "name": "AmityCommunityType.Event",
+      "kind": "enum_member",
+      "file": "@types/domains/community.ts",
+      "line": 28
     },
     {
       "name": "AmityCommunityType",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/community.ts",
+      "file": "@types/domains/community.ts",
       "line": 26
     },
     {
-      "name": "ContentFeedType",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/content.ts",
-      "line": 1
+      "name": "AmityEventOrderOption.Ascending",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 31
+    },
+    {
+      "name": "AmityEventOrderOption.Descending",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 32
+    },
+    {
+      "name": "AmityEventOrderOption",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 30
+    },
+    {
+      "name": "AmityEventOriginType.Community",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 9
+    },
+    {
+      "name": "AmityEventOriginType.User",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 10
+    },
+    {
+      "name": "AmityEventOriginType",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 8
+    },
+    {
+      "name": "AmityEventResponseStatus.Going",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 21
+    },
+    {
+      "name": "AmityEventResponseStatus.NotGoing",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 22
+    },
+    {
+      "name": "AmityEventResponseStatus",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 20
+    },
+    {
+      "name": "AmityEventSortOption.CreatedAt",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 27
+    },
+    {
+      "name": "AmityEventSortOption.StartTime",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 26
+    },
+    {
+      "name": "AmityEventSortOption",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 25
+    },
+    {
+      "name": "AmityEventStatus.Cancelled",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 17
+    },
+    {
+      "name": "AmityEventStatus.Ended",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 16
+    },
+    {
+      "name": "AmityEventStatus.Live",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 15
+    },
+    {
+      "name": "AmityEventStatus.Scheduled",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 14
+    },
+    {
+      "name": "AmityEventStatus",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 13
+    },
+    {
+      "name": "AmityEventType.InPerson",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 5
+    },
+    {
+      "name": "AmityEventType.Virtual",
+      "kind": "enum_member",
+      "file": "@types/domains/event.ts",
+      "line": 4
+    },
+    {
+      "name": "AmityEventType",
+      "kind": "enum",
+      "file": "@types/domains/event.ts",
+      "line": 3
+    },
+    {
+      "name": "AmitySharableContentType.COMMUNITY",
+      "kind": "enum_member",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 5
+    },
+    {
+      "name": "AmitySharableContentType.EVENT",
+      "kind": "enum_member",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 8
+    },
+    {
+      "name": "AmitySharableContentType.LIVESTREAM",
+      "kind": "enum_member",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 7
+    },
+    {
+      "name": "AmitySharableContentType.POST",
+      "kind": "enum_member",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 4
+    },
+    {
+      "name": "AmitySharableContentType.USER",
+      "kind": "enum_member",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 6
+    },
+    {
+      "name": "AmitySharableContentType",
+      "kind": "enum",
+      "file": "@types/domains/sharableContentType.ts",
+      "line": 3
+    },
+    {
+      "name": "AnalyticsSourceTypeEnum.POST",
+      "kind": "enum_member",
+      "file": "@types/domains/product.ts",
+      "line": 4
+    },
+    {
+      "name": "AnalyticsSourceTypeEnum.ROOM",
+      "kind": "enum_member",
+      "file": "@types/domains/product.ts",
+      "line": 5
+    },
+    {
+      "name": "AnalyticsSourceTypeEnum",
+      "kind": "enum",
+      "file": "@types/domains/product.ts",
+      "line": 3
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.COMMENT_CREATED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 10
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.COMMENT_REACTED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 12
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.COMMENT_REPLIED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 11
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.LIVESTREAM_START",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 16
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.POST_CREATED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 8
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.POST_REACTED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 9
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.STORY_COMMENT_CREATED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 15
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.STORY_CREATED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 13
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum.STORY_REACTED",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 14
+    },
+    {
+      "name": "CommunityNotificationEventNameEnum",
+      "kind": "enum",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 7
+    },
+    {
+      "name": "ContentFlagReasonEnum.CommunityGuidelines",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 10
+    },
+    {
+      "name": "ContentFlagReasonEnum.FalseInformation",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 17
+    },
+    {
+      "name": "ContentFlagReasonEnum.HarassmentOrBullying",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 11
+    },
+    {
+      "name": "ContentFlagReasonEnum.Others",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 18
+    },
+    {
+      "name": "ContentFlagReasonEnum.SelfHarmOrSuicide",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 12
+    },
+    {
+      "name": "ContentFlagReasonEnum.SellingRestrictedItems",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 14
+    },
+    {
+      "name": "ContentFlagReasonEnum.SexualContentOrNudity",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 15
+    },
+    {
+      "name": "ContentFlagReasonEnum.SpamOrScams",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 16
+    },
+    {
+      "name": "ContentFlagReasonEnum.ViolenceOrThreateningContent",
+      "kind": "enum_member",
+      "file": "@types/domains/content.ts",
+      "line": 13
     },
     {
       "name": "ContentFlagReasonEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/content.ts",
+      "file": "@types/domains/content.ts",
       "line": 9
     },
     {
-      "name": "FileType",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
-      "line": 1
+      "name": "FeedDataTypeEnum.Audio",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 8
     },
     {
-      "name": "VideoResolution",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
+      "name": "FeedDataTypeEnum.Clip",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 10
+    },
+    {
+      "name": "FeedDataTypeEnum.File",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 7
+    },
+    {
+      "name": "FeedDataTypeEnum.Image",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 6
+    },
+    {
+      "name": "FeedDataTypeEnum.LiveStream",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
       "line": 9
     },
     {
-      "name": "VideoTranscodingStatus",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
+      "name": "FeedDataTypeEnum.Poll",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 11
+    },
+    {
+      "name": "FeedDataTypeEnum.Room",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 12
+    },
+    {
+      "name": "FeedDataTypeEnum.Text",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 4
+    },
+    {
+      "name": "FeedDataTypeEnum.Video",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 5
+    },
+    {
+      "name": "FeedDataTypeEnum",
+      "kind": "enum",
+      "file": "@types/domains/feed.ts",
+      "line": 3
+    },
+    {
+      "name": "FeedSortByEnum.FirstCreated",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
       "line": 17
     },
     {
-      "name": "VideoSize",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
+      "name": "FeedSortByEnum.FirstUpdated",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 19
+    },
+    {
+      "name": "FeedSortByEnum.LastCreated",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 16
+    },
+    {
+      "name": "FeedSortByEnum.LastUpdated",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 18
+    },
+    {
+      "name": "FeedSortByEnum",
+      "kind": "enum",
+      "file": "@types/domains/feed.ts",
+      "line": 15
+    },
+    {
+      "name": "FeedSourceEnum.Community",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 23
+    },
+    {
+      "name": "FeedSourceEnum.User",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
       "line": 24
+    },
+    {
+      "name": "FeedSourceEnum",
+      "kind": "enum",
+      "file": "@types/domains/feed.ts",
+      "line": 22
+    },
+    {
+      "name": "FeedTypeEnum.Declined",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 30
+    },
+    {
+      "name": "FeedTypeEnum.Published",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 29
+    },
+    {
+      "name": "FeedTypeEnum.Reviewing",
+      "kind": "enum_member",
+      "file": "@types/domains/feed.ts",
+      "line": 28
+    },
+    {
+      "name": "FeedTypeEnum",
+      "kind": "enum",
+      "file": "@types/domains/feed.ts",
+      "line": 27
+    },
+    {
+      "name": "FileAccessTypeEnum.NETWORK",
+      "kind": "enum_member",
+      "file": "@types/domains/file.ts",
+      "line": 33
+    },
+    {
+      "name": "FileAccessTypeEnum.PUBLIC",
+      "kind": "enum_member",
+      "file": "@types/domains/file.ts",
+      "line": 32
     },
     {
       "name": "FileAccessTypeEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/file.ts",
+      "file": "@types/domains/file.ts",
       "line": 31
     },
     {
-      "name": "MessageContentType",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/message.ts",
-      "line": 1
+      "name": "InvitationSortByEnum.FirstCreated",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 16
     },
     {
-      "name": "PostContentType",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-      "line": 1
+      "name": "InvitationSortByEnum.LastCreated",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 17
     },
     {
-      "name": "PostStructureType",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/post.ts",
-      "line": 13
-    },
-    {
-      "name": "MembershipAcceptanceTypeEnum",
+      "name": "InvitationSortByEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/client.ts",
+      "file": "@types/domains/invitation.ts",
+      "line": 15
+    },
+    {
+      "name": "InvitationStatusEnum.Approved",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 10
+    },
+    {
+      "name": "InvitationStatusEnum.Cancelled",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 12
+    },
+    {
+      "name": "InvitationStatusEnum.Pending",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 9
+    },
+    {
+      "name": "InvitationStatusEnum.Rejected",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 11
+    },
+    {
+      "name": "InvitationStatusEnum",
+      "kind": "enum",
+      "file": "@types/domains/invitation.ts",
+      "line": 8
+    },
+    {
+      "name": "InvitationTargetTypeEnum.Community",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 21
+    },
+    {
+      "name": "InvitationTargetTypeEnum.Room",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 22
+    },
+    {
+      "name": "InvitationTargetTypeEnum",
+      "kind": "enum",
+      "file": "@types/domains/invitation.ts",
+      "line": 20
+    },
+    {
+      "name": "InvitationTypeEnum.CommunityMemberInvite",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
+      "line": 4
+    },
+    {
+      "name": "InvitationTypeEnum.LivestreamCohostInvite",
+      "kind": "enum_member",
+      "file": "@types/domains/invitation.ts",
       "line": 5
     },
     {
       "name": "InvitationTypeEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/invitation.ts",
+      "file": "@types/domains/invitation.ts",
       "line": 3
     },
     {
-      "name": "InvitationStatusEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/invitation.ts",
-      "line": 8
+      "name": "JoinRequestStatusEnum.Approved",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 5
     },
     {
-      "name": "InvitationSortByEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/invitation.ts",
-      "line": 15
+      "name": "JoinRequestStatusEnum.Cancelled",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 7
     },
     {
-      "name": "InvitationTargetTypeEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/invitation.ts",
-      "line": 20
+      "name": "JoinRequestStatusEnum.Pending",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 4
+    },
+    {
+      "name": "JoinRequestStatusEnum.Rejected",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 6
     },
     {
       "name": "JoinRequestStatusEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/joinRequest.ts",
+      "file": "@types/domains/joinRequest.ts",
       "line": 3
+    },
+    {
+      "name": "JoinResultStatusEnum.Pending",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 12
+    },
+    {
+      "name": "JoinResultStatusEnum.Success",
+      "kind": "enum_member",
+      "file": "@types/domains/joinRequest.ts",
+      "line": 11
     },
     {
       "name": "JoinResultStatusEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/joinRequest.ts",
+      "file": "@types/domains/joinRequest.ts",
       "line": 10
     },
     {
-      "name": "FeedDataTypeEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/feed.ts",
-      "line": 3
+      "name": "MembershipAcceptanceTypeEnum.AUTOMATIC",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
+      "line": 6
     },
     {
-      "name": "FeedSortByEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/feed.ts",
-      "line": 15
-    },
-    {
-      "name": "FeedSourceEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/feed.ts",
-      "line": 22
-    },
-    {
-      "name": "FeedTypeEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/feed.ts",
-      "line": 27
-    },
-    {
-      "name": "UserTypeEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/user.ts",
-      "line": 3
-    },
-    {
-      "name": "SearchUsersByEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/user.ts",
-      "line": 9
-    },
-    {
-      "name": "AmityEventType",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 3
-    },
-    {
-      "name": "AmityEventOriginType",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 8
-    },
-    {
-      "name": "AmityEventStatus",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 13
-    },
-    {
-      "name": "AmityEventResponseStatus",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 20
-    },
-    {
-      "name": "AmityEventSortOption",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 25
-    },
-    {
-      "name": "AmityEventOrderOption",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/event.ts",
-      "line": 30
-    },
-    {
-      "name": "AmitySharableContentType",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/sharableContentType.ts",
-      "line": 3
-    },
-    {
-      "name": "AnalyticsSourceTypeEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/product.ts",
-      "line": 3
-    },
-    {
-      "name": "UserNotificationModuleNameEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/notificationSettings.ts",
-      "line": 1
-    },
-    {
-      "name": "CommunityNotificationEventNameEnum",
-      "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/notificationSettings.ts",
+      "name": "MembershipAcceptanceTypeEnum.INVITATION",
+      "kind": "enum_member",
+      "file": "@types/domains/client.ts",
       "line": 7
     },
     {
-      "name": "NotificationSettingsLevelEnum",
+      "name": "MembershipAcceptanceTypeEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/notificationSettings.ts",
-      "line": 19
+      "file": "@types/domains/client.ts",
+      "line": 5
+    },
+    {
+      "name": "NotificationRolesFilterTypeEnum.ALL",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 29
+    },
+    {
+      "name": "NotificationRolesFilterTypeEnum.ONLY",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 30
     },
     {
       "name": "NotificationRolesFilterTypeEnum",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/@types/domains/notificationSettings.ts",
+      "file": "@types/domains/notificationSettings.ts",
       "line": 28
     },
     {
-      "name": "VERSION",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/version.ts",
-      "line": 10
+      "name": "NotificationSettingsLevelEnum.CHANNEL",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 22
     },
     {
-      "name": "createQuery",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/query.ts",
-      "line": 94
-    },
-    {
-      "name": "queryOptions",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/query.ts",
-      "line": 112
-    },
-    {
-      "name": "runQuery",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/query.ts",
-      "line": 163
-    },
-    {
-      "name": "filterByStringComparePartially",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/filtering.ts",
-      "line": 26
-    },
-    {
-      "name": "filterByPropInclusion",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/filtering.ts",
-      "line": 40
-    },
-    {
-      "name": "filterByPropIntersection",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/filtering.ts",
-      "line": 46
-    },
-    {
-      "name": "sortByDisplayName",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 10
-    },
-    {
-      "name": "sortByName",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
+      "name": "NotificationSettingsLevelEnum.COMMUNITY",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
       "line": 21
     },
     {
-      "name": "sortByChannelSegment",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 29
+      "name": "NotificationSettingsLevelEnum.USER",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 20
     },
     {
-      "name": "sortBySegmentNumber",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 37
+      "name": "NotificationSettingsLevelEnum",
+      "kind": "enum",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 19
     },
     {
-      "name": "sortByFirstCreated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 45
+      "name": "SearchUsersByEnum.DISPLAY_NAME",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 10
     },
     {
-      "name": "sortByLocalSortingDate",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 53
+      "name": "SearchUsersByEnum.PROFILE_HANDLE",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 11
     },
     {
-      "name": "sortByLastCreated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 61
+      "name": "SearchUsersByEnum.USER_ID",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 12
     },
     {
-      "name": "sortByFirstUpdated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 70
+      "name": "SearchUsersByEnum",
+      "kind": "enum",
+      "file": "@types/domains/user.ts",
+      "line": 9
     },
     {
-      "name": "sortByLastUpdated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 79
+      "name": "SubscriptionLevels.COMMENT",
+      "kind": "enum_member",
+      "file": "core/subscription.ts",
+      "line": 10
     },
     {
-      "name": "sortByLastActivity",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 87
+      "name": "SubscriptionLevels.COMMUNITY",
+      "kind": "enum_member",
+      "file": "core/subscription.ts",
+      "line": 8
     },
     {
-      "name": "filterByUntilAt",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 98
+      "name": "SubscriptionLevels.POST",
+      "kind": "enum_member",
+      "file": "core/subscription.ts",
+      "line": 9
     },
     {
-      "name": "validateUntilAt",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 119
+      "name": "SubscriptionLevels.POST_AND_COMMENT",
+      "kind": "enum_member",
+      "file": "core/subscription.ts",
+      "line": 11
     },
     {
-      "name": "exceedsUntilAtBoundary",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/query/sorting.ts",
-      "line": 139
+      "name": "SubscriptionLevels.USER",
+      "kind": "enum_member",
+      "file": "core/subscription.ts",
+      "line": 12
     },
     {
       "name": "SubscriptionLevels",
       "kind": "enum",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
+      "file": "core/subscription.ts",
       "line": 7
     },
     {
-      "name": "getNetworkId",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 31
+      "name": "UserNotificationModuleNameEnum.CHAT",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 2
     },
     {
-      "name": "getCommunityTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 33
+      "name": "UserNotificationModuleNameEnum.SOCIAL",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 3
     },
     {
-      "name": "getUserTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 38
+      "name": "UserNotificationModuleNameEnum.VIDEO_STREAMING",
+      "kind": "enum_member",
+      "file": "@types/domains/notificationSettings.ts",
+      "line": 4
     },
     {
-      "name": "getPostTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 47
-    },
-    {
-      "name": "getCommentTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 59
-    },
-    {
-      "name": "getStoryTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 64
-    },
-    {
-      "name": "getCommunityStoriesTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 74
-    },
-    {
-      "name": "getMyFollowersTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 82
-    },
-    {
-      "name": "getMyFollowingsTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 88
-    },
-    {
-      "name": "getChannelTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 94
-    },
-    {
-      "name": "getSubChannelTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 96
-    },
-    {
-      "name": "getMessageTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 99
-    },
-    {
-      "name": "getMarkedMessageTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 101
-    },
-    {
-      "name": "getMarkerUserFeedTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 110
-    },
-    {
-      "name": "getLiveStreamTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 158
-    },
-    {
-      "name": "getLiveReactionTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 164
-    },
-    {
-      "name": "getRoomWatcherTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 168
-    },
-    {
-      "name": "getRoomStreamerTopic",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 173
-    },
-    {
-      "name": "subscribeTopic",
-      "kind": "function",
-      "file": "AmityTypescriptSDK/packages/sdk/src/core/subscription.ts",
-      "line": 182
-    },
-    {
-      "name": "enableCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/enableCache.ts",
-      "line": 19
-    },
-    {
-      "name": "disableCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/disableCache.ts",
-      "line": 14
-    },
-    {
-      "name": "restoreCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/restoreCache.ts",
-      "line": 23
-    },
-    {
-      "name": "backupCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/backupCache.ts",
-      "line": 25
-    },
-    {
-      "name": "wipeCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/wipeCache.ts",
-      "line": 22
-    },
-    {
-      "name": "queryCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/queryCache.ts",
-      "line": 20
-    },
-    {
-      "name": "pullFromCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/pullFromCache.ts",
-      "line": 20
-    },
-    {
-      "name": "pushToCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/pushToCache.ts",
-      "line": 20
-    },
-    {
-      "name": "mergeInCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/mergeInCache.ts",
-      "line": 25
-    },
-    {
-      "name": "dropFromCache",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/cache/api/dropFromCache.ts",
-      "line": 19
-    },
-    {
-      "name": "API_REGIONS",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/client/utils/endpoints.ts",
+      "name": "UserNotificationModuleNameEnum",
+      "kind": "enum",
+      "file": "@types/domains/notificationSettings.ts",
       "line": 1
     },
     {
-      "name": "queryRoles",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/role/api/queryRoles.ts",
-      "line": 21
+      "name": "UserTypeEnum.BOT",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 6
     },
     {
-      "name": "getRole",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/role/api/getRole.ts",
-      "line": 20
+      "name": "UserTypeEnum.SIGNED_IN",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 4
     },
     {
-      "name": "createReport",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/report/api/createReport.ts",
-      "line": 107
+      "name": "UserTypeEnum.VISITOR",
+      "kind": "enum_member",
+      "file": "@types/domains/user.ts",
+      "line": 5
     },
     {
-      "name": "deleteReport",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/report/api/deleteReport.ts",
-      "line": 108
-    },
-    {
-      "name": "isReportedByMe",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/report/api/isReportedByMe.ts",
-      "line": 78
-    },
-    {
-      "name": "onChannelMarkerFetched",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onChannelMarkerFetched.ts",
-      "line": 19
-    },
-    {
-      "name": "onSubChannelMarkerFetched",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onSubChannelMarkerFetched.ts",
-      "line": 19
-    },
-    {
-      "name": "onSubChannelMarkerUpdated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onSubChannelMarkerUpdated.ts",
-      "line": 19
-    },
-    {
-      "name": "onFeedMarkerFetched",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onFeedlMarkerFetched.ts",
-      "line": 19
-    },
-    {
-      "name": "onFeedMarkerUpdated",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onFeedlMarkerUpdated.ts",
-      "line": 20
-    },
-    {
-      "name": "onUserMarkerFetched",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onUserMarkerFetched.ts",
-      "line": 19
-    },
-    {
-      "name": "onUserMarkerFetchedLegacy",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onUserMarkerFetched.ts",
-      "line": 36
-    },
-    {
-      "name": "onMessageMarkerFetched",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onMessageMarkerFetched.ts",
-      "line": 19
-    },
-    {
-      "name": "onMessageMarked",
-      "kind": "const",
-      "file": "AmityTypescriptSDK/packages/sdk/src/marker/events/onMessageMarked.ts",
-      "line": 23
+      "name": "UserTypeEnum",
+      "kind": "enum",
+      "file": "@types/domains/user.ts",
+      "line": 3
     },
     {
       "name": "AmityAttachmentProductTags",
       "kind": "class",
-      "file": "AmityTypescriptSDK/packages/sdk/src/productRepository/helpers/AttachmentProductTags.ts",
+      "file": "productRepository/helpers/AttachmentProductTags.ts",
       "line": 24
+    },
+    {
+      "name": "API_REGIONS",
+      "kind": "const",
+      "file": "client/utils/endpoints.ts",
+      "line": 1
+    },
+    {
+      "name": "CommunityPostSettingMaps",
+      "kind": "const",
+      "file": "@types/domains/community.ts",
+      "line": 9
+    },
+    {
+      "name": "CommunityPostSettings",
+      "kind": "const",
+      "file": "@types/domains/community.ts",
+      "line": 3
+    },
+    {
+      "name": "ContentFeedType",
+      "kind": "const",
+      "file": "@types/domains/content.ts",
+      "line": 1
+    },
+    {
+      "name": "DefaultCommunityPostSetting",
+      "kind": "const",
+      "file": "@types/domains/community.ts",
+      "line": 24
+    },
+    {
+      "name": "FileType",
+      "kind": "const",
+      "file": "@types/domains/file.ts",
+      "line": 1
+    },
+    {
+      "name": "GET_WATCHER_URLS",
+      "kind": "const",
+      "file": "utils/linkedObject/streamLinkedObject.ts",
+      "line": 5
+    },
+    {
+      "name": "MessageContentType",
+      "kind": "const",
+      "file": "@types/domains/message.ts",
+      "line": 1
+    },
+    {
+      "name": "PostContentType",
+      "kind": "const",
+      "file": "@types/domains/post.ts",
+      "line": 1
+    },
+    {
+      "name": "PostStructureType",
+      "kind": "const",
+      "file": "@types/domains/post.ts",
+      "line": 13
+    },
+    {
+      "name": "sortByChannelSegment",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 29
+    },
+    {
+      "name": "sortByDisplayName",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 10
+    },
+    {
+      "name": "sortByFirstCreated",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 45
+    },
+    {
+      "name": "sortByFirstUpdated",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 70
+    },
+    {
+      "name": "sortByLastActivity",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 87
+    },
+    {
+      "name": "sortByLastCreated",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 61
+    },
+    {
+      "name": "sortByLastUpdated",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 79
+    },
+    {
+      "name": "sortByLocalSortingDate",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 53
+    },
+    {
+      "name": "sortByName",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 21
+    },
+    {
+      "name": "sortBySegmentNumber",
+      "kind": "const",
+      "file": "core/query/sorting.ts",
+      "line": 37
+    },
+    {
+      "name": "VERSION",
+      "kind": "const",
+      "file": "version.ts",
+      "line": 10
+    },
+    {
+      "name": "VideoResolution",
+      "kind": "const",
+      "file": "@types/domains/file.ts",
+      "line": 9
+    },
+    {
+      "name": "VideoSize",
+      "kind": "const",
+      "file": "@types/domains/file.ts",
+      "line": 24
+    },
+    {
+      "name": "VideoTranscodingStatus",
+      "kind": "const",
+      "file": "@types/domains/file.ts",
+      "line": 17
+    },
+    {
+      "name": "backupCache",
+      "kind": "function",
+      "file": "cache/api/backupCache.ts",
+      "line": 25,
+      "signature": {
+        "parameters": [
+          {
+            "name": "storageKey",
+            "type": "string"
+          },
+          {
+            "name": "persistIf",
+            "type": "{}"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
+    },
+    {
+      "name": "createQuery",
+      "kind": "function",
+      "file": "core/query/query.ts",
+      "line": 94,
+      "signature": {
+        "parameters": [
+          {
+            "name": "func",
+            "type": "AsyncFunc<Args, Returned> | OfflineFunc<Args, Returned>"
+          },
+          {
+            "name": "args",
+            "type": "Args"
+          }
+        ],
+        "returns": "{}"
+      }
+    },
+    {
+      "name": "createReport",
+      "kind": "function",
+      "file": "report/api/createReport.ts",
+      "line": 107,
+      "signature": {
+        "parameters": [
+          {
+            "name": "referenceType",
+            "type": "'post' | 'message' | 'user' | 'comment'"
+          },
+          {
+            "name": "referenceId",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
+    },
+    {
+      "name": "deleteReport",
+      "kind": "function",
+      "file": "report/api/deleteReport.ts",
+      "line": 108,
+      "signature": {
+        "parameters": [
+          {
+            "name": "referenceType",
+            "type": "'post' | 'message' | 'user' | 'comment'"
+          },
+          {
+            "name": "referenceId",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
+    },
+    {
+      "name": "disableCache",
+      "kind": "function",
+      "file": "cache/api/disableCache.ts",
+      "line": 14
+    },
+    {
+      "name": "dropFromCache",
+      "kind": "function",
+      "file": "cache/api/dropFromCache.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "key",
+            "type": "CacheKey"
+          },
+          {
+            "name": "exact",
+            "type": "boolean"
+          }
+        ],
+        "returns": "boolean"
+      }
+    },
+    {
+      "name": "enableCache",
+      "kind": "function",
+      "file": "cache/api/enableCache.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "prevState",
+            "type": "Record<string, CacheEntry<unknown>>"
+          },
+          {
+            "name": "persistIf",
+            "type": "{}",
+            "optional": true
+          }
+        ],
+        "returns": "void"
+      }
+    },
+    {
+      "name": "exceedsUntilAtBoundary",
+      "kind": "function",
+      "file": "core/query/sorting.ts",
+      "line": 139,
+      "signature": {
+        "parameters": [
+          {
+            "name": "createdAt",
+            "type": "string | number | Date"
+          },
+          {
+            "name": "untilAt",
+            "type": "string | number | Date"
+          },
+          {
+            "name": "sortBy",
+            "type": "'lastCreated' | 'firstCreated'"
+          }
+        ],
+        "returns": "boolean"
+      }
+    },
+    {
+      "name": "filterByPropInclusion",
+      "kind": "function",
+      "file": "core/query/filtering.ts",
+      "line": 41,
+      "signature": {
+        "parameters": [
+          {
+            "name": "collection",
+            "type": "T[]"
+          },
+          {
+            "name": "key",
+            "type": "typeOperator"
+          },
+          {
+            "name": "value",
+            "type": "any[] | undefined"
+          }
+        ],
+        "returns": "T[]"
+      }
+    },
+    {
+      "name": "filterByPropIntersection",
+      "kind": "function",
+      "file": "core/query/filtering.ts",
+      "line": 47,
+      "signature": {
+        "parameters": [
+          {
+            "name": "collection",
+            "type": "T[]"
+          },
+          {
+            "name": "key",
+            "type": "typeOperator"
+          },
+          {
+            "name": "values",
+            "type": "any[] | undefined"
+          }
+        ],
+        "returns": "T[]"
+      }
+    },
+    {
+      "name": "filterByStringComparePartially",
+      "kind": "function",
+      "file": "core/query/filtering.ts",
+      "line": 27,
+      "signature": {
+        "parameters": [
+          {
+            "name": "collection",
+            "type": "T[]"
+          },
+          {
+            "name": "key",
+            "type": "typeOperator"
+          },
+          {
+            "name": "value",
+            "type": "any"
+          }
+        ],
+        "returns": "T[]"
+      }
+    },
+    {
+      "name": "filterByUntilAt",
+      "kind": "function",
+      "file": "core/query/sorting.ts",
+      "line": 98,
+      "signature": {
+        "parameters": [
+          {
+            "name": "items",
+            "type": "T[]"
+          },
+          {
+            "name": "untilAt",
+            "type": "string | number | Date"
+          },
+          {
+            "name": "sortBy",
+            "type": "'lastCreated' | 'firstCreated'"
+          }
+        ],
+        "returns": "T[]"
+      }
+    },
+    {
+      "name": "getChannelTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 94,
+      "signature": {
+        "parameters": [
+          {
+            "name": "channel",
+            "type": "Subscribable"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getCommentTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 59,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Subscribable"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getCommunityStoriesTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 74,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Pick<Amity.Story, 'targetId' | 'targetType'>"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getCommunityTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 33,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Subscribable"
+          },
+          {
+            "name": "level",
+            "type": "COMMUNITY | POST | COMMENT | POST_AND_COMMENT"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getLiveReactionTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 164,
+      "signature": {
+        "parameters": [
+          {
+            "name": "post",
+            "type": "Post"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getLiveStreamTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 158,
+      "signature": {
+        "parameters": [],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getMarkedMessageTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 101,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Pick<Amity.SubChannel, 'channelId' | 'subChannelId'>"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getMarkerUserFeedTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 110,
+      "signature": {
+        "parameters": [],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getMessageTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 99,
+      "signature": {
+        "parameters": [
+          {
+            "name": "message",
+            "type": "Subscribable"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getMyFollowersTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 82,
+      "signature": {
+        "parameters": [],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getMyFollowingsTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 88,
+      "signature": {
+        "parameters": [],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getNetworkId",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 31,
+      "signature": {
+        "parameters": [
+          {
+            "name": "user",
+            "type": "{}"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getPostTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 47,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Subscribable"
+          },
+          {
+            "name": "level",
+            "type": "POST | COMMENT"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getRole",
+      "kind": "function",
+      "file": "role/api/getRole.ts",
+      "line": 20,
+      "signature": {
+        "parameters": [
+          {
+            "name": "roleId",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<Cached<Role>>"
+      }
+    },
+    {
+      "name": "getRoomStreamerTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 173,
+      "signature": {
+        "parameters": [
+          {
+            "name": "room",
+            "type": "Room"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getRoomWatcherTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 168,
+      "signature": {
+        "parameters": [
+          {
+            "name": "room",
+            "type": "Room"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getStoryTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 64,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Pick<Amity.Story, 'targetId' | 'targetType' | 'storyId'>"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getSubChannelTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 96,
+      "signature": {
+        "parameters": [
+          {
+            "name": "subChannel",
+            "type": "Subscribable"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "getUserTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 38,
+      "signature": {
+        "parameters": [
+          {
+            "name": "__namedParameters",
+            "type": "Subscribable"
+          },
+          {
+            "name": "level",
+            "type": "POST | COMMENT | POST_AND_COMMENT | USER"
+          }
+        ],
+        "returns": "string"
+      }
+    },
+    {
+      "name": "isReportedByMe",
+      "kind": "function",
+      "file": "report/api/isReportedByMe.ts",
+      "line": 78,
+      "signature": {
+        "parameters": [
+          {
+            "name": "referenceType",
+            "type": "'post' | 'message' | 'user' | 'comment'"
+          },
+          {
+            "name": "referenceId",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
+    },
+    {
+      "name": "mergeInCache",
+      "kind": "function",
+      "file": "cache/api/mergeInCache.ts",
+      "line": 25,
+      "signature": {
+        "parameters": [
+          {
+            "name": "key",
+            "type": "CacheKey"
+          },
+          {
+            "name": "mutation",
+            "type": "Partial<T> | {}"
+          },
+          {
+            "name": "options",
+            "type": "CacheOptions",
+            "optional": true
+          }
+        ],
+        "returns": "boolean"
+      }
+    },
+    {
+      "name": "onChannelMarkerFetched",
+      "kind": "function",
+      "file": "marker/events/onChannelMarkerFetched.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<ChannelMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onFeedMarkerFetched",
+      "kind": "function",
+      "file": "marker/events/onFeedlMarkerFetched.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<FeedMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onFeedMarkerUpdated",
+      "kind": "function",
+      "file": "marker/events/onFeedlMarkerUpdated.ts",
+      "line": 20,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<FeedMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onMessageMarked",
+      "kind": "function",
+      "file": "marker/events/onMessageMarked.ts",
+      "line": 23,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<MessageMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onMessageMarkerFetched",
+      "kind": "function",
+      "file": "marker/events/onMessageMarkerFetched.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<MessageMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onSubChannelMarkerFetched",
+      "kind": "function",
+      "file": "marker/events/onSubChannelMarkerFetched.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<SubChannelMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onSubChannelMarkerUpdated",
+      "kind": "function",
+      "file": "marker/events/onSubChannelMarkerUpdated.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<SubChannelMarker[]>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onUserMarkerFetched",
+      "kind": "function",
+      "file": "marker/events/onUserMarkerFetched.ts",
+      "line": 19,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<UserMarker[]>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "onUserMarkerFetchedLegacy",
+      "kind": "function",
+      "file": "marker/events/onUserMarkerFetched.ts",
+      "line": 36,
+      "signature": {
+        "parameters": [
+          {
+            "name": "callback",
+            "type": "Listener<UserMarker>"
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "pullFromCache",
+      "kind": "function",
+      "file": "cache/api/pullFromCache.ts",
+      "line": 20,
+      "signature": {
+        "parameters": [
+          {
+            "name": "key",
+            "type": "CacheKey"
+          }
+        ],
+        "returns": "CacheEntry<T> | undefined"
+      }
+    },
+    {
+      "name": "pushToCache",
+      "kind": "function",
+      "file": "cache/api/pushToCache.ts",
+      "line": 20,
+      "signature": {
+        "parameters": [
+          {
+            "name": "key",
+            "type": "CacheKey"
+          },
+          {
+            "name": "data",
+            "type": "unknown"
+          },
+          {
+            "name": "options",
+            "type": "CacheOptions"
+          }
+        ],
+        "returns": "boolean"
+      }
+    },
+    {
+      "name": "queryCache",
+      "kind": "function",
+      "file": "cache/api/queryCache.ts",
+      "line": 20,
+      "signature": {
+        "parameters": [
+          {
+            "name": "key",
+            "type": "CacheKey"
+          }
+        ],
+        "returns": "CacheEntry<T>[] | undefined"
+      }
+    },
+    {
+      "name": "queryOptions",
+      "kind": "function",
+      "file": "core/query/query.ts",
+      "line": 112,
+      "signature": {
+        "parameters": [
+          {
+            "name": "policy",
+            "type": "QueryPolicy"
+          },
+          {
+            "name": "lifeSpan",
+            "type": "number"
+          }
+        ],
+        "returns": "QueryOptions"
+      }
+    },
+    {
+      "name": "queryRoles",
+      "kind": "function",
+      "file": "role/api/queryRoles.ts",
+      "line": 21,
+      "signature": {
+        "parameters": [
+          {
+            "name": "query",
+            "type": "{}",
+            "optional": true
+          }
+        ],
+        "returns": "Promise<{} & Pages<Page<number>> & {} & Pagination>"
+      }
+    },
+    {
+      "name": "restoreCache",
+      "kind": "function",
+      "file": "cache/api/restoreCache.ts",
+      "line": 23,
+      "signature": {
+        "parameters": [
+          {
+            "name": "storageKey",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
+    },
+    {
+      "name": "runQuery",
+      "kind": "function",
+      "file": "core/query/query.ts",
+      "line": 163,
+      "signature": {
+        "parameters": [
+          {
+            "name": "query",
+            "type": "Query<Args, Returned>"
+          },
+          {
+            "name": "callback",
+            "type": "{}",
+            "optional": true
+          },
+          {
+            "name": "options",
+            "type": "QueryOptions"
+          }
+        ],
+        "returns": "void"
+      }
+    },
+    {
+      "name": "subscribeTopic",
+      "kind": "function",
+      "file": "core/subscription.ts",
+      "line": 182,
+      "signature": {
+        "parameters": [
+          {
+            "name": "topic",
+            "type": "string"
+          },
+          {
+            "name": "callback",
+            "type": "Listener<void | ASCError, any>",
+            "optional": true
+          }
+        ],
+        "returns": "Unsubscriber"
+      }
+    },
+    {
+      "name": "validateUntilAt",
+      "kind": "function",
+      "file": "core/query/sorting.ts",
+      "line": 119,
+      "signature": {
+        "parameters": [
+          {
+            "name": "untilAt",
+            "type": "string"
+          }
+        ],
+        "returns": "string | undefined"
+      }
+    },
+    {
+      "name": "wipeCache",
+      "kind": "function",
+      "file": "cache/api/wipeCache.ts",
+      "line": 22,
+      "signature": {
+        "parameters": [
+          {
+            "name": "storageKey",
+            "type": "string"
+          }
+        ],
+        "returns": "Promise<boolean>"
+      }
     }
-  ],
-  "unhandled": [
-    "named export not found: getActiveClient from /Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK/packages/sdk/src/client/api/activeClient.ts",
-    "named export not found: getSubChannelByIds from /Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK/packages/sdk/src/subChannelRepository/api/getSubChannels.ts",
-    "named export not found: getCommunityByIds from /Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK/packages/sdk/src/communityRepository/api/getCommunities.ts",
-    "named export not found at barrel: GET_WATCHER_URLS from /Users/admin/Documents/GitHub/sp-sdks/AmityTypescriptSDK/packages/sdk/src/utils/linkedObject/streamLinkedObject.ts"
   ],
   "stats": {
     "namespaces": 25,
     "sub_namespaces_total": 5,
-    "namespaced_members_total": 1361,
-    "amity_global_members": 977,
-    "amity_enum_cases_total": 257,
-    "root_exports": 106,
-    "unhandled_lines": 4
+    "namespaced_members_total": 1393,
+    "amity_global_members": 990,
+    "amity_enum_cases_total": 258,
+    "root_exports": 213
   }
 }


### PR DESCRIPTION
Re-extracts all four platform SDK surfaces against the current sources (TS 7.23.0, Android 7.23.0, iOS 8.3.0, Flutter 7.8.6), capturing the July release: **channel archiving, message search, For-You feed, notification settings/modes**. Purely additive on TS/Android (0 removed); iOS removals are superset-overload signature evolution; Flutter net-neutral.

**Extractor fix:** `flutter-hybrid-extractor.py` now selects the `amity_sdk` package library for `sdk_product` instead of `lib_entries[0]`, which had become the incidental `access_token_renewal` part-library (wrong provenance label).

iOS was extracted from a freshly built 8.3.0 xcframework device slice (the vendored xcframework is git-ignored, unchanged here).

Consumed downstream by the Vise `sdk-surface:import` (social-plus-forge#163), which grounds `vise sdk-facts` and the symbol-anchored rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)