### PR TITLE
docs(vise): sync CLI reference + how-it-works with the day-2/engagement release

### DIFF
--- a/ai-mcp/vise/cli-reference.mdx
+++ b/ai-mcp/vise/cli-reference.mdx
@@ -16,7 +16,7 @@ This page covers the commands most integrations use. For the complete list and e
 | `vise explore "<request>"` | Map a request to what social.plus offers — no project or API key needed |
 | `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, and available sensors |
 | `vise plan [path] --request "..."` | Grounded implementation plan with intake questions and docs citations (`--summary` for a compact view) |
-| `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered |
+| `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered. Initializing a different outcome records the previous engagement to `sp-vise/engagements/` first; replacing a **green** engagement asks for `--supersede-engagement` |
 
 For broad requests that span several surfaces (feed + chat + profile), Vise sequences them:
 
@@ -32,10 +32,12 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | --- | --- |
 | `vise check [path]` | Validate the code against the recorded contract |
 | `vise check [path] --ci` | Read-only; exits non-zero unless green |
-| `vise check [path] --new-only` | Gate only on findings introduced since the baseline |
+| `vise check [path] --new-only` | Gate only on *rule findings* introduced since the baseline — the outcome's completeness checklist and selected capabilities always gate (they are the engagement's deliverables) |
 | `vise check [path] --allow-proof-waiver` | Accept an honest `runtime-proof-waived` result as passing |
+| `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
+| `vise check [path] --all-engagements` | The normal check plus re-verification of every recorded engagement; exit `11` means your current work is green but a previously finished surface drifted |
 | `vise validate [path]` | Run the deterministic validators only (no attestation comparison) |
-| `vise status [path]` | Summarize the current compliance state |
+| `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
 See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) for what each state means.
@@ -44,7 +46,7 @@ See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) f
 
 | Command | Purpose |
 | --- | --- |
-| `vise baseline [path]` | Snapshot pre-existing findings so `--new-only` can ignore them |
+| `vise baseline [path]` | Snapshot pre-existing rule findings so `--new-only` can exclude them. Record it right after `vise init`, before writing code; the feature you asked for is never baselined — it still has to be built |
 | `vise attest [path] --rule <id> --signer host-agent --confidence high --evidence-file evidence.json --rationale "..."` | Record that a rule is satisfied through architecture the check can't see |
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke [path] --log <file>` | Assess a captured mount-smoke log into a pass/fail verdict |

--- a/ai-mcp/vise/how-it-works.mdx
+++ b/ai-mcp/vise/how-it-works.mdx
@@ -58,6 +58,7 @@ Deterministic SDK correctness and explicit completeness decisions are the checks
 | `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
 | `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
+| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--all-engagements` only, exit `11`) | Re-open the drifted surface or re-attest what changed |
 
 Add `--ci` for a read-only run that exits non-zero unless the result is green.
 
@@ -83,15 +84,29 @@ vise smoke . --log run.log                          # assess a captured smoke lo
 vise smoke waive . --reason "no emulator in CI" --mode deviceless
 ```
 
+## Adding features to an app that already uses social.plus
+
+The second feature is governed as carefully as the first. Two situations:
+
+**The existing integration was built by hand.** Run `vise init` for the new request as normal. If the repo carries pre-existing findings, the init result includes a `brownfield` hint: record `vise baseline .` **before writing any code**, then gate your work with `vise check --new-only`. The baseline excludes legacy rule findings only — the feature you asked for still has to be built, and its completeness checklist still gates.
+
+**The existing features were built through Vise.** The sidecar governs one engagement at a time, but switching is recorded, not destructive: initializing a new outcome writes the previous engagement's final state to `sp-vise/engagements/` and discloses the switch in the result; replacing a **green** engagement additionally asks for `--supersede-engagement`. Finished surfaces stay visible in `vise status` under `previousEngagements`, and stay verifiable:
+
+```sh
+vise check --engagement <outcome>   # re-verify one finished surface (exit 11 on drift)
+vise check --all-engagements        # current work + every finished surface, in one run
+```
+
 ## Add Vise to CI
 
 After the first successful integration, commit `sp-vise/` and run Vise in CI:
 
 ```sh
 vise check --ci                # read-only; non-zero unless green
+vise check --all-engagements   # optional: also hold every previously finished surface green (exit 11 on drift)
 ```
 
-Use `vise baseline` to snapshot pre-existing findings, then `vise check --new-only` to gate only on findings introduced since — useful when adopting Vise on an existing codebase.
+When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
 
 ## Related
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69816,6 +69816,7 @@ Deterministic SDK correctness and explicit completeness decisions are the checks
 | `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
 | `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
+| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--all-engagements` only, exit `11`) | Re-open the drifted surface or re-attest what changed |
 
 Add `--ci` for a read-only run that exits non-zero unless the result is green.
 
@@ -69841,15 +69842,29 @@ vise smoke . --log run.log                          # assess a captured smoke lo
 vise smoke waive . --reason "no emulator in CI" --mode deviceless
 ```
 
+## Adding features to an app that already uses social.plus
+
+The second feature is governed as carefully as the first. Two situations:
+
+**The existing integration was built by hand.** Run `vise init` for the new request as normal. If the repo carries pre-existing findings, the init result includes a `brownfield` hint: record `vise baseline .` **before writing any code**, then gate your work with `vise check --new-only`. The baseline excludes legacy rule findings only — the feature you asked for still has to be built, and its completeness checklist still gates.
+
+**The existing features were built through Vise.** The sidecar governs one engagement at a time, but switching is recorded, not destructive: initializing a new outcome writes the previous engagement's final state to `sp-vise/engagements/` and discloses the switch in the result; replacing a **green** engagement additionally asks for `--supersede-engagement`. Finished surfaces stay visible in `vise status` under `previousEngagements`, and stay verifiable:
+
+```sh
+vise check --engagement <outcome>   # re-verify one finished surface (exit 11 on drift)
+vise check --all-engagements        # current work + every finished surface, in one run
+```
+
 ## Add Vise to CI
 
 After the first successful integration, commit `sp-vise/` and run Vise in CI:
 
 ```sh
 vise check --ci                # read-only; non-zero unless green
+vise check --all-engagements   # optional: also hold every previously finished surface green (exit 11 on drift)
 ```
 
-Use `vise baseline` to snapshot pre-existing findings, then `vise check --new-only` to gate only on findings introduced since — useful when adopting Vise on an existing codebase.
+When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
 
 ## Related
 
@@ -69982,7 +69997,7 @@ This page covers the commands most integrations use. For the complete list and e
 | `vise explore "<request>"` | Map a request to what social.plus offers — no project or API key needed |
 | `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, and available sensors |
 | `vise plan [path] --request "..."` | Grounded implementation plan with intake questions and docs citations (`--summary` for a compact view) |
-| `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered |
+| `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered. Initializing a different outcome records the previous engagement to `sp-vise/engagements/` first; replacing a **green** engagement asks for `--supersede-engagement` |
 
 For broad requests that span several surfaces (feed + chat + profile), Vise sequences them:
 
@@ -69998,10 +70013,12 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | --- | --- |
 | `vise check [path]` | Validate the code against the recorded contract |
 | `vise check [path] --ci` | Read-only; exits non-zero unless green |
-| `vise check [path] --new-only` | Gate only on findings introduced since the baseline |
+| `vise check [path] --new-only` | Gate only on *rule findings* introduced since the baseline — the outcome's completeness checklist and selected capabilities always gate (they are the engagement's deliverables) |
 | `vise check [path] --allow-proof-waiver` | Accept an honest `runtime-proof-waived` result as passing |
+| `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
+| `vise check [path] --all-engagements` | The normal check plus re-verification of every recorded engagement; exit `11` means your current work is green but a previously finished surface drifted |
 | `vise validate [path]` | Run the deterministic validators only (no attestation comparison) |
-| `vise status [path]` | Summarize the current compliance state |
+| `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
 See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) for what each state means.
@@ -70010,7 +70027,7 @@ See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) f
 
 | Command | Purpose |
 | --- | --- |
-| `vise baseline [path]` | Snapshot pre-existing findings so `--new-only` can ignore them |
+| `vise baseline [path]` | Snapshot pre-existing rule findings so `--new-only` can exclude them. Record it right after `vise init`, before writing code; the feature you asked for is never baselined — it still has to be built |
 | `vise attest [path] --rule <id> --signer host-agent --confidence high --evidence-file evidence.json --rationale "..."` | Record that a rule is satisfied through architecture the check can't see |
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke [path] --log <file>` | Assess a captured mount-smoke log into a pass/fail verdict |


### PR DESCRIPTION
Syncs the public Vise pages with the CLI surface shipped in social-plus-forge #176–#180 (day-2 brownfield governance + engagement ledger/re-verification). Written before those landed, the pages were missing the new flags and — more importantly — described the old baseline semantics, which could read as "baselining defers the feature checklist" (exactly the misunderstanding the release removed).

- `cli-reference.mdx`: `--engagement` / `--all-engagements` rows (exit 11), corrected `--new-only` + `baseline` semantics, `init` outcome-switch/supersede note, `status` previousEngagements.
- `how-it-works.mdx`: `engagement-drift` in the check-result table; new "Adding features to an app that already uses social.plus" section covering both the hand-rolled and prior-Vise-engagement flows; CI section gains the `--all-engagements` option.

Wording kept consistent with the shipped README/skill. llms.txt regeneration is handled by the existing workflow. Launch-relevant: the GTM announcement points readers at these pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)