### PR TITLE
docs: create event noti

### DIFF
--- a/social-plus-sdk/social/discovery-engagement/notifications/notification-events-reference.mdx
+++ b/social-plus-sdk/social/discovery-engagement/notifications/notification-events-reference.mdx
@@ -34,6 +34,7 @@ The TypeScript SDK type surface defines these action values. iOS and Android exp
 | `reply` | Reply-related notification |
 | `join_request` | Join-request-related notification |
 | `user` | User-related notification |
+| `event` | Event-related notification (routes to the event detail page) |
 
 ## Tray Item Categories
 
@@ -61,6 +62,7 @@ The TypeScript SDK type surface defines these category values. iOS and Android e
 - Use `targetType` and `targetId` for the primary destination.
 - Use `referenceType` and `referenceId` when your UI needs to highlight a related post, comment, event, or other referenced object.
 - Use `rootId` and `latestCommentId` when they are present and your comment UI needs to open a thread context.
+- For `actionType == "event"` items, resolve the event id from `actionReferenceId` and route to the event detail page. When `trayItemCategory == "event_created"`, the hydrated `event` object (including `event.targetCommunity`) is available on the item for rendering the community avatar, event-type chip (`In-person` / `Virtual` from `event.type`), and event start date/time (from `event.startTime`).
 - Prefer the returned `text` or `templatedText` for display copy instead of rebuilding notification copy in the client.
 
 ## Related Documentation

--- a/uikit/components/social/content-discovery.mdx
+++ b/uikit/components/social/content-discovery.mdx
@@ -847,6 +847,17 @@ The Content Discovery & Search UIKit provides comprehensive components for build
 
     The Notification Tray automatically creates and groups notification records for each user, ensuring they stay informed about relevant activities within their communities and encouraging deeper platform engagement.
 
+    #### Event Creation Item
+
+    When a moderator creates an event in a community, active members receive an **Event Creation** tray item (audience: public communities → whole network; private communities → community members only). The item is rendered as a dedicated variant:
+
+    - **Leading avatar:** the community avatar (from the event's hydrated `targetCommunity`).
+    - **Primary line:** `{{CommunityName}} has event {{EventName}}` with community name and event name bolded via `templatedText`.
+    - **Context row:** an event-type chip (`In-person` / `Virtual`, derived from `event.type`) followed by the event start date and start time (formatted client-side from `event.startTime`).
+    - **Tap:** marks the item seen and navigates via `goToEventDetailPage(eventId)` — the event id resolves from the item's `actionReferenceId`.
+
+    Detection keys: `actionType == "event"` and `trayItemCategory == "event_created"`. Other `event` categories (`event_reminder`, `event_started`) continue to render as generic tray items.
+
     ### Code Examples
 
     <CodeGroup>
@@ -899,10 +910,12 @@ The Content Discovery & Search UIKit provides comprehensive components for build
     | `notification_tray_page/*/title` | Element | You can customize text |
     | `notification_tray_page/*/empty_notification` | Element | You can customize image and text |
     | `notification_tray_page/*/no_internet_connection` | Element | You can customize image and text |
+    | `notification_tray_page/*/event_notification_item` | ListItem | Customize the Event Creation tray item |
+    | `notification_tray_page/*/event_type_badge` | Element | Customize the event-type chip (`In-person` / `Virtual`) |
 
     ### Navigation Behavior
 
-    The behavior can be customized to handle navigation to post detail and community profile pages differently.
+    The behavior can be customized to handle navigation to post detail, community profile, user profile, and event detail pages differently.
 
     <CodeGroup>
     ```swift iOS
@@ -918,6 +931,10 @@ The Content Discovery & Search UIKit provides comprehensive components for build
         
         override func goToCommunityProfilePage(context: AmityNotificationTrayPageBehavior.Context) {
             // Custom implementation
+        }
+
+        override func goToEventDetailPage(context: AmityNotificationTrayPageBehavior.Context) {
+            // Custom implementation — invoked when the user taps an Event Creation item
         }
     }
 
@@ -943,6 +960,13 @@ The Content Discovery & Search UIKit provides comprehensive components for build
             communityId: String,
         ) {
             super.goToCommunityProfilePage(context, communityId)
+        }
+
+        override fun goToEventDetailPage(
+            context: Context,
+            eventId: String,
+        ) {
+            super.goToEventDetailPage(context, eventId)
         }
 
     }
@@ -976,6 +1000,9 @@ The Content Discovery & Search UIKit provides comprehensive components for build
               },
               goToUserProfilePage: ({ userId }) => {
                 console.log('goToUserProfilePage', userId);
+              },
+              goToEventDetailPage: ({ eventId }) => {
+                console.log('goToEventDetailPage', eventId);
               },
             },
           }}


### PR DESCRIPTION
Epic : https://socialplus.atlassian.net/browse/PDT-3421

Path to check
- /uikit/components/social/content-discovery — Notification Tray tab (Event Creation Item section)
- /social-plus-sdk/social/discovery-engagement/notifications/notification-events-reference