### PR TITLE
docs(vise): add 1.8 onboarding and CI guidance

### DIFF
--- a/ai-mcp/vise/brownfield-day2.mdx
+++ b/ai-mcp/vise/brownfield-day2.mdx
@@ -1,0 +1,68 @@
+---
+title: "Brownfield and day-2 path"
+description: "Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable."
+---
+
+Vise supports both apps that adopted social.plus before Vise and apps whose earlier features already have a Vise contract.
+
+## Existing integration built without Vise
+
+Initialize the new feature before editing. If Vise reports pre-existing findings, record a baseline immediately:
+
+```sh
+vise init . --request "Add comments to the existing feed" \
+  --answer comment_target=post \
+  --answer comment_depth="one level of replies" \
+  --answer lifecycle_owner="React component" \
+  --answer target_screen="existing feed detail"
+vise baseline .
+```
+
+Then gate new rule findings with:
+
+```sh
+vise check . --new-only
+```
+
+The baseline excludes legacy rule findings only. The new feature's completeness checklist and selected capabilities still have to pass.
+
+## Existing integration already governed by Vise
+
+Initializing a different outcome records the previous engagement under `sp-vise/engagements/`. Replacing a green engagement requires an explicit acknowledgement:
+
+```sh
+vise init . --request "Add comments to the existing feed" \
+  --supersede-engagement \
+  --answer comment_target=post \
+  --answer comment_depth="one level of replies" \
+  --answer lifecycle_owner="React component" \
+  --answer target_screen="existing feed detail"
+```
+
+Review prior work at any time:
+
+```sh
+vise status .
+vise check . --engagement <outcome>
+vise check . --all-engagements
+```
+
+In CI, one command holds the active and recorded engagements green:
+
+```sh
+vise check . --ci
+```
+
+Exit `11` means the active feature is green but previously completed work drifted.
+
+## Handoff checklist
+
+- State whether a baseline was used and when it was recorded.
+- Identify the active outcome and every recorded previous engagement.
+- Report unresolved non-blocking intake and any scope-omit decisions.
+- Include runtime proof or an explicit waiver for the new user-visible surface.
+- Do not describe a green active engagement as sufficient when `--ci` reports previous-engagement drift.
+
+<Card title="Reading a check result" icon="shield-check" href="/ai-mcp/vise/how-it-works#reading-a-check-result">
+  Understand active failures, proof waivers, contract drift, and engagement drift.
+</Card>

--- a/ai-mcp/vise/cli-reference.mdx
+++ b/ai-mcp/vise/cli-reference.mdx
@@ -14,7 +14,7 @@ This page covers the commands most integrations use. For the complete list and e
 | Command | Purpose |
 | --- | --- |
 | `vise explore "<request>"` | Map a request to what social.plus offers — no project or API key needed |
-| `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, and available sensors |
+| `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, available sensors, and bounded scan coverage. An incomplete scan cannot initialize or produce a green check; select the concrete app surface in a large monorepo |
 | `vise plan [path] --request "..."` | Grounded implementation plan with intake questions and docs citations (`--summary` for a compact view) |
 | `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered. Initializing a different outcome records the previous engagement to `sp-vise/engagements/` first; replacing a **green** engagement asks for `--supersede-engagement` |
 
@@ -31,7 +31,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | Command | Purpose |
 | --- | --- |
 | `vise check [path]` | Validate the code against the recorded contract |
-| `vise check [path] --ci` | Read-only; exits non-zero unless green |
+| `vise check [path] --ci` | Read-only release gate for the active contract and every recorded engagement; exits `11` when active work is green but completed work drifted |
 | `vise check [path] --new-only` | Gate only on *rule findings* introduced since the baseline — the outcome's completeness checklist and selected capabilities always gate (they are the engagement's deliverables) |
 | `vise check [path] --allow-proof-waiver` | Accept an honest `runtime-proof-waived` result as passing |
 | `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
@@ -51,6 +51,12 @@ See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) f
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke [path] --log <file>` | Assess a captured mount-smoke log into a pass/fail verdict |
 | `vise smoke waive [path] --reason "..." --mode declined\|deviceless` | Record an auditable runtime-proof waiver |
+
+## Project sensors
+
+| Command | Purpose |
+| --- | --- |
+| `vise run-sensors [path] [--dry-run] [--include "<sensor name>"]` | Run detected project build, lint, typecheck, test, and SDK-smoke commands. An explicit `--include` must match a detected sensor or the command fails; captured output is bounded, and timed-out sensors terminate their descendant processes |
 
 ## Docs and SDK facts
 

--- a/ai-mcp/vise/evaluate.mdx
+++ b/ai-mcp/vise/evaluate.mdx
@@ -1,0 +1,70 @@
+---
+title: "Evaluate Vise in 15 minutes"
+description: "Inspect a real app and review a grounded Vise plan before using production credentials or changing code."
+---
+
+This evaluation shows how Vise reads an app, identifies the integration surface, and asks for decisions an AI agent should not invent. It deliberately stops before implementation, so you can assess the workflow without production credentials or source changes.
+
+<Info>
+  Vise requires Node.js 20 or newer. Vise itself runs locally and does not upload your source code, file contents, or search queries. Your AI coding host follows its own data policy.
+</Info>
+
+## Run the evaluation
+
+Use a clean branch or disposable copy of a real app repository.
+
+<Steps>
+  <Step title="Verify the package">
+    ```sh
+    npx -y -p @amityco/social-plus-vise vise doctor
+    ```
+
+    Confirm that the command reports the installed version and hosted documentation source.
+  </Step>
+  <Step title="Inspect the app">
+    ```sh
+    npx -y -p @amityco/social-plus-vise vise inspect .
+    ```
+
+    Review the detected platform, app surfaces, design signals, sensors, and scan coverage. If the scan is incomplete or several app surfaces are detected, select the concrete app before continuing.
+  </Step>
+  <Step title="Request a compact plan">
+    ```sh
+    npx -y -p @amityco/social-plus-vise vise plan . \
+      --request "Add a social feed to this app" \
+      --summary
+    ```
+
+    A useful plan identifies the implementation path, cites relevant social.plus documentation, and lists unresolved project decisions such as region, route, feed scope, and target source.
+  </Step>
+  <Step title="Review the stopping boundary">
+    Do not invent answers or run `vise init` during this short evaluation. The expected result is a grounded route and a reviewable decision list—not generated code or runtime proof.
+  </Step>
+</Steps>
+
+## What this proves
+
+- The package can run in your environment.
+- Vise recognizes the intended app surface and supported platform.
+- The plan is grounded in social.plus documentation and local project signals.
+- Missing product and integration decisions are explicit instead of silently guessed.
+
+## What this does not prove
+
+- That an SDK or UIKit integration has been implemented.
+- That `vise check`, project sensors, or the app runtime will pass.
+- That the selected social surface works with your tenant data and credentials.
+
+## Choose the next path
+
+<CardGroup cols={3}>
+  <Card title="Custom SDK UI" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
+    Build a differentiated app-owned experience directly on the social.plus SDK.
+  </Card>
+  <Card title="UIKit quick launch" icon="window" href="/ai-mcp/vise/uikit-quickstart">
+    Use prebuilt social.plus UIKit surfaces and the lowest suitable customization level.
+  </Card>
+  <Card title="Brownfield and day 2" icon="rotate" href="/ai-mcp/vise/brownfield-day2">
+    Add a feature to an app that already uses social.plus without losing earlier evidence.
+  </Card>
+</CardGroup>

--- a/ai-mcp/vise/how-it-works.mdx
+++ b/ai-mcp/vise/how-it-works.mdx
@@ -20,7 +20,7 @@ flowchart LR
   F --> G[done: evidence recorded]
 ```
 
-- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors.
+- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors. Inspection includes bounded scan receipts; if a large repository cannot be scanned completely, select the concrete app surface before continuing.
 - **plan** — produce a grounded plan with docs citations and the project-specific questions the agent must not guess.
 - **init** — write the local compliance contract under `sp-vise/` once blocking questions are answered.
 - **implement** — the agent edits your app, grounded in real SDK APIs.
@@ -58,9 +58,9 @@ Deterministic SDK correctness and explicit completeness decisions are the checks
 | `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
 | `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--all-engagements` only, exit `11`) | Re-open the drifted surface or re-attest what changed |
+| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--ci` or `--all-engagements`, exit `11`) | Re-open the drifted surface or re-attest what changed |
 
-Add `--ci` for a read-only run that exits non-zero unless the result is green.
+Add `--ci` for a read-only release gate. It checks the active contract and automatically re-verdicts every recorded engagement, exiting non-zero unless all governed work remains green.
 
 ## Attestation and evidence
 
@@ -102,9 +102,10 @@ vise check --all-engagements        # current work + every finished surface, in 
 After the first successful integration, commit `sp-vise/` and run Vise in CI:
 
 ```sh
-vise check --ci                # read-only; non-zero unless green
-vise check --all-engagements   # optional: also hold every previously finished surface green (exit 11 on drift)
+vise check --ci   # read-only; active contract + every recorded engagement
 ```
+
+Use `--all-engagements` when you want the same combined re-verdict outside CI. It is not an additional command that CI needs to run after `--ci`.
 
 When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
 

--- a/ai-mcp/vise/mcp-server.mdx
+++ b/ai-mcp/vise/mcp-server.mdx
@@ -90,11 +90,11 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 
 | Tool | Mirrors | Purpose |
 | --- | --- | --- |
-| `inspect_project` | `vise inspect` | Detect platform, surfaces, and sensors |
+| `inspect_project` | `vise inspect` | Detect platform, surfaces, sensors, and complete-scan coverage |
 | `plan_integration` | `vise plan` | Grounded plan with docs citations and intake |
 | `init_compliance` | `vise init` | Write the `sp-vise/` contract |
 | `check_compliance` | `vise check` | Validate the code against the contract |
-| `run_sensors` | `vise run-sensors` | Run build, lint, typecheck, and smoke checks |
+| `run_sensors` | `vise run-sensors` | Run detected build, lint, typecheck, and smoke checks; explicitly included sensor names must match |
 | `get_sdk_facts` | `vise sdk-facts` | Read grounded SDK surface facts |
 | `search_docs` / `get_doc_page` | `vise search-docs` / `vise get-doc-page` | Find and read social.plus docs |
 | `debug_issue` | `vise debug` | Diagnose an SDK-specific runtime failure |

--- a/ai-mcp/vise/overview.mdx
+++ b/ai-mcp/vise/overview.mdx
@@ -30,11 +30,15 @@ Use the hosted MCP server when you want an assistant to **find and read document
 ## Who should use Vise
 
 - **Developer using an AI coding agent** — Install the skill, ask for the SDK feature, answer project-specific questions, and let Vise drive the loop through plan, check, and sensors.
-- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result before accepting the integration.
+- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result — including re-verdicts of previously completed engagements — before accepting the integration.
 - **Partner or solutions engineer** — Use Vise as a repeatable delivery workflow across customer apps, so each integration ends with the same local evidence rather than a prompt transcript.
 - **Product or design owner** — Use the advisory design and experience outputs to review whether the generated surface fits the product intent. Correctness and explicit completeness checks remain the gates.
 
 ## Install
+
+<Info>
+  Vise requires Node.js 20 or newer. Run `node --version` before installing if you are unsure which runtime your terminal or CI environment uses.
+</Info>
 
 Install Vise globally:
 
@@ -92,6 +96,9 @@ vise print-skill
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="Evaluate Vise in 15 minutes" icon="stopwatch" href="/ai-mcp/vise/evaluate">
+    Inspect a real app and review a grounded plan before using production credentials or changing code.
+  </Card>
   <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
     The governed loop, what Vise checks, and how to read a check result.
   </Card>

--- a/ai-mcp/vise/sdk-custom-ui.mdx
+++ b/ai-mcp/vise/sdk-custom-ui.mdx
@@ -1,0 +1,44 @@
+---
+title: "Custom SDK UI path"
+description: "Use Vise to govern a differentiated social.plus experience built directly on the SDK."
+---
+
+Choose the SDK path when the app needs a differentiated layout, workflow, or interaction model that should remain owned by the host application.
+
+## Suggested request
+
+```text
+Add a social feed to this app using the social.plus SDK. Keep the UI consistent with the existing design system and ask me for any missing scope, target, route, region, or identity decisions before editing.
+```
+
+## Governed loop
+
+```sh
+vise inspect .
+vise plan . --request "Add a social feed to this app using the social.plus SDK" --summary
+```
+
+Review the plan, then repeat the full `vise plan` and `vise init` commands with one explicit `--answer id=value` flag for every blocking question. Do not place API keys or server-issued tokens in command history or AI chat; use the app's ignored local environment/configuration pattern.
+
+After the agent implements the agreed surface:
+
+```sh
+vise check .
+vise validate .
+vise run-sensors .
+```
+
+For a user-visible handoff, launch the real target and capture runtime-smoke evidence. Static green and passing sensors do not prove that the screen mounted, authenticated, or populated with tenant data.
+
+## Review checklist
+
+- The selected SDK path is explicit.
+- Read and write targets come from route, app state, user selection, SDK discovery, or a create flow—not invented IDs.
+- Loading, empty, error, and data states are implemented.
+- Live collections, cleanup, pagination, session renewal, and user switching follow the platform SDK lifecycle.
+- Scope decisions for post types, composer types, comments, reactions, and moderation are recorded.
+- The final handoff includes remaining advisory findings and unresolved non-blocking decisions.
+
+<Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+  Understand the contract, evidence, runtime-proof boundary, and CI behavior.
+</Card>

--- a/ai-mcp/vise/uikit-quickstart.mdx
+++ b/ai-mcp/vise/uikit-quickstart.mdx
@@ -1,0 +1,42 @@
+---
+title: "UIKit quick-launch path"
+description: "Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI."
+---
+
+Choose UIKit when the request is primarily a standard social surface, fast launch, white-label experience, or supported UIKit customization. Vise keeps UIKit fit and customization advisory while continuing to validate customer-owned configuration, SDK setup, authentication, and project sensors.
+
+## Suggested request
+
+```text
+Use social.plus UIKit to launch a standard community feed in this app. Recommend the lowest customization level that fits the existing design system, and do not hand-roll the standard surface from SDK primitives.
+```
+
+## Confirm the path before implementation
+
+```sh
+vise inspect .
+vise plan . --request "Use social.plus UIKit to launch a standard community feed" --summary
+```
+
+Review `solutionPath` and `uikitCustomization`. If UIKit is the chosen path, repeat the plan and initialize with explicit answers such as:
+
+```sh
+vise plan . --request "Use social.plus UIKit to launch a standard community feed" \
+  --answer solution_path=uikit \
+  --answer uikit_customization=dynamic-ui
+```
+
+Also answer the platform, route, region, identity, and target questions Vise reports. The exact customization choice may instead be component styling, localization, behavior overrides, fork-and-extend, or a hybrid path.
+
+## Implementation boundary
+
+- Treat UIKit installation, provider/page, behavior, localization, and customization guidance as the primary implementation source.
+- Do not execute direct-SDK feed/chat/profile steps for a locked UIKit route.
+- Use hybrid only when UIKit covers standard surfaces and direct SDK code is genuinely needed for differentiated app behavior.
+- Do not claim deterministic validation of UIKit internals hidden outside the customer repository.
+
+Finish with `vise check`, `vise validate`, project sensors, and a real app launch. A themed UIKit screen still requires product QA and runtime verification.
+
+<Card title="CLI reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
+  Review planning, validation, evidence, and sensor commands.
+</Card>

--- a/docs.json
+++ b/docs.json
@@ -856,6 +856,10 @@
             "group": "Vise",
             "pages": [
               "ai-mcp/vise/overview",
+              "ai-mcp/vise/evaluate",
+              "ai-mcp/vise/sdk-custom-ui",
+              "ai-mcp/vise/uikit-quickstart",
+              "ai-mcp/vise/brownfield-day2",
               "ai-mcp/vise/how-it-works",
               "ai-mcp/vise/mcp-server",
               "ai-mcp/vise/cli-reference"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69701,11 +69701,13 @@ Use the hosted MCP server when you want an assistant to **find and read document
 ## Who should use Vise
 
 - **Developer using an AI coding agent** — Install the skill, ask for the SDK feature, answer project-specific questions, and let Vise drive the loop through plan, check, and sensors.
-- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result before accepting the integration.
+- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result — including re-verdicts of previously completed engagements — before accepting the integration.
 - **Partner or solutions engineer** — Use Vise as a repeatable delivery workflow across customer apps, so each integration ends with the same local evidence rather than a prompt transcript.
 - **Product or design owner** — Use the advisory design and experience outputs to review whether the generated surface fits the product intent. Correctness and explicit completeness checks remain the gates.
 
 ## Install
+
+  Vise requires Node.js 20 or newer. Run `node --version` before installing if you are unsure which runtime your terminal or CI environment uses.
 
 Install Vise globally:
 
@@ -69750,10 +69752,217 @@ vise print-skill
 
 ## Next steps
 
+    Inspect a real app and review a grounded plan before using production credentials or changing code.
     The governed loop, what Vise checks, and how to read a check result.
     Expose Vise's tools to Claude Code, Cursor, Codex, and VS Code.
     The commands you'll run most, grouped by task.
     Install and initialize social.plus SDKs for your platform.
+
+---
+
+### [Evaluate Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate)
+
+> Inspect a real app and review a grounded Vise plan before using production credentials or changing code.
+
+This evaluation shows how Vise reads an app, identifies the integration surface, and asks for decisions an AI agent should not invent. It deliberately stops before implementation, so you can assess the workflow without production credentials or source changes.
+
+  Vise requires Node.js 20 or newer. Vise itself runs locally and does not upload your source code, file contents, or search queries. Your AI coding host follows its own data policy.
+
+## Run the evaluation
+
+Use a clean branch or disposable copy of a real app repository.
+
+```sh
+npx -y -p @amityco/social-plus-vise vise doctor
+```
+
+    Confirm that the command reports the installed version and hosted documentation source.
+```sh
+npx -y -p @amityco/social-plus-vise vise inspect .
+```
+
+    Review the detected platform, app surfaces, design signals, sensors, and scan coverage. If the scan is incomplete or several app surfaces are detected, select the concrete app before continuing.
+```sh
+npx -y -p @amityco/social-plus-vise vise plan . \
+  --request "Add a social feed to this app" \
+  --summary
+```
+
+    A useful plan identifies the implementation path, cites relevant social.plus documentation, and lists unresolved project decisions such as region, route, feed scope, and target source.
+    Do not invent answers or run `vise init` during this short evaluation. The expected result is a grounded route and a reviewable decision list—not generated code or runtime proof.
+
+## What this proves
+
+- The package can run in your environment.
+- Vise recognizes the intended app surface and supported platform.
+- The plan is grounded in social.plus documentation and local project signals.
+- Missing product and integration decisions are explicit instead of silently guessed.
+
+## What this does not prove
+
+- That an SDK or UIKit integration has been implemented.
+- That `vise check`, project sensors, or the app runtime will pass.
+- That the selected social surface works with your tenant data and credentials.
+
+## Choose the next path
+
+    Build a differentiated app-owned experience directly on the social.plus SDK.
+    Use prebuilt social.plus UIKit surfaces and the lowest suitable customization level.
+    Add a feature to an app that already uses social.plus without losing earlier evidence.
+
+---
+
+### [Custom SDK UI path](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui)
+
+> Use Vise to govern a differentiated social.plus experience built directly on the SDK.
+
+Choose the SDK path when the app needs a differentiated layout, workflow, or interaction model that should remain owned by the host application.
+
+## Suggested request
+
+```text
+Add a social feed to this app using the social.plus SDK. Keep the UI consistent with the existing design system and ask me for any missing scope, target, route, region, or identity decisions before editing.
+```
+
+## Governed loop
+
+```sh
+vise inspect .
+vise plan . --request "Add a social feed to this app using the social.plus SDK" --summary
+```
+
+Review the plan, then repeat the full `vise plan` and `vise init` commands with one explicit `--answer id=value` flag for every blocking question. Do not place API keys or server-issued tokens in command history or AI chat; use the app's ignored local environment/configuration pattern.
+
+After the agent implements the agreed surface:
+
+```sh
+vise check .
+vise validate .
+vise run-sensors .
+```
+
+For a user-visible handoff, launch the real target and capture runtime-smoke evidence. Static green and passing sensors do not prove that the screen mounted, authenticated, or populated with tenant data.
+
+## Review checklist
+
+- The selected SDK path is explicit.
+- Read and write targets come from route, app state, user selection, SDK discovery, or a create flow—not invented IDs.
+- Loading, empty, error, and data states are implemented.
+- Live collections, cleanup, pagination, session renewal, and user switching follow the platform SDK lifecycle.
+- Scope decisions for post types, composer types, comments, reactions, and moderation are recorded.
+- The final handoff includes remaining advisory findings and unresolved non-blocking decisions.
+
+  Understand the contract, evidence, runtime-proof boundary, and CI behavior.
+
+---
+
+### [UIKit quick-launch path](https://learn.social.plus/ai-mcp/vise/uikit-quickstart)
+
+> Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI.
+
+Choose UIKit when the request is primarily a standard social surface, fast launch, white-label experience, or supported UIKit customization. Vise keeps UIKit fit and customization advisory while continuing to validate customer-owned configuration, SDK setup, authentication, and project sensors.
+
+## Suggested request
+
+```text
+Use social.plus UIKit to launch a standard community feed in this app. Recommend the lowest customization level that fits the existing design system, and do not hand-roll the standard surface from SDK primitives.
+```
+
+## Confirm the path before implementation
+
+```sh
+vise inspect .
+vise plan . --request "Use social.plus UIKit to launch a standard community feed" --summary
+```
+
+Review `solutionPath` and `uikitCustomization`. If UIKit is the chosen path, repeat the plan and initialize with explicit answers such as:
+
+```sh
+vise plan . --request "Use social.plus UIKit to launch a standard community feed" \
+  --answer solution_path=uikit \
+  --answer uikit_customization=dynamic-ui
+```
+
+Also answer the platform, route, region, identity, and target questions Vise reports. The exact customization choice may instead be component styling, localization, behavior overrides, fork-and-extend, or a hybrid path.
+
+## Implementation boundary
+
+- Treat UIKit installation, provider/page, behavior, localization, and customization guidance as the primary implementation source.
+- Do not execute direct-SDK feed/chat/profile steps for a locked UIKit route.
+- Use hybrid only when UIKit covers standard surfaces and direct SDK code is genuinely needed for differentiated app behavior.
+- Do not claim deterministic validation of UIKit internals hidden outside the customer repository.
+
+Finish with `vise check`, `vise validate`, project sensors, and a real app launch. A themed UIKit screen still requires product QA and runtime verification.
+
+  Review planning, validation, evidence, and sensor commands.
+
+---
+
+### [Brownfield and day-2 path](https://learn.social.plus/ai-mcp/vise/brownfield-day2)
+
+> Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable.
+
+Vise supports both apps that adopted social.plus before Vise and apps whose earlier features already have a Vise contract.
+
+## Existing integration built without Vise
+
+Initialize the new feature before editing. If Vise reports pre-existing findings, record a baseline immediately:
+
+```sh
+vise init . --request "Add comments to the existing feed" \
+  --answer comment_target=post \
+  --answer comment_depth="one level of replies" \
+  --answer lifecycle_owner="React component" \
+  --answer target_screen="existing feed detail"
+vise baseline .
+```
+
+Then gate new rule findings with:
+
+```sh
+vise check . --new-only
+```
+
+The baseline excludes legacy rule findings only. The new feature's completeness checklist and selected capabilities still have to pass.
+
+## Existing integration already governed by Vise
+
+Initializing a different outcome records the previous engagement under `sp-vise/engagements/`. Replacing a green engagement requires an explicit acknowledgement:
+
+```sh
+vise init . --request "Add comments to the existing feed" \
+  --supersede-engagement \
+  --answer comment_target=post \
+  --answer comment_depth="one level of replies" \
+  --answer lifecycle_owner="React component" \
+  --answer target_screen="existing feed detail"
+```
+
+Review prior work at any time:
+
+```sh
+vise status .
+vise check . --engagement <outcome>
+vise check . --all-engagements
+```
+
+In CI, one command holds the active and recorded engagements green:
+
+```sh
+vise check . --ci
+```
+
+Exit `11` means the active feature is green but previously completed work drifted.
+
+## Handoff checklist
+
+- State whether a baseline was used and when it was recorded.
+- Identify the active outcome and every recorded previous engagement.
+- Report unresolved non-blocking intake and any scope-omit decisions.
+- Include runtime proof or an explicit waiver for the new user-visible surface.
+- Do not describe a green active engagement as sufficient when `--ci` reports previous-engagement drift.
+
+  Understand active failures, proof waivers, contract drift, and engagement drift.
 
 ---
 
@@ -69778,7 +69987,7 @@ flowchart LR
   F --> G[done: evidence recorded]
 ```
 
-- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors.
+- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors. Inspection includes bounded scan receipts; if a large repository cannot be scanned completely, select the concrete app surface before continuing.
 - **plan** — produce a grounded plan with docs citations and the project-specific questions the agent must not guess.
 - **init** — write the local compliance contract under `sp-vise/` once blocking questions are answered.
 - **implement** — the agent edits your app, grounded in real SDK APIs.
@@ -69816,9 +70025,9 @@ Deterministic SDK correctness and explicit completeness decisions are the checks
 | `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
 | `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--all-engagements` only, exit `11`) | Re-open the drifted surface or re-attest what changed |
+| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--ci` or `--all-engagements`, exit `11`) | Re-open the drifted surface or re-attest what changed |
 
-Add `--ci` for a read-only run that exits non-zero unless the result is green.
+Add `--ci` for a read-only release gate. It checks the active contract and automatically re-verdicts every recorded engagement, exiting non-zero unless all governed work remains green.
 
 ## Attestation and evidence
 
@@ -69860,9 +70069,10 @@ vise check --all-engagements        # current work + every finished surface, in 
 After the first successful integration, commit `sp-vise/` and run Vise in CI:
 
 ```sh
-vise check --ci                # read-only; non-zero unless green
-vise check --all-engagements   # optional: also hold every previously finished surface green (exit 11 on drift)
+vise check --ci   # read-only; active contract + every recorded engagement
 ```
+
+Use `--all-engagements` when you want the same combined re-verdict outside CI. It is not an additional command that CI needs to run after `--ci`.
 
 When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
 
@@ -69954,11 +70164,11 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 
 | Tool | Mirrors | Purpose |
 | --- | --- | --- |
-| `inspect_project` | `vise inspect` | Detect platform, surfaces, and sensors |
+| `inspect_project` | `vise inspect` | Detect platform, surfaces, sensors, and complete-scan coverage |
 | `plan_integration` | `vise plan` | Grounded plan with docs citations and intake |
 | `init_compliance` | `vise init` | Write the `sp-vise/` contract |
 | `check_compliance` | `vise check` | Validate the code against the contract |
-| `run_sensors` | `vise run-sensors` | Run build, lint, typecheck, and smoke checks |
+| `run_sensors` | `vise run-sensors` | Run detected build, lint, typecheck, and smoke checks; explicitly included sensor names must match |
 | `get_sdk_facts` | `vise sdk-facts` | Read grounded SDK surface facts |
 | `search_docs` / `get_doc_page` | `vise search-docs` / `vise get-doc-page` | Find and read social.plus docs |
 | `debug_issue` | `vise debug` | Diagnose an SDK-specific runtime failure |
@@ -69995,7 +70205,7 @@ This page covers the commands most integrations use. For the complete list and e
 | Command | Purpose |
 | --- | --- |
 | `vise explore "<request>"` | Map a request to what social.plus offers — no project or API key needed |
-| `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, and available sensors |
+| `vise inspect [path]` | Detect platform, monorepo surfaces, design signals, available sensors, and bounded scan coverage. An incomplete scan cannot initialize or produce a green check; select the concrete app surface in a large monorepo |
 | `vise plan [path] --request "..."` | Grounded implementation plan with intake questions and docs citations (`--summary` for a compact view) |
 | `vise init [path] --request "..." --answer key=value` | Write the `sp-vise/` compliance contract once blocking intake is answered. Initializing a different outcome records the previous engagement to `sp-vise/engagements/` first; replacing a **green** engagement asks for `--supersede-engagement` |
 
@@ -70012,7 +70222,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | Command | Purpose |
 | --- | --- |
 | `vise check [path]` | Validate the code against the recorded contract |
-| `vise check [path] --ci` | Read-only; exits non-zero unless green |
+| `vise check [path] --ci` | Read-only release gate for the active contract and every recorded engagement; exits `11` when active work is green but completed work drifted |
 | `vise check [path] --new-only` | Gate only on *rule findings* introduced since the baseline — the outcome's completeness checklist and selected capabilities always gate (they are the engagement's deliverables) |
 | `vise check [path] --allow-proof-waiver` | Accept an honest `runtime-proof-waived` result as passing |
 | `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
@@ -70032,6 +70242,12 @@ See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) f
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke [path] --log <file>` | Assess a captured mount-smoke log into a pass/fail verdict |
 | `vise smoke waive [path] --reason "..." --mode declined\|deviceless` | Record an auditable runtime-proof waiver |
+
+## Project sensors
+
+| Command | Purpose |
+| --- | --- |
+| `vise run-sensors [path] [--dry-run] [--include "<sensor name>"]` | Run detected project build, lint, typecheck, test, and SDK-smoke commands. An explicit `--include` must match a detected sensor or the command fails; captured output is bounded, and timed-out sensors terminate their descendant processes |
 
 ## Docs and SDK facts
 

--- a/llms.txt
+++ b/llms.txt
@@ -430,6 +430,10 @@
 
 - [AI / MCP](https://learn.social.plus/ai-mcp/overview): Connect AI coding tools to the social.plus documentation MCP server.
 - [Vise](https://learn.social.plus/ai-mcp/vise/overview): Use the local Vise CLI to guide and validate AI-assisted social.plus SDK integrations.
+- [Evaluate Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate): Inspect a real app and review a grounded Vise plan before using production credentials or changing code.
+- [Custom SDK UI path](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui): Use Vise to govern a differentiated social.plus experience built directly on the SDK.
+- [UIKit quick-launch path](https://learn.social.plus/ai-mcp/vise/uikit-quickstart): Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI.
+- [Brownfield and day-2 path](https://learn.social.plus/ai-mcp/vise/brownfield-day2): Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable.
 - [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works): The governed loop, what Vise checks, and how to read a compliance result.
 - [Run Vise as an MCP server](https://learn.social.plus/ai-mcp/vise/mcp-server): Expose Vise's local tools to Claude Code, Cursor, Codex, and VS Code over MCP.
 - [CLI reference](https://learn.social.plus/ai-mcp/vise/cli-reference): The Vise commands you'll run most often, grouped by task.

--- a/llmstxt/llms-config.yml
+++ b/llmstxt/llms-config.yml
@@ -478,6 +478,10 @@ sections:
     pages:
       - path: ai-mcp/overview.mdx
       - path: ai-mcp/vise/overview.mdx
+      - path: ai-mcp/vise/evaluate.mdx
+      - path: ai-mcp/vise/sdk-custom-ui.mdx
+      - path: ai-mcp/vise/uikit-quickstart.mdx
+      - path: ai-mcp/vise/brownfield-day2.mdx
       - path: ai-mcp/vise/how-it-works.mdx
       - path: ai-mcp/vise/mcp-server.mdx
       - path: ai-mcp/vise/cli-reference.mdx


### PR DESCRIPTION
## Summary
- add a credential-free 15-minute evaluation path
- add dedicated SDK/custom UI, UIKit quick-launch, and brownfield/day-2 guides
- align inspect, sensor, and `check --ci` semantics with Vise 1.8 behavior
- regenerate `llms.txt` and `llms-full.txt`

## Validation
- `python3 tools/check_internal_links.py`
- `python3 -m json.tool docs.json`
- `go test ./...` (from `llmstxt/`)
- `git diff --check`