### PR TITLE
docs(vise): add preview-release notice

### DIFF
--- a/ai-mcp/vise/overview.mdx
+++ b/ai-mcp/vise/overview.mdx
@@ -1,11 +1,16 @@
 ---
 title: "Vise"
 description: "Use the local Vise CLI to guide and validate AI-assisted social.plus SDK integrations."
+tag: "Preview"
 ---
 
 Vise is a local command-line tool for teams using AI coding agents to integrate social.plus SDKs. It gives the agent a repeatable workflow, grounds the plan in the public docs, writes a local compliance contract, and checks the implementation before you call it done.
 
 The agent still writes the code. Vise wraps that work in guardrails: it grounds the agent in real SDK APIs, checks correctness and completeness, helps align generated UI with your design system, and asks you the calls only a human should make — then keeps checking until the result is green, attested with evidence, intentionally scoped out, or explicitly blocked on your decision.
+
+<Warning>
+  **Preview release.** Vise is usable for guided social.plus SDK integrations, but its CLI surface, evidence format, and advisory intelligence may still change as it hardens through more real projects. Treat it as governed AI assistance with strong validation gates — not a substitute for code review, product QA, or runtime verification.
+</Warning>
 
 <Info>
   Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69683,6 +69683,8 @@ Vise is a local command-line tool for teams using AI coding agents to integrate 
 
 The agent still writes the code. Vise wraps that work in guardrails: it grounds the agent in real SDK APIs, checks correctness and completeness, helps align generated UI with your design system, and asks you the calls only a human should make — then keeps checking until the result is green, attested with evidence, intentionally scoped out, or explicitly blocked on your decision.
 
+  **Preview release.** Vise is usable for guided social.plus SDK integrations, but its CLI surface, evidence format, and advisory intelligence may still change as it hardens through more real projects. Treat it as governed AI assistance with strong validation gates — not a substitute for code review, product QA, or runtime verification.
+
   Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
 
 ## Vise vs. the docs MCP server


### PR DESCRIPTION
Marks the Vise docs as a **preview release**, matching the README's preview framing.

- **Preview callout** at the top of `ai-mcp/vise/overview` (adapted from the README blockquote — drops the benchmark reference, which isn't in the public docs): notes the CLI surface / evidence format / advisory intelligence may still change, and that Vise isn't a substitute for code review, product QA, or runtime verification.
- **`tag: "Preview"`** frontmatter on the overview (sidebar badge equivalent of the README's Preview status badge).
- Regenerated `llms-full.txt`.

Follow-up to #273. The **Mintlify Deployment** check is the authoritative render validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)