### PR TITLE
docs(vise): reframe user-facing docs skill-first instead of CLI-first

### DIFF
--- a/ai-mcp/overview.mdx
+++ b/ai-mcp/overview.mdx
@@ -30,7 +30,7 @@ Choose the AI tool you use most often:
 
 <CardGroup cols={2}>
   <Card title="Vise" icon="shield-check" href="/ai-mcp/vise/overview">
-    Use the local Vise CLI to guide, validate, and sensor-check AI-assisted SDK integrations.
+    Give your AI coding agent guardrails for building social.plus features — install Vise, add its skill, and ask.
   </Card>
   <Card title="Claude" icon="message-bot" href="/ai-mcp/claude-desktop">
     Connect Claude.ai or Claude Desktop to the social.plus MCP server.
@@ -89,7 +89,7 @@ The public docs MCP server is best for:
 
 It is not a replacement for your app's local validation, build, test, or security review process.
 
-For local integration validation, use [Vise](/ai-mcp/vise/overview). Vise runs in your app repository, guides the AI coding loop, and checks the generated integration before you call it done. It can also run as a [local MCP server](/ai-mcp/vise/mcp-server).
+When an agent is **editing your app**, use [Vise](/ai-mcp/vise/overview): install it, add its skill to your agent, and it guides the coding loop and checks the generated integration before you call it done. It can also run as a [local MCP server](/ai-mcp/vise/mcp-server).
 
 ## Related docs
 

--- a/ai-mcp/vise/brownfield-day2.mdx
+++ b/ai-mcp/vise/brownfield-day2.mdx
@@ -1,68 +1,54 @@
 ---
-title: "Brownfield and day-2 path"
-description: "Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable."
+title: "Adding to an existing app"
+description: "Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it."
 ---
 
-Vise supports both apps that adopted social.plus before Vise and apps whose earlier features already have a Vise contract.
+The second feature gets the same guardrails as the first. Just ask:
 
-## Existing integration built without Vise
-
-Initialize the new feature before editing. If Vise reports pre-existing findings, record a baseline immediately:
-
-```sh
-vise init . --request "Add comments to the existing feed" \
-  --answer comment_target=post \
-  --answer comment_depth="one level of replies" \
-  --answer lifecycle_owner="React component" \
-  --answer target_screen="existing feed detail"
-vise baseline .
+```text
+We already use social.plus for the feed — add comments to it.
 ```
 
-Then gate new rule findings with:
+Vise handles both histories your app might have.
 
-```sh
-vise check . --new-only
+## The existing integration was built by hand
+
+If your app adopted social.plus before Vise, the codebase may carry findings Vise would flag today. The agent snapshots those as a **baseline** before writing any code, so your new feature is judged on its own merits — not blocked by legacy code you didn't touch.
+
+Two guarantees keep the baseline honest:
+
+- It excludes only pre-existing findings. Anything the new work introduces still gates.
+- The feature you asked for is never baselined — the app can't pass without the feature actually being built, complete with its agreed scope.
+
+## Earlier features were built with Vise
+
+Finished features stay recorded, visible, and re-verifiable. When the agent starts a new feature, the previous one's final state is preserved and the switch is disclosed — and replacing a feature that already passed requires an explicit confirmation from you, so nothing green is silently overwritten.
+
+At any point you can ask:
+
+```text
+Check whether the features we built earlier with Vise still hold.
 ```
 
-The baseline excludes legacy rule findings only. The new feature's completeness checklist and selected capabilities still have to pass.
+If a later change broke a previously finished surface, you'll be told exactly which one drifted — even while the current work passes.
 
-## Existing integration already governed by Vise
+## Keep everything verified in CI
 
-Initializing a different outcome records the previous engagement under `sp-vise/engagements/`. Replacing a green engagement requires an explicit acknowledgement:
-
-```sh
-vise init . --request "Add comments to the existing feed" \
-  --supersede-engagement \
-  --answer comment_target=post \
-  --answer comment_depth="one level of replies" \
-  --answer lifecycle_owner="React component" \
-  --answer target_screen="existing feed detail"
-```
-
-Review prior work at any time:
+One read-only command in your pipeline holds the current work *and* every previously finished feature green:
 
 ```sh
-vise status .
-vise check . --engagement <outcome>
-vise check . --all-engagements
+vise check --ci
 ```
 
-In CI, one command holds the active and recorded engagements green:
+It fails with a distinct exit code when a finished feature drifts, even if the active work passes. See the [reference](/ai-mcp/vise/cli-reference) for baseline and re-verification details.
 
-```sh
-vise check . --ci
-```
+## When you review the handoff
 
-Exit `11` means the active feature is green but previously completed work drifted.
+- Was a baseline used, and when was it recorded?
+- Do earlier features still hold, or did the agent disclose drift?
+- Is there runtime proof for the new surface — or an explicit, recorded waiver?
+- Are remaining advisory findings and open non-blocking decisions listed?
 
-## Handoff checklist
-
-- State whether a baseline was used and when it was recorded.
-- Identify the active outcome and every recorded previous engagement.
-- Report unresolved non-blocking intake and any scope-omit decisions.
-- Include runtime proof or an explicit waiver for the new user-visible surface.
-- Do not describe a green active engagement as sufficient when `--ci` reports previous-engagement drift.
-
-<Card title="Reading a check result" icon="shield-check" href="/ai-mcp/vise/how-it-works#reading-a-check-result">
-  Understand active failures, proof waivers, contract drift, and engagement drift.
+<Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+  Contracts, evidence, and what your agent's reports mean.
 </Card>

--- a/ai-mcp/vise/cli-reference.mdx
+++ b/ai-mcp/vise/cli-reference.mdx
@@ -1,12 +1,12 @@
 ---
-title: "CLI reference"
-description: "The Vise commands you'll run most often, grouped by task."
+title: "Command reference"
+description: "For reviewers and CI — the commands behind the skill, and the ones you run to verify recorded evidence."
 ---
 
-This page covers the commands most integrations use. For the complete list and every flag, run `vise --help` or `vise <command> --help`. Each command has an [MCP tool equivalent](/ai-mcp/vise/mcp-server#what-it-exposes) in snake_case.
+Day to day, you don't need this page: your agent runs these commands through the [skill](/ai-mcp/vise/overview#get-started). It exists for the moments a human drives Vise directly — reviewing recorded evidence, gating a release in CI, or peeking under the hood. For the complete list and every flag, run `vise --help` or `vise <command> --help`. Each command has an [MCP tool equivalent](/ai-mcp/vise/mcp-server#what-it-exposes) in snake_case.
 
 <Info>
-  Most commands take a project path (default: the current directory) and write their state under `sp-vise/`. Commands that change generated code are run by your AI agent through the [skill](/ai-mcp/vise/overview#install-the-ai-skill); the commands below are the ones you or your reviewer run directly.
+  Most commands take a project path (default: the current directory) and read or write state under `sp-vise/`. The ones reviewers reach for most: `vise status`, `vise check --ci`, and `vise explain`.
 </Info>
 
 ## Explore and plan
@@ -40,7 +40,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
-See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) for what each state means.
+See [What your agent will report](/ai-mcp/vise/how-it-works#what-your-agent-will-report) for what each state means.
 
 ## Evidence
 

--- a/ai-mcp/vise/evaluate.mdx
+++ b/ai-mcp/vise/evaluate.mdx
@@ -1,70 +1,73 @@
 ---
-title: "Evaluate Vise in 15 minutes"
-description: "Inspect a real app and review a grounded Vise plan before using production credentials or changing code."
+title: "Try Vise in 15 minutes"
+description: "Add the skill to your agent and watch it plan a real integration — no credentials, no code changes."
 ---
 
-This evaluation shows how Vise reads an app, identifies the integration surface, and asks for decisions an AI agent should not invent. It deliberately stops before implementation, so you can assess the workflow without production credentials or source changes.
+This walkthrough shows what working with Vise feels like before you commit to anything. You'll ask your agent to *plan* an integration and stop there — so you can judge the workflow without production credentials or source changes.
 
 <Info>
-  Vise requires Node.js 20 or newer. Vise itself runs locally and does not upload your source code, file contents, or search queries. Your AI coding host follows its own data policy.
+  Vise requires Node.js 20 or newer. It runs locally and does not upload your source code, file contents, or search queries. Your AI coding tool follows its own data policy.
 </Info>
 
 ## Run the evaluation
 
-Use a clean branch or disposable copy of a real app repository.
+Use a clean branch or a disposable copy of a real app repository — a real codebase shows you far more than an empty scaffold.
 
 <Steps>
-  <Step title="Verify the package">
+  <Step title="Install Vise and add the skill">
     ```sh
-    npx -y -p @amityco/social-plus-vise vise doctor
+    npm install -g @amityco/social-plus-vise
+    vise install-skill --target claude     # or: cursor . / vscode . / copilot . / codex
     ```
-
-    Confirm that the command reports the installed version and hosted documentation source.
   </Step>
-  <Step title="Inspect the app">
-    ```sh
-    npx -y -p @amityco/social-plus-vise vise inspect .
+  <Step title="Ask your agent for a plan — and only a plan">
+    Open the app in your agent and ask:
+
+    ```text
+    Using Vise, plan how you'd add a social feed to this app with social.plus.
+    Don't change any code yet — show me the plan and the questions
+    you'd need me to answer first.
     ```
-
-    Review the detected platform, app surfaces, design signals, sensors, and scan coverage. If the scan is incomplete or several app surfaces are detected, select the concrete app before continuing.
   </Step>
-  <Step title="Request a compact plan">
-    ```sh
-    npx -y -p @amityco/social-plus-vise vise plan . \
-      --request "Add a social feed to this app" \
-      --summary
-    ```
+  <Step title="Review what comes back">
+    A good result has three parts:
 
-    A useful plan identifies the implementation path, cites relevant social.plus documentation, and lists unresolved project decisions such as region, route, feed scope, and target source.
+    - **Your app, recognized.** The agent identifies the platform and, in a monorepo, which app the feature would land in.
+    - **A grounded route.** The plan cites real social.plus documentation and SDK capabilities — not remembered or invented APIs.
+    - **Questions instead of guesses.** Decisions the agent should never make alone — region, target screen, where the feed's data comes from — arrive as explicit questions for you.
   </Step>
-  <Step title="Review the stopping boundary">
-    Do not invent answers or run `vise init` during this short evaluation. The expected result is a grounded route and a reviewable decision list—not generated code or runtime proof.
+  <Step title="Stop here (for now)">
+    Don't answer the questions yet — answering them is what moves the agent into implementation. For the evaluation, the deliverable is the plan and the decision list, and you've seen the most important behavior already: the agent asked rather than guessed.
   </Step>
 </Steps>
 
-## What this proves
+Curious what happened under the hood? The agent ran a couple of Vise commands on your behalf — you can see them in its transcript, and they're documented in the [reference](/ai-mcp/vise/cli-reference). You never need to run them yourself.
 
-- The package can run in your environment.
-- Vise recognizes the intended app surface and supported platform.
-- The plan is grounded in social.plus documentation and local project signals.
-- Missing product and integration decisions are explicit instead of silently guessed.
+## What this shows
 
-## What this does not prove
+- Vise works in your environment, with your agent.
+- It reads your actual codebase, not a template.
+- Plans are grounded in social.plus documentation.
+- Product decisions are surfaced to you instead of silently invented.
 
-- That an SDK or UIKit integration has been implemented.
-- That `vise check`, project sensors, or the app runtime will pass.
-- That the selected social surface works with your tenant data and credentials.
+## What this doesn't show
 
-## Choose the next path
+- An implemented, validated integration — nothing was built yet.
+- That the feature works with your tenant data and credentials.
+- Runtime behavior on a device or in a browser.
+
+To see those, take the next step: answer the agent's questions and let it implement. Vise then checks the work until it's verifiably done.
+
+## Choose your integration path
 
 <CardGroup cols={3}>
   <Card title="Custom SDK UI" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
-    Build a differentiated app-owned experience directly on the social.plus SDK.
+    A differentiated, app-owned experience built directly on the social.plus SDK.
   </Card>
   <Card title="UIKit quick launch" icon="window" href="/ai-mcp/vise/uikit-quickstart">
-    Use prebuilt social.plus UIKit surfaces and the lowest suitable customization level.
+    Prebuilt social.plus UIKit surfaces with the lightest customization that fits.
   </Card>
-  <Card title="Brownfield and day 2" icon="rotate" href="/ai-mcp/vise/brownfield-day2">
-    Add a feature to an app that already uses social.plus without losing earlier evidence.
+  <Card title="Adding to an existing app" icon="rotate" href="/ai-mcp/vise/brownfield-day2">
+    Add a feature to an app that already uses social.plus.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/how-it-works.mdx
+++ b/ai-mcp/vise/how-it-works.mdx
@@ -1,31 +1,31 @@
 ---
 title: "How Vise works"
-description: "The governed loop, what Vise checks, and how to read a compliance result."
+description: "The loop the skill drives your agent through, what gets checked, and what 'done' means."
 ---
 
-Vise turns an SDK request into a grounded plan, records a local contract, and keeps checking the generated code until the integration is finished — where "finished" means green, attested with evidence, intentionally scoped, or explicitly blocked on your input, not just "the agent stopped."
+Vise turns your feature request into a grounded plan, records what "done" means for it, and keeps checking the generated code until the integration is finished — where finished means verified, explained with evidence, intentionally scoped out, or explicitly waiting on your decision. Never just "the agent stopped."
 
-## The governed loop
+## The loop your agent follows
 
-The bundled [skill](/ai-mcp/vise/overview#install-the-ai-skill) drives your AI agent through the same loop on every integration:
+The [skill](/ai-mcp/vise/overview#get-started) drives your agent through the same loop on every integration:
 
 ```mermaid
 flowchart LR
-  A[inspect] --> B[plan]
-  B --> C[init contract]
+  A[understand your app] --> B[plan from the docs]
+  B --> C[record the contract]
   C --> D[implement]
   D --> E[check]
-  E -->|not green| D
-  E -->|green| F[run-sensors]
+  E -->|not done| D
+  E -->|passes| F[run your project's checks]
   F --> G[done: evidence recorded]
 ```
 
-- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors. Inspection includes bounded scan receipts; if a large repository cannot be scanned completely, select the concrete app surface before continuing.
-- **plan** — produce a grounded plan with docs citations and the project-specific questions the agent must not guess.
-- **init** — write the local compliance contract under `sp-vise/` once blocking questions are answered.
-- **implement** — the agent edits your app, grounded in real SDK APIs.
-- **check** — re-validate the code against the recorded contract.
-- **run-sensors** — run your project's own build, lint, typecheck, and SDK smoke checks.
+- **Understand your app** — detect the platform, the app surfaces in a monorepo, design signals, and which of your project's own checks are available. In a very large repository, the agent confirms which concrete app it's working in before continuing.
+- **Plan from the docs** — produce a plan with social.plus docs citations, plus the questions the agent must ask you rather than guess.
+- **Record the contract** — once you've answered, the expectations for this feature are written down (see below).
+- **Implement** — the agent edits your app, held to real SDK APIs.
+- **Check** — the code is validated against the recorded contract; the agent iterates until it passes.
+- **Run your project's checks** — your repository's own build, lint, typecheck, and SDK smoke checks.
 
 ## What Vise checks
 
@@ -39,84 +39,59 @@ Vise focuses on the mistakes that pass a demo and break in production:
 
 Deterministic SDK correctness and explicit completeness decisions are the checks that block. Design and experience guidance stays advisory.
 
-## The `sp-vise/` contract
+## The `sp-vise/` folder
 
-`vise init` writes a local contract directory, `sp-vise/`, that records what the integration is expected to satisfy for the detected platform and requested outcome. Subsequent `vise check` runs validate the current code against it. Commit `sp-vise/` with your app so the same expectations run in review and in CI.
+The recorded contract, its check results, and all supporting evidence live in a small `sp-vise/` folder in your repo. Commit it with your app: it's what lets a reviewer see *why* the integration is trustworthy — and what lets CI keep verifying the work after the chat transcript is long gone.
 
-## Reading a check result
+## What your agent will report
 
-`vise check` reports one of the following states:
+Every check ends in one of these states. Your agent will name them when it reports back, so here's what each one means for you:
 
-| Result | Meaning | What to do |
+| State | Meaning | What you do |
 | --- | --- | --- |
 | `green` | Every applicable check passes | Accept the integration |
-| `needs-attestation` | A rule passed through architecture the deterministic check can't see | Record an attestation with evidence (see below) |
-| `deterministic-failures` | A rule failed deterministically in the code | Fix the code and re-check |
-| `completeness-gap` | The requested outcome isn't fully covered yet | Implement the missing surface or capability |
-| `selected-capability-failures` | An optional capability you chose to include isn't satisfied | Complete or intentionally drop that capability |
-| `blocked` | A decision only your team can make is missing | Answer the intake or confirm the plan |
-| `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
-| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
+| `needs-attestation` | A rule is satisfied through architecture the automatic check can't see | Let the agent record evidence and a rationale, then review it |
+| `deterministic-failures` | A rule failed in the code | Nothing — the agent fixes and re-checks |
+| `completeness-gap` | The feature you asked for isn't fully built yet | Nothing — the agent keeps going, or asks you to drop scope explicitly |
+| `selected-capability-failures` | An optional capability you chose isn't satisfied | Decide: finish it, or intentionally drop it |
+| `blocked` | A decision only your team can make is missing | Answer the question |
+| `contract-drift` | The code no longer matches what was recorded | Decide with the agent: re-plan, or restore the code |
+| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept the recorded waiver, or ask for a real run |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--ci` or `--all-engagements`, exit `11`) | Re-open the drifted surface or re-attest what changed |
+| `engagement-drift` | Current work is fine, but a previously finished feature no longer holds | Re-open the drifted feature or accept the documented change |
 
-Add `--ci` for a read-only release gate. It checks the active contract and automatically re-verdicts every recorded engagement, exiting non-zero unless all governed work remains green.
+## Evidence instead of "trust me"
 
-## Attestation and evidence
+Three kinds of proof accumulate in `sp-vise/` as the agent works:
 
-Some correct integrations pass through indirection the static check can't follow — a helper module, a wrapper, or a pattern unique to your codebase. When that happens, the result is `needs-attestation`: you record that the rule is satisfied, with evidence and a rationale, instead of the check silently failing.
+- **Attestations.** Some correct code passes through indirection a static check can't follow — a helper module, a wrapper, a pattern unique to your codebase. Instead of failing silently or passing blindly, the agent records *why* the rule is satisfied, with evidence and a rationale you can audit.
+- **Runtime proof.** For user-visible surfaces, Vise can assess a captured app-launch log into a pass/fail verdict — did the screen mount, authenticate, and load data? When no device or emulator is available, an explicit waiver is recorded instead of a silent pass.
+- **Deterministic passes.** After a green check, the passing evidence itself is persisted, so review doesn't depend on re-running anything.
 
-```sh
-vise explain <ruleId>          # rule rationale, evidence needed, remediation
-vise attest . --rule <ruleId> --signer host-agent --confidence high \
-  --evidence-file evidence.json --rationale "why this is satisfied"
-vise sync .                    # persist deterministic-pass evidence after a green check
-```
+Reviewers can inspect all of it with a few read-only commands — see the [reference](/ai-mcp/vise/cli-reference).
 
-Attestations and evidence live under `sp-vise/`, so a reviewer can see *why* something is green — not just that a prompt finished.
+## Adding features later
 
-## Runtime proof and waivers
+The second feature is governed as carefully as the first, whether the existing integration was built by hand or through Vise — and earlier finished features stay recorded and re-verifiable. See [Adding to an existing app](/ai-mcp/vise/brownfield-day2).
 
-For surfaces that should be proven at runtime, Vise can assess a captured mount-smoke log into a pass/fail verdict. When a device or emulator isn't available, or you decline runtime proof, record an auditable waiver instead of a silent pass:
+## Vise in CI
 
-```sh
-vise smoke . --log run.log                          # assess a captured smoke log
-vise smoke waive . --reason "no emulator in CI" --mode deviceless
-```
-
-## Adding features to an app that already uses social.plus
-
-The second feature is governed as carefully as the first. Two situations:
-
-**The existing integration was built by hand.** Run `vise init` for the new request as normal. If the repo carries pre-existing findings, the init result includes a `brownfield` hint: record `vise baseline .` **before writing any code**, then gate your work with `vise check --new-only`. The baseline excludes legacy rule findings only — the feature you asked for still has to be built, and its completeness checklist still gates.
-
-**The existing features were built through Vise.** The sidecar governs one engagement at a time, but switching is recorded, not destructive: initializing a new outcome writes the previous engagement's final state to `sp-vise/engagements/` and discloses the switch in the result; replacing a **green** engagement additionally asks for `--supersede-engagement`. Finished surfaces stay visible in `vise status` under `previousEngagements`, and stay verifiable:
+After the first successful integration, commit `sp-vise/` and add one read-only command to your pipeline:
 
 ```sh
-vise check --engagement <outcome>   # re-verify one finished surface (exit 11 on drift)
-vise check --all-engagements        # current work + every finished surface, in one run
+vise check --ci
 ```
 
-## Add Vise to CI
-
-After the first successful integration, commit `sp-vise/` and run Vise in CI:
-
-```sh
-vise check --ci   # read-only; active contract + every recorded engagement
-```
-
-Use `--all-engagements` when you want the same combined re-verdict outside CI. It is not an additional command that CI needs to run after `--ci`.
-
-When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
+It verifies the active contract *and* re-verdicts every previously finished feature, failing the build unless all governed work still holds. Baseline behavior for pre-existing codebases and per-feature re-verification are covered in the [reference](/ai-mcp/vise/cli-reference).
 
 ## Related
 
 <CardGroup cols={2}>
   <Card title="Vise overview" icon="shield-check" href="/ai-mcp/vise/overview">
-    Install Vise and run your first integration.
+    Install Vise and ask for your first feature.
   </Card>
-  <Card title="CLI reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
-    The commands behind each step of the loop.
+  <Card title="For reviewers and CI" icon="terminal" href="/ai-mcp/vise/cli-reference">
+    The commands for verifying recorded evidence and gating releases.
   </Card>
   <Card title="Live Objects and Collections" icon="radio" href="/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview">
     Build realtime SDK features with the correct lifecycle.

--- a/ai-mcp/vise/mcp-server.mdx
+++ b/ai-mcp/vise/mcp-server.mdx
@@ -102,7 +102,7 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 
 ## Skill or MCP?
 
-The [skill](/ai-mcp/vise/overview#install-the-ai-skill) and the MCP server are complementary:
+The [skill](/ai-mcp/vise/overview#get-started) and the MCP server are complementary:
 
 - The **skill** teaches the agent *when* to inspect, plan, fetch docs, validate, and attest.
 - The **MCP server** exposes the *tools* the agent calls to do it.

--- a/ai-mcp/vise/overview.mdx
+++ b/ai-mcp/vise/overview.mdx
@@ -1,114 +1,103 @@
 ---
 title: "Vise"
-description: "Use the local Vise CLI to guide and validate AI-assisted social.plus SDK integrations."
+description: "Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work."
 tag: "Preview"
 ---
 
-Vise is a local command-line tool for teams using AI coding agents to integrate social.plus SDKs. It gives the agent a repeatable workflow, grounds the plan in the public docs, writes a local compliance contract, and checks the implementation before you call it done.
+Vise makes AI coding agents good at integrating social.plus. Install it, add its skill to the agent you already use, then ask for the feature you want — a social feed, chat, communities, stories. Your agent writes the code; Vise keeps it grounded in the real SDK, asks you the decisions only you can make, and keeps checking until the feature is genuinely done.
 
-The agent still writes the code. Vise wraps that work in guardrails: it grounds the agent in real SDK APIs, checks correctness and completeness, helps align generated UI with your design system, and asks you the calls only a human should make — then keeps checking until the result is green, attested with evidence, intentionally scoped out, or explicitly blocked on your decision.
+You interact with Vise twice: once to install it, once to add the skill. After that, you talk to your agent — not to Vise.
+
+## Get started
+
+<Info>
+  Vise requires Node.js 20 or newer.
+</Info>
+
+<Steps>
+  <Step title="Install Vise">
+    ```sh
+    npm install -g @amityco/social-plus-vise
+    ```
+  </Step>
+  <Step title="Add the skill to your AI coding agent">
+    ```sh
+    vise install-skill --target claude     # Claude Code
+    vise install-skill --target cursor .   # Cursor
+    vise install-skill --target vscode .   # VS Code
+    vise install-skill --target copilot .  # GitHub Copilot
+    vise install-skill --target codex      # OpenAI Codex
+    ```
+
+    Using a different agent? `vise print-skill` prints the skill so you can paste it anywhere.
+  </Step>
+  <Step title="Ask for a feature">
+    Open your app in your agent and ask in plain language:
+
+    ```text
+    Add a social feed to this app using social.plus.
+    ```
+
+    ```text
+    Add chat between users in this app with social.plus.
+    ```
+
+    ```text
+    We already use social.plus for the feed — add comments to it.
+    ```
+  </Step>
+</Steps>
+
+That's the whole setup. The skill teaches your agent when to inspect your project, ground its plan in the real social.plus SDK, and validate its own work — you watch that happen; you don't run it.
+
+## What happens next
+
+Once you ask for a feature, expect three things:
+
+1. **Your agent asks you a few product questions.** Things only you can decide — which region your app runs in, which screen the feature lives on, where a community ID comes from. Vise stops the agent from inventing these answers.
+2. **Your agent writes the code, and Vise checks it.** Not just "does it compile" — that the code uses APIs the SDK actually exposes, follows the platform's session and realtime-data lifecycle, and covers the whole feature: pagination, loading, empty, and error states, not just the happy path.
+3. **"Done" means verified, not "the agent stopped talking."** The work ends in one of a few honest states: every check passes, a check is satisfied in a way that's explained with recorded evidence, something was intentionally scoped out, or the agent is blocked waiting on a decision from you. The evidence lives in your repo (an `sp-vise/` folder), so a reviewer can see *why* the integration is trustworthy — not just that a chat transcript ended.
+
+## What Vise checks
+
+- **Real SDK usage** — the agent is held to source-anchored SDK facts (actual types and field names), so it can't invent an API that doesn't exist.
+- **Platform correctness** — 400+ checks for the mistakes that pass a demo and break in production: setup and region, session renewal, secret handling, realtime data lifecycle, and feature-specific patterns across feeds, chat, comments, communities, notifications, and more.
+- **Feature completeness** — the outcome you asked for, in full, including the optional capabilities you chose.
+- **Your project's own checks** — your repository's build, lint, typecheck, and test commands run as part of the loop.
+- **Design fit** — generated UI is reviewed against your design system. This part is advisory; brand judgment stays human.
 
 <Warning>
-  **Preview release.** Vise is usable for guided social.plus SDK integrations, but its CLI surface, evidence format, and advisory intelligence may still change as it hardens through more real projects. Treat it as governed AI assistance with strong validation gates — not a substitute for code review, product QA, or runtime verification.
+  **Preview release.** Vise is usable for guided social.plus integrations today, but details may still change as it hardens through more real projects. Treat it as strong guardrails for AI-assisted work — not a substitute for code review, product QA, or trying the feature on a real device.
 </Warning>
 
 <Info>
   Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
 </Info>
 
-## Vise vs. the docs MCP server
+## Vise and the docs MCP server
 
-Both tools connect AI coding tools to social.plus, and they work well together.
+Both connect AI tools to social.plus, and they work well together.
 
-| Tool | Best for | Runs where |
+| Tool | What it does | Runs where |
 | --- | --- | --- |
-| [Docs MCP server](/ai-mcp/overview) | Searching and reading social.plus documentation inside an AI chat | Hosted at `https://learn.social.plus/mcp` |
-| Vise | Planning, validating, and sensor-running an integration in your app repository | Local CLI in your project |
+| [Docs MCP server](/ai-mcp/overview) | Lets an assistant search and read social.plus documentation | Hosted at `https://learn.social.plus/mcp` |
+| Vise | Guides and validates an agent that is **editing your app** | Locally, in your project |
 
-Use the hosted MCP server when you want an assistant to **find and read documentation**. Use Vise when the assistant is **editing your app** and you want local validation, sensors, and a clear stop condition. Vise can also run as a [local MCP server](/ai-mcp/vise/mcp-server) so MCP hosts call its tools directly.
-
-## Who should use Vise
-
-- **Developer using an AI coding agent** — Install the skill, ask for the SDK feature, answer project-specific questions, and let Vise drive the loop through plan, check, and sensors.
-- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result — including re-verdicts of previously completed engagements — before accepting the integration.
-- **Partner or solutions engineer** — Use Vise as a repeatable delivery workflow across customer apps, so each integration ends with the same local evidence rather than a prompt transcript.
-- **Product or design owner** — Use the advisory design and experience outputs to review whether the generated surface fits the product intent. Correctness and explicit completeness checks remain the gates.
-
-## Install
-
-<Info>
-  Vise requires Node.js 20 or newer. Run `node --version` before installing if you are unsure which runtime your terminal or CI environment uses.
-</Info>
-
-Install Vise globally:
-
-```sh
-npm install -g @amityco/social-plus-vise
-vise doctor
-```
-
-Or run it without a global install:
-
-```sh
-npx -y -p @amityco/social-plus-vise vise doctor
-```
-
-`vise doctor` prints the version, install path, and docs source so you can confirm the setup.
-
-## Install the AI skill
-
-Vise includes a bundled skill that teaches your AI coding tool when to inspect, plan, fetch docs, edit code, validate, and ask you for missing decisions. Install it for your tool:
-
-```sh
-vise install-skill --target claude     # Claude Code
-vise install-skill --target cursor .   # Cursor
-vise install-skill --target vscode .   # VS Code
-vise install-skill --target copilot .  # GitHub Copilot
-vise install-skill --target codex      # OpenAI Codex
-```
-
-You can also print the skill and paste it into another coding agent:
-
-```sh
-vise print-skill
-```
-
-## Quickstart
-
-<Steps>
-  <Step title="Open your project in your AI coding tool">
-    Work inside the app repository where you want to add social.plus SDK features.
-  </Step>
-  <Step title="Ask for the integration">
-    For example: `Add a social feed to this app using the social.plus SDK.`
-  </Step>
-  <Step title="Let the agent run Vise">
-    The skill guides the agent through `vise inspect`, `vise plan`, `vise init`, docs lookup, implementation, `vise check`, and `vise run-sensors`.
-  </Step>
-  <Step title="Answer project-specific questions">
-    Vise asks for values the agent should not invent, such as region, feed target, community ID source, platform scope, or design-system source.
-  </Step>
-  <Step title="Review the final evidence">
-    Done means the local contract is green, attested with evidence, or explicitly blocked on a decision only your team can make.
-  </Step>
-</Steps>
+Vise can also expose its tools [over MCP](/ai-mcp/vise/mcp-server) if your agent host prefers MCP tools to a skill.
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Evaluate Vise in 15 minutes" icon="stopwatch" href="/ai-mcp/vise/evaluate">
-    Inspect a real app and review a grounded plan before using production credentials or changing code.
+  <Card title="Try Vise in 15 minutes" icon="stopwatch" href="/ai-mcp/vise/evaluate">
+    Watch your agent plan a real integration — no credentials, no code changes.
   </Card>
   <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-    The governed loop, what Vise checks, and how to read a check result.
+    What the skill drives, what gets checked, and what "done" means.
   </Card>
   <Card title="Run Vise as an MCP server" icon="plug" href="/ai-mcp/vise/mcp-server">
-    Expose Vise's tools to Claude Code, Cursor, Codex, and VS Code.
+    Optional: expose Vise's tools to MCP-capable hosts.
   </Card>
-  <Card title="CLI reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
-    The commands you'll run most, grouped by task.
-  </Card>
-  <Card title="SDK Quick Start" icon="rocket" href="/social-plus-sdk/getting-started/overview">
-    Install and initialize social.plus SDKs for your platform.
+  <Card title="For reviewers and CI" icon="terminal" href="/ai-mcp/vise/cli-reference">
+    The commands for reviewing recorded evidence and gating releases.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/sdk-custom-ui.mdx
+++ b/ai-mcp/vise/sdk-custom-ui.mdx
@@ -1,44 +1,49 @@
 ---
-title: "Custom SDK UI path"
-description: "Use Vise to govern a differentiated social.plus experience built directly on the SDK."
+title: "Custom SDK UI"
+description: "Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app."
 ---
 
-Choose the SDK path when the app needs a differentiated layout, workflow, or interaction model that should remain owned by the host application.
+Choose this path when the feature needs your own layout, workflow, or interaction model — UI your app owns, built directly on the social.plus SDK.
 
-## Suggested request
+## What to ask
 
 ```text
-Add a social feed to this app using the social.plus SDK. Keep the UI consistent with the existing design system and ask me for any missing scope, target, route, region, or identity decisions before editing.
+Add a social feed to this app using the social.plus SDK. Keep the UI
+consistent with the existing design system, and ask me about any missing
+scope, target, route, region, or identity decisions before editing.
 ```
 
-## Governed loop
+## What your agent will ask you
 
-```sh
-vise inspect .
-vise plan . --request "Add a social feed to this app using the social.plus SDK" --summary
-```
+Expect questions before any code changes. Typical ones for an app-owned surface:
 
-Review the plan, then repeat the full `vise plan` and `vise init` commands with one explicit `--answer id=value` flag for every blocking question. Do not place API keys or server-issued tokens in command history or AI chat; use the app's ignored local environment/configuration pattern.
+- **Region** — which social.plus region your app runs in.
+- **Where it lives** — the screen or route that hosts the new surface.
+- **Where data comes from** — the feed or community target: from a route, app state, user selection, SDK discovery, or a create flow. Vise won't let the agent hard-code an invented ID.
+- **Scope** — which post types, composer options, comments, reactions, and moderation behavior are in or out.
 
-After the agent implements the agreed surface:
+<Warning>
+  Don't paste API keys or server-issued tokens into the chat. Point the agent at your app's ignored environment/configuration pattern instead.
+</Warning>
 
-```sh
-vise check .
-vise validate .
-vise run-sensors .
-```
+## What "done" looks like
 
-For a user-visible handoff, launch the real target and capture runtime-smoke evidence. Static green and passing sensors do not prove that the screen mounted, authenticated, or populated with tenant data.
+Before the agent calls this finished, Vise holds it to:
 
-## Review checklist
+- Real SDK APIs — actual types and field names, not remembered ones.
+- The platform lifecycle — realtime data subscriptions and cleanup, pagination, session renewal, and user switching handled correctly.
+- The whole feature — loading, empty, and error states, not just the happy path.
+- Recorded decisions — your scope answers are part of the contract, so a reviewer can see what was agreed.
 
-- The selected SDK path is explicit.
-- Read and write targets come from route, app state, user selection, SDK discovery, or a create flow—not invented IDs.
-- Loading, empty, error, and data states are implemented.
-- Live collections, cleanup, pagination, session renewal, and user switching follow the platform SDK lifecycle.
-- Scope decisions for post types, composer types, comments, reactions, and moderation are recorded.
-- The final handoff includes remaining advisory findings and unresolved non-blocking decisions.
+Then run the app and look at it. Passing checks prove the code is right; only a real launch proves the screen mounts, authenticates, and fills with your tenant's data. Your agent can assess that launch and record it as runtime evidence — or record an explicit waiver if no device is available.
 
-<Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-  Understand the contract, evidence, runtime-proof boundary, and CI behavior.
-</Card>
+## Related
+
+<CardGroup cols={2}>
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    The loop your agent follows and what its reports mean.
+  </Card>
+  <Card title="UIKit quick launch" icon="window" href="/ai-mcp/vise/uikit-quickstart">
+    Prefer a prebuilt surface? Launch with UIKit instead.
+  </Card>
+</CardGroup>

--- a/ai-mcp/vise/uikit-quickstart.mdx
+++ b/ai-mcp/vise/uikit-quickstart.mdx
@@ -1,42 +1,39 @@
 ---
-title: "UIKit quick-launch path"
-description: "Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI."
+title: "UIKit quick launch"
+description: "Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits."
 ---
 
-Choose UIKit when the request is primarily a standard social surface, fast launch, white-label experience, or supported UIKit customization. Vise keeps UIKit fit and customization advisory while continuing to validate customer-owned configuration, SDK setup, authentication, and project sensors.
+Choose this path when you want a standard social surface live quickly — a community feed, chat, stories — using social.plus UIKit's prebuilt screens, themed to your brand.
 
-## Suggested request
+## What to ask
 
 ```text
-Use social.plus UIKit to launch a standard community feed in this app. Recommend the lowest customization level that fits the existing design system, and do not hand-roll the standard surface from SDK primitives.
+Use social.plus UIKit to launch a standard community feed in this app.
+Recommend the lowest customization level that fits our design system,
+and don't hand-roll standard surfaces from SDK primitives.
 ```
 
-## Confirm the path before implementation
+## What your agent will ask you
 
-```sh
-vise inspect .
-vise plan . --request "Use social.plus UIKit to launch a standard community feed" --summary
-```
+The usual product questions — platform, screen or route, region, identity — plus one that's specific to UIKit:
 
-Review `solutionPath` and `uikitCustomization`. If UIKit is the chosen path, repeat the plan and initialize with explicit answers such as:
+- **How much to customize.** The agent recommends the lightest level that fits your design system: theming and dynamic UI, component styling, localization, behavior overrides, or fork-and-extend as a last resort. You confirm the choice; it's recorded with the rest of the plan.
 
-```sh
-vise plan . --request "Use social.plus UIKit to launch a standard community feed" \
-  --answer solution_path=uikit \
-  --answer uikit_customization=dynamic-ui
-```
+## Staying on the UIKit path
 
-Also answer the platform, route, region, identity, and target questions Vise reports. The exact customization choice may instead be component styling, localization, behavior overrides, fork-and-extend, or a hybrid path.
+The skill keeps the agent honest about the boundary. Once UIKit is the chosen route, UIKit's installation, provider, behavior, and customization guidance is the implementation source — the agent shouldn't quietly rebuild a standard feed from raw SDK calls. Mixing in direct SDK code is reserved for behavior that's genuinely differentiated for your app.
 
-## Implementation boundary
+## What "done" looks like
 
-- Treat UIKit installation, provider/page, behavior, localization, and customization guidance as the primary implementation source.
-- Do not execute direct-SDK feed/chat/profile steps for a locked UIKit route.
-- Use hybrid only when UIKit covers standard surfaces and direct SDK code is genuinely needed for differentiated app behavior.
-- Do not claim deterministic validation of UIKit internals hidden outside the customer repository.
+Vise validates everything your app owns — SDK setup and region, authentication, configuration, and your project's own build, lint, and test checks. What it can't see inside prebuilt UIKit internals it won't claim to have verified. A themed UIKit screen still deserves product QA and a real launch before you ship it.
 
-Finish with `vise check`, `vise validate`, project sensors, and a real app launch. A themed UIKit screen still requires product QA and runtime verification.
+## Related
 
-<Card title="CLI reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
-  Review planning, validation, evidence, and sensor commands.
-</Card>
+<CardGroup cols={2}>
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    The loop your agent follows and what its reports mean.
+  </Card>
+  <Card title="Custom SDK UI" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
+    Need a differentiated experience? Build directly on the SDK.
+  </Card>
+</CardGroup>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69623,7 +69623,7 @@ The public docs MCP server:
 
 Choose the AI tool you use most often:
 
-    Use the local Vise CLI to guide, validate, and sensor-check AI-assisted SDK integrations.
+    Give your AI coding agent guardrails for building social.plus features — install Vise, add its skill, and ask.
     Connect Claude.ai or Claude Desktop to the social.plus MCP server.
     Connect GitHub Copilot in VS Code through MCP settings.
     Add the social.plus MCP server to Cursor's MCP configuration.
@@ -69664,7 +69664,7 @@ The public docs MCP server is best for:
 
 It is not a replacement for your app's local validation, build, test, or security review process.
 
-For local integration validation, use [Vise](/ai-mcp/vise/overview). Vise runs in your app repository, guides the AI coding loop, and checks the generated integration before you call it done. It can also run as a [local MCP server](/ai-mcp/vise/mcp-server).
+When an agent is **editing your app**, use [Vise](/ai-mcp/vise/overview): install it, add its skill to your agent, and it guides the coding loop and checks the generated integration before you call it done. It can also run as a [local MCP server](/ai-mcp/vise/mcp-server).
 
 ## Related docs
 
@@ -69677,57 +69677,19 @@ For local integration validation, use [Vise](/ai-mcp/vise/overview). Vise runs i
 
 ### [Vise](https://learn.social.plus/ai-mcp/vise/overview)
 
-> Use the local Vise CLI to guide and validate AI-assisted social.plus SDK integrations.
+> Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work.
 
-Vise is a local command-line tool for teams using AI coding agents to integrate social.plus SDKs. It gives the agent a repeatable workflow, grounds the plan in the public docs, writes a local compliance contract, and checks the implementation before you call it done.
+Vise makes AI coding agents good at integrating social.plus. Install it, add its skill to the agent you already use, then ask for the feature you want — a social feed, chat, communities, stories. Your agent writes the code; Vise keeps it grounded in the real SDK, asks you the decisions only you can make, and keeps checking until the feature is genuinely done.
 
-The agent still writes the code. Vise wraps that work in guardrails: it grounds the agent in real SDK APIs, checks correctness and completeness, helps align generated UI with your design system, and asks you the calls only a human should make — then keeps checking until the result is green, attested with evidence, intentionally scoped out, or explicitly blocked on your decision.
+You interact with Vise twice: once to install it, once to add the skill. After that, you talk to your agent — not to Vise.
 
-  **Preview release.** Vise is usable for guided social.plus SDK integrations, but its CLI surface, evidence format, and advisory intelligence may still change as it hardens through more real projects. Treat it as governed AI assistance with strong validation gates — not a substitute for code review, product QA, or runtime verification.
+## Get started
 
-  Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
-
-## Vise vs. the docs MCP server
-
-Both tools connect AI coding tools to social.plus, and they work well together.
-
-| Tool | Best for | Runs where |
-| --- | --- | --- |
-| [Docs MCP server](/ai-mcp/overview) | Searching and reading social.plus documentation inside an AI chat | Hosted at `https://learn.social.plus/mcp` |
-| Vise | Planning, validating, and sensor-running an integration in your app repository | Local CLI in your project |
-
-Use the hosted MCP server when you want an assistant to **find and read documentation**. Use Vise when the assistant is **editing your app** and you want local validation, sensors, and a clear stop condition. Vise can also run as a [local MCP server](/ai-mcp/vise/mcp-server) so MCP hosts call its tools directly.
-
-## Who should use Vise
-
-- **Developer using an AI coding agent** — Install the skill, ask for the SDK feature, answer project-specific questions, and let Vise drive the loop through plan, check, and sensors.
-- **Technical lead or reviewer** — Review the `sp-vise/` contract, deterministic findings, attestations, and the `vise check --ci` result — including re-verdicts of previously completed engagements — before accepting the integration.
-- **Partner or solutions engineer** — Use Vise as a repeatable delivery workflow across customer apps, so each integration ends with the same local evidence rather than a prompt transcript.
-- **Product or design owner** — Use the advisory design and experience outputs to review whether the generated surface fits the product intent. Correctness and explicit completeness checks remain the gates.
-
-## Install
-
-  Vise requires Node.js 20 or newer. Run `node --version` before installing if you are unsure which runtime your terminal or CI environment uses.
-
-Install Vise globally:
+  Vise requires Node.js 20 or newer.
 
 ```sh
 npm install -g @amityco/social-plus-vise
-vise doctor
 ```
-
-Or run it without a global install:
-
-```sh
-npx -y -p @amityco/social-plus-vise vise doctor
-```
-
-`vise doctor` prints the version, install path, and docs source so you can confirm the setup.
-
-## Install the AI skill
-
-Vise includes a bundled skill that teaches your AI coding tool when to inspect, plan, fetch docs, edit code, validate, and ask you for missing decisions. Install it for your tool:
-
 ```sh
 vise install-skill --target claude     # Claude Code
 vise install-skill --target cursor .   # Cursor
@@ -69736,263 +69698,277 @@ vise install-skill --target copilot .  # GitHub Copilot
 vise install-skill --target codex      # OpenAI Codex
 ```
 
-You can also print the skill and paste it into another coding agent:
+    Using a different agent? `vise print-skill` prints the skill so you can paste it anywhere.
+    Open your app in your agent and ask in plain language:
 
-```sh
-vise print-skill
+```text
+Add a social feed to this app using social.plus.
 ```
 
-## Quickstart
+```text
+Add chat between users in this app with social.plus.
+```
 
-    Work inside the app repository where you want to add social.plus SDK features.
-    For example: `Add a social feed to this app using the social.plus SDK.`
-    The skill guides the agent through `vise inspect`, `vise plan`, `vise init`, docs lookup, implementation, `vise check`, and `vise run-sensors`.
-    Vise asks for values the agent should not invent, such as region, feed target, community ID source, platform scope, or design-system source.
-    Done means the local contract is green, attested with evidence, or explicitly blocked on a decision only your team can make.
+```text
+We already use social.plus for the feed — add comments to it.
+```
+
+That's the whole setup. The skill teaches your agent when to inspect your project, ground its plan in the real social.plus SDK, and validate its own work — you watch that happen; you don't run it.
+
+## What happens next
+
+Once you ask for a feature, expect three things:
+
+1. **Your agent asks you a few product questions.** Things only you can decide — which region your app runs in, which screen the feature lives on, where a community ID comes from. Vise stops the agent from inventing these answers.
+2. **Your agent writes the code, and Vise checks it.** Not just "does it compile" — that the code uses APIs the SDK actually exposes, follows the platform's session and realtime-data lifecycle, and covers the whole feature: pagination, loading, empty, and error states, not just the happy path.
+3. **"Done" means verified, not "the agent stopped talking."** The work ends in one of a few honest states: every check passes, a check is satisfied in a way that's explained with recorded evidence, something was intentionally scoped out, or the agent is blocked waiting on a decision from you. The evidence lives in your repo (an `sp-vise/` folder), so a reviewer can see *why* the integration is trustworthy — not just that a chat transcript ended.
+
+## What Vise checks
+
+- **Real SDK usage** — the agent is held to source-anchored SDK facts (actual types and field names), so it can't invent an API that doesn't exist.
+- **Platform correctness** — 400+ checks for the mistakes that pass a demo and break in production: setup and region, session renewal, secret handling, realtime data lifecycle, and feature-specific patterns across feeds, chat, comments, communities, notifications, and more.
+- **Feature completeness** — the outcome you asked for, in full, including the optional capabilities you chose.
+- **Your project's own checks** — your repository's build, lint, typecheck, and test commands run as part of the loop.
+- **Design fit** — generated UI is reviewed against your design system. This part is advisory; brand judgment stays human.
+
+  **Preview release.** Vise is usable for guided social.plus integrations today, but details may still change as it hardens through more real projects. Treat it as strong guardrails for AI-assisted work — not a substitute for code review, product QA, or trying the feature on a real device.
+
+  Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
+
+## Vise and the docs MCP server
+
+Both connect AI tools to social.plus, and they work well together.
+
+| Tool | What it does | Runs where |
+| --- | --- | --- |
+| [Docs MCP server](/ai-mcp/overview) | Lets an assistant search and read social.plus documentation | Hosted at `https://learn.social.plus/mcp` |
+| Vise | Guides and validates an agent that is **editing your app** | Locally, in your project |
+
+Vise can also expose its tools [over MCP](/ai-mcp/vise/mcp-server) if your agent host prefers MCP tools to a skill.
 
 ## Next steps
 
-    Inspect a real app and review a grounded plan before using production credentials or changing code.
-    The governed loop, what Vise checks, and how to read a check result.
-    Expose Vise's tools to Claude Code, Cursor, Codex, and VS Code.
-    The commands you'll run most, grouped by task.
-    Install and initialize social.plus SDKs for your platform.
+    Watch your agent plan a real integration — no credentials, no code changes.
+    What the skill drives, what gets checked, and what "done" means.
+    Optional: expose Vise's tools to MCP-capable hosts.
+    The commands for reviewing recorded evidence and gating releases.
 
 ---
 
-### [Evaluate Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate)
+### [Try Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate)
 
-> Inspect a real app and review a grounded Vise plan before using production credentials or changing code.
+> Add the skill to your agent and watch it plan a real integration — no credentials, no code changes.
 
-This evaluation shows how Vise reads an app, identifies the integration surface, and asks for decisions an AI agent should not invent. It deliberately stops before implementation, so you can assess the workflow without production credentials or source changes.
+This walkthrough shows what working with Vise feels like before you commit to anything. You'll ask your agent to *plan* an integration and stop there — so you can judge the workflow without production credentials or source changes.
 
-  Vise requires Node.js 20 or newer. Vise itself runs locally and does not upload your source code, file contents, or search queries. Your AI coding host follows its own data policy.
+  Vise requires Node.js 20 or newer. It runs locally and does not upload your source code, file contents, or search queries. Your AI coding tool follows its own data policy.
 
 ## Run the evaluation
 
-Use a clean branch or disposable copy of a real app repository.
+Use a clean branch or a disposable copy of a real app repository — a real codebase shows you far more than an empty scaffold.
 
 ```sh
-npx -y -p @amityco/social-plus-vise vise doctor
+npm install -g @amityco/social-plus-vise
+vise install-skill --target claude     # or: cursor . / vscode . / copilot . / codex
 ```
-
-    Confirm that the command reports the installed version and hosted documentation source.
-```sh
-npx -y -p @amityco/social-plus-vise vise inspect .
-```
-
-    Review the detected platform, app surfaces, design signals, sensors, and scan coverage. If the scan is incomplete or several app surfaces are detected, select the concrete app before continuing.
-```sh
-npx -y -p @amityco/social-plus-vise vise plan . \
-  --request "Add a social feed to this app" \
-  --summary
-```
-
-    A useful plan identifies the implementation path, cites relevant social.plus documentation, and lists unresolved project decisions such as region, route, feed scope, and target source.
-    Do not invent answers or run `vise init` during this short evaluation. The expected result is a grounded route and a reviewable decision list—not generated code or runtime proof.
-
-## What this proves
-
-- The package can run in your environment.
-- Vise recognizes the intended app surface and supported platform.
-- The plan is grounded in social.plus documentation and local project signals.
-- Missing product and integration decisions are explicit instead of silently guessed.
-
-## What this does not prove
-
-- That an SDK or UIKit integration has been implemented.
-- That `vise check`, project sensors, or the app runtime will pass.
-- That the selected social surface works with your tenant data and credentials.
-
-## Choose the next path
-
-    Build a differentiated app-owned experience directly on the social.plus SDK.
-    Use prebuilt social.plus UIKit surfaces and the lowest suitable customization level.
-    Add a feature to an app that already uses social.plus without losing earlier evidence.
-
----
-
-### [Custom SDK UI path](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui)
-
-> Use Vise to govern a differentiated social.plus experience built directly on the SDK.
-
-Choose the SDK path when the app needs a differentiated layout, workflow, or interaction model that should remain owned by the host application.
-
-## Suggested request
+    Open the app in your agent and ask:
 
 ```text
-Add a social feed to this app using the social.plus SDK. Keep the UI consistent with the existing design system and ask me for any missing scope, target, route, region, or identity decisions before editing.
+Using Vise, plan how you'd add a social feed to this app with social.plus.
+Don't change any code yet — show me the plan and the questions
+you'd need me to answer first.
 ```
+    A good result has three parts:
 
-## Governed loop
+    - **Your app, recognized.** The agent identifies the platform and, in a monorepo, which app the feature would land in.
+    - **A grounded route.** The plan cites real social.plus documentation and SDK capabilities — not remembered or invented APIs.
+    - **Questions instead of guesses.** Decisions the agent should never make alone — region, target screen, where the feed's data comes from — arrive as explicit questions for you.
+    Don't answer the questions yet — answering them is what moves the agent into implementation. For the evaluation, the deliverable is the plan and the decision list, and you've seen the most important behavior already: the agent asked rather than guessed.
 
-```sh
-vise inspect .
-vise plan . --request "Add a social feed to this app using the social.plus SDK" --summary
-```
+Curious what happened under the hood? The agent ran a couple of Vise commands on your behalf — you can see them in its transcript, and they're documented in the [reference](/ai-mcp/vise/cli-reference). You never need to run them yourself.
 
-Review the plan, then repeat the full `vise plan` and `vise init` commands with one explicit `--answer id=value` flag for every blocking question. Do not place API keys or server-issued tokens in command history or AI chat; use the app's ignored local environment/configuration pattern.
+## What this shows
 
-After the agent implements the agreed surface:
+- Vise works in your environment, with your agent.
+- It reads your actual codebase, not a template.
+- Plans are grounded in social.plus documentation.
+- Product decisions are surfaced to you instead of silently invented.
 
-```sh
-vise check .
-vise validate .
-vise run-sensors .
-```
+## What this doesn't show
 
-For a user-visible handoff, launch the real target and capture runtime-smoke evidence. Static green and passing sensors do not prove that the screen mounted, authenticated, or populated with tenant data.
+- An implemented, validated integration — nothing was built yet.
+- That the feature works with your tenant data and credentials.
+- Runtime behavior on a device or in a browser.
 
-## Review checklist
+To see those, take the next step: answer the agent's questions and let it implement. Vise then checks the work until it's verifiably done.
 
-- The selected SDK path is explicit.
-- Read and write targets come from route, app state, user selection, SDK discovery, or a create flow—not invented IDs.
-- Loading, empty, error, and data states are implemented.
-- Live collections, cleanup, pagination, session renewal, and user switching follow the platform SDK lifecycle.
-- Scope decisions for post types, composer types, comments, reactions, and moderation are recorded.
-- The final handoff includes remaining advisory findings and unresolved non-blocking decisions.
+## Choose your integration path
 
-  Understand the contract, evidence, runtime-proof boundary, and CI behavior.
+    A differentiated, app-owned experience built directly on the social.plus SDK.
+    Prebuilt social.plus UIKit surfaces with the lightest customization that fits.
+    Add a feature to an app that already uses social.plus.
 
 ---
 
-### [UIKit quick-launch path](https://learn.social.plus/ai-mcp/vise/uikit-quickstart)
+### [Custom SDK UI](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui)
 
-> Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI.
+> Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app.
 
-Choose UIKit when the request is primarily a standard social surface, fast launch, white-label experience, or supported UIKit customization. Vise keeps UIKit fit and customization advisory while continuing to validate customer-owned configuration, SDK setup, authentication, and project sensors.
+Choose this path when the feature needs your own layout, workflow, or interaction model — UI your app owns, built directly on the social.plus SDK.
 
-## Suggested request
+## What to ask
 
 ```text
-Use social.plus UIKit to launch a standard community feed in this app. Recommend the lowest customization level that fits the existing design system, and do not hand-roll the standard surface from SDK primitives.
+Add a social feed to this app using the social.plus SDK. Keep the UI
+consistent with the existing design system, and ask me about any missing
+scope, target, route, region, or identity decisions before editing.
 ```
 
-## Confirm the path before implementation
+## What your agent will ask you
 
-```sh
-vise inspect .
-vise plan . --request "Use social.plus UIKit to launch a standard community feed" --summary
-```
+Expect questions before any code changes. Typical ones for an app-owned surface:
 
-Review `solutionPath` and `uikitCustomization`. If UIKit is the chosen path, repeat the plan and initialize with explicit answers such as:
+- **Region** — which social.plus region your app runs in.
+- **Where it lives** — the screen or route that hosts the new surface.
+- **Where data comes from** — the feed or community target: from a route, app state, user selection, SDK discovery, or a create flow. Vise won't let the agent hard-code an invented ID.
+- **Scope** — which post types, composer options, comments, reactions, and moderation behavior are in or out.
 
-```sh
-vise plan . --request "Use social.plus UIKit to launch a standard community feed" \
-  --answer solution_path=uikit \
-  --answer uikit_customization=dynamic-ui
-```
+  Don't paste API keys or server-issued tokens into the chat. Point the agent at your app's ignored environment/configuration pattern instead.
 
-Also answer the platform, route, region, identity, and target questions Vise reports. The exact customization choice may instead be component styling, localization, behavior overrides, fork-and-extend, or a hybrid path.
+## What "done" looks like
 
-## Implementation boundary
+Before the agent calls this finished, Vise holds it to:
 
-- Treat UIKit installation, provider/page, behavior, localization, and customization guidance as the primary implementation source.
-- Do not execute direct-SDK feed/chat/profile steps for a locked UIKit route.
-- Use hybrid only when UIKit covers standard surfaces and direct SDK code is genuinely needed for differentiated app behavior.
-- Do not claim deterministic validation of UIKit internals hidden outside the customer repository.
+- Real SDK APIs — actual types and field names, not remembered ones.
+- The platform lifecycle — realtime data subscriptions and cleanup, pagination, session renewal, and user switching handled correctly.
+- The whole feature — loading, empty, and error states, not just the happy path.
+- Recorded decisions — your scope answers are part of the contract, so a reviewer can see what was agreed.
 
-Finish with `vise check`, `vise validate`, project sensors, and a real app launch. A themed UIKit screen still requires product QA and runtime verification.
+Then run the app and look at it. Passing checks prove the code is right; only a real launch proves the screen mounts, authenticates, and fills with your tenant's data. Your agent can assess that launch and record it as runtime evidence — or record an explicit waiver if no device is available.
 
-  Review planning, validation, evidence, and sensor commands.
+## Related
+
+    The loop your agent follows and what its reports mean.
+    Prefer a prebuilt surface? Launch with UIKit instead.
 
 ---
 
-### [Brownfield and day-2 path](https://learn.social.plus/ai-mcp/vise/brownfield-day2)
+### [UIKit quick launch](https://learn.social.plus/ai-mcp/vise/uikit-quickstart)
 
-> Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable.
+> Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
 
-Vise supports both apps that adopted social.plus before Vise and apps whose earlier features already have a Vise contract.
+Choose this path when you want a standard social surface live quickly — a community feed, chat, stories — using social.plus UIKit's prebuilt screens, themed to your brand.
 
-## Existing integration built without Vise
+## What to ask
 
-Initialize the new feature before editing. If Vise reports pre-existing findings, record a baseline immediately:
-
-```sh
-vise init . --request "Add comments to the existing feed" \
-  --answer comment_target=post \
-  --answer comment_depth="one level of replies" \
-  --answer lifecycle_owner="React component" \
-  --answer target_screen="existing feed detail"
-vise baseline .
+```text
+Use social.plus UIKit to launch a standard community feed in this app.
+Recommend the lowest customization level that fits our design system,
+and don't hand-roll standard surfaces from SDK primitives.
 ```
 
-Then gate new rule findings with:
+## What your agent will ask you
 
-```sh
-vise check . --new-only
+The usual product questions — platform, screen or route, region, identity — plus one that's specific to UIKit:
+
+- **How much to customize.** The agent recommends the lightest level that fits your design system: theming and dynamic UI, component styling, localization, behavior overrides, or fork-and-extend as a last resort. You confirm the choice; it's recorded with the rest of the plan.
+
+## Staying on the UIKit path
+
+The skill keeps the agent honest about the boundary. Once UIKit is the chosen route, UIKit's installation, provider, behavior, and customization guidance is the implementation source — the agent shouldn't quietly rebuild a standard feed from raw SDK calls. Mixing in direct SDK code is reserved for behavior that's genuinely differentiated for your app.
+
+## What "done" looks like
+
+Vise validates everything your app owns — SDK setup and region, authentication, configuration, and your project's own build, lint, and test checks. What it can't see inside prebuilt UIKit internals it won't claim to have verified. A themed UIKit screen still deserves product QA and a real launch before you ship it.
+
+## Related
+
+    The loop your agent follows and what its reports mean.
+    Need a differentiated experience? Build directly on the SDK.
+
+---
+
+### [Adding to an existing app](https://learn.social.plus/ai-mcp/vise/brownfield-day2)
+
+> Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it.
+
+The second feature gets the same guardrails as the first. Just ask:
+
+```text
+We already use social.plus for the feed — add comments to it.
 ```
 
-The baseline excludes legacy rule findings only. The new feature's completeness checklist and selected capabilities still have to pass.
+Vise handles both histories your app might have.
 
-## Existing integration already governed by Vise
+## The existing integration was built by hand
 
-Initializing a different outcome records the previous engagement under `sp-vise/engagements/`. Replacing a green engagement requires an explicit acknowledgement:
+If your app adopted social.plus before Vise, the codebase may carry findings Vise would flag today. The agent snapshots those as a **baseline** before writing any code, so your new feature is judged on its own merits — not blocked by legacy code you didn't touch.
 
-```sh
-vise init . --request "Add comments to the existing feed" \
-  --supersede-engagement \
-  --answer comment_target=post \
-  --answer comment_depth="one level of replies" \
-  --answer lifecycle_owner="React component" \
-  --answer target_screen="existing feed detail"
+Two guarantees keep the baseline honest:
+
+- It excludes only pre-existing findings. Anything the new work introduces still gates.
+- The feature you asked for is never baselined — the app can't pass without the feature actually being built, complete with its agreed scope.
+
+## Earlier features were built with Vise
+
+Finished features stay recorded, visible, and re-verifiable. When the agent starts a new feature, the previous one's final state is preserved and the switch is disclosed — and replacing a feature that already passed requires an explicit confirmation from you, so nothing green is silently overwritten.
+
+At any point you can ask:
+
+```text
+Check whether the features we built earlier with Vise still hold.
 ```
 
-Review prior work at any time:
+If a later change broke a previously finished surface, you'll be told exactly which one drifted — even while the current work passes.
+
+## Keep everything verified in CI
+
+One read-only command in your pipeline holds the current work *and* every previously finished feature green:
 
 ```sh
-vise status .
-vise check . --engagement <outcome>
-vise check . --all-engagements
+vise check --ci
 ```
 
-In CI, one command holds the active and recorded engagements green:
+It fails with a distinct exit code when a finished feature drifts, even if the active work passes. See the [reference](/ai-mcp/vise/cli-reference) for baseline and re-verification details.
 
-```sh
-vise check . --ci
-```
+## When you review the handoff
 
-Exit `11` means the active feature is green but previously completed work drifted.
+- Was a baseline used, and when was it recorded?
+- Do earlier features still hold, or did the agent disclose drift?
+- Is there runtime proof for the new surface — or an explicit, recorded waiver?
+- Are remaining advisory findings and open non-blocking decisions listed?
 
-## Handoff checklist
-
-- State whether a baseline was used and when it was recorded.
-- Identify the active outcome and every recorded previous engagement.
-- Report unresolved non-blocking intake and any scope-omit decisions.
-- Include runtime proof or an explicit waiver for the new user-visible surface.
-- Do not describe a green active engagement as sufficient when `--ci` reports previous-engagement drift.
-
-  Understand active failures, proof waivers, contract drift, and engagement drift.
+  Contracts, evidence, and what your agent's reports mean.
 
 ---
 
 ### [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works)
 
-> The governed loop, what Vise checks, and how to read a compliance result.
+> The loop the skill drives your agent through, what gets checked, and what 'done' means.
 
-Vise turns an SDK request into a grounded plan, records a local contract, and keeps checking the generated code until the integration is finished — where "finished" means green, attested with evidence, intentionally scoped, or explicitly blocked on your input, not just "the agent stopped."
+Vise turns your feature request into a grounded plan, records what "done" means for it, and keeps checking the generated code until the integration is finished — where finished means verified, explained with evidence, intentionally scoped out, or explicitly waiting on your decision. Never just "the agent stopped."
 
-## The governed loop
+## The loop your agent follows
 
-The bundled [skill](/ai-mcp/vise/overview#install-the-ai-skill) drives your AI agent through the same loop on every integration:
+The [skill](/ai-mcp/vise/overview#get-started) drives your agent through the same loop on every integration:
 
 ```mermaid
 flowchart LR
-  A[inspect] --> B[plan]
-  B --> C[init contract]
+  A[understand your app] --> B[plan from the docs]
+  B --> C[record the contract]
   C --> D[implement]
   D --> E[check]
-  E -->|not green| D
-  E -->|green| F[run-sensors]
+  E -->|not done| D
+  E -->|passes| F[run your project's checks]
   F --> G[done: evidence recorded]
 ```
 
-- **inspect** — detect the platform, monorepo surfaces, design signals, and available sensors. Inspection includes bounded scan receipts; if a large repository cannot be scanned completely, select the concrete app surface before continuing.
-- **plan** — produce a grounded plan with docs citations and the project-specific questions the agent must not guess.
-- **init** — write the local compliance contract under `sp-vise/` once blocking questions are answered.
-- **implement** — the agent edits your app, grounded in real SDK APIs.
-- **check** — re-validate the code against the recorded contract.
-- **run-sensors** — run your project's own build, lint, typecheck, and SDK smoke checks.
+- **Understand your app** — detect the platform, the app surfaces in a monorepo, design signals, and which of your project's own checks are available. In a very large repository, the agent confirms which concrete app it's working in before continuing.
+- **Plan from the docs** — produce a plan with social.plus docs citations, plus the questions the agent must ask you rather than guess.
+- **Record the contract** — once you've answered, the expectations for this feature are written down (see below).
+- **Implement** — the agent edits your app, held to real SDK APIs.
+- **Check** — the code is validated against the recorded contract; the agent iterates until it passes.
+- **Run your project's checks** — your repository's own build, lint, typecheck, and SDK smoke checks.
 
 ## What Vise checks
 
@@ -70006,80 +69982,55 @@ Vise focuses on the mistakes that pass a demo and break in production:
 
 Deterministic SDK correctness and explicit completeness decisions are the checks that block. Design and experience guidance stays advisory.
 
-## The `sp-vise/` contract
+## The `sp-vise/` folder
 
-`vise init` writes a local contract directory, `sp-vise/`, that records what the integration is expected to satisfy for the detected platform and requested outcome. Subsequent `vise check` runs validate the current code against it. Commit `sp-vise/` with your app so the same expectations run in review and in CI.
+The recorded contract, its check results, and all supporting evidence live in a small `sp-vise/` folder in your repo. Commit it with your app: it's what lets a reviewer see *why* the integration is trustworthy — and what lets CI keep verifying the work after the chat transcript is long gone.
 
-## Reading a check result
+## What your agent will report
 
-`vise check` reports one of the following states:
+Every check ends in one of these states. Your agent will name them when it reports back, so here's what each one means for you:
 
-| Result | Meaning | What to do |
+| State | Meaning | What you do |
 | --- | --- | --- |
 | `green` | Every applicable check passes | Accept the integration |
-| `needs-attestation` | A rule passed through architecture the deterministic check can't see | Record an attestation with evidence (see below) |
-| `deterministic-failures` | A rule failed deterministically in the code | Fix the code and re-check |
-| `completeness-gap` | The requested outcome isn't fully covered yet | Implement the missing surface or capability |
-| `selected-capability-failures` | An optional capability you chose to include isn't satisfied | Complete or intentionally drop that capability |
-| `blocked` | A decision only your team can make is missing | Answer the intake or confirm the plan |
-| `contract-drift` | The code no longer matches the recorded contract | Re-plan or re-initialize the contract |
-| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept with `--allow-proof-waiver` if appropriate |
+| `needs-attestation` | A rule is satisfied through architecture the automatic check can't see | Let the agent record evidence and a rationale, then review it |
+| `deterministic-failures` | A rule failed in the code | Nothing — the agent fixes and re-checks |
+| `completeness-gap` | The feature you asked for isn't fully built yet | Nothing — the agent keeps going, or asks you to drop scope explicitly |
+| `selected-capability-failures` | An optional capability you chose isn't satisfied | Decide: finish it, or intentionally drop it |
+| `blocked` | A decision only your team can make is missing | Answer the question |
+| `contract-drift` | The code no longer matches what was recorded | Decide with the agent: re-plan, or restore the code |
+| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept the recorded waiver, or ask for a real run |
 | `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Your current work is green, but a previously finished surface no longer holds (`--ci` or `--all-engagements`, exit `11`) | Re-open the drifted surface or re-attest what changed |
+| `engagement-drift` | Current work is fine, but a previously finished feature no longer holds | Re-open the drifted feature or accept the documented change |
 
-Add `--ci` for a read-only release gate. It checks the active contract and automatically re-verdicts every recorded engagement, exiting non-zero unless all governed work remains green.
+## Evidence instead of "trust me"
 
-## Attestation and evidence
+Three kinds of proof accumulate in `sp-vise/` as the agent works:
 
-Some correct integrations pass through indirection the static check can't follow — a helper module, a wrapper, or a pattern unique to your codebase. When that happens, the result is `needs-attestation`: you record that the rule is satisfied, with evidence and a rationale, instead of the check silently failing.
+- **Attestations.** Some correct code passes through indirection a static check can't follow — a helper module, a wrapper, a pattern unique to your codebase. Instead of failing silently or passing blindly, the agent records *why* the rule is satisfied, with evidence and a rationale you can audit.
+- **Runtime proof.** For user-visible surfaces, Vise can assess a captured app-launch log into a pass/fail verdict — did the screen mount, authenticate, and load data? When no device or emulator is available, an explicit waiver is recorded instead of a silent pass.
+- **Deterministic passes.** After a green check, the passing evidence itself is persisted, so review doesn't depend on re-running anything.
 
-```sh
-vise explain <ruleId>          # rule rationale, evidence needed, remediation
-vise attest . --rule <ruleId> --signer host-agent --confidence high \
-  --evidence-file evidence.json --rationale "why this is satisfied"
-vise sync .                    # persist deterministic-pass evidence after a green check
-```
+Reviewers can inspect all of it with a few read-only commands — see the [reference](/ai-mcp/vise/cli-reference).
 
-Attestations and evidence live under `sp-vise/`, so a reviewer can see *why* something is green — not just that a prompt finished.
+## Adding features later
 
-## Runtime proof and waivers
+The second feature is governed as carefully as the first, whether the existing integration was built by hand or through Vise — and earlier finished features stay recorded and re-verifiable. See [Adding to an existing app](/ai-mcp/vise/brownfield-day2).
 
-For surfaces that should be proven at runtime, Vise can assess a captured mount-smoke log into a pass/fail verdict. When a device or emulator isn't available, or you decline runtime proof, record an auditable waiver instead of a silent pass:
+## Vise in CI
 
-```sh
-vise smoke . --log run.log                          # assess a captured smoke log
-vise smoke waive . --reason "no emulator in CI" --mode deviceless
-```
-
-## Adding features to an app that already uses social.plus
-
-The second feature is governed as carefully as the first. Two situations:
-
-**The existing integration was built by hand.** Run `vise init` for the new request as normal. If the repo carries pre-existing findings, the init result includes a `brownfield` hint: record `vise baseline .` **before writing any code**, then gate your work with `vise check --new-only`. The baseline excludes legacy rule findings only — the feature you asked for still has to be built, and its completeness checklist still gates.
-
-**The existing features were built through Vise.** The sidecar governs one engagement at a time, but switching is recorded, not destructive: initializing a new outcome writes the previous engagement's final state to `sp-vise/engagements/` and discloses the switch in the result; replacing a **green** engagement additionally asks for `--supersede-engagement`. Finished surfaces stay visible in `vise status` under `previousEngagements`, and stay verifiable:
+After the first successful integration, commit `sp-vise/` and add one read-only command to your pipeline:
 
 ```sh
-vise check --engagement <outcome>   # re-verify one finished surface (exit 11 on drift)
-vise check --all-engagements        # current work + every finished surface, in one run
+vise check --ci
 ```
 
-## Add Vise to CI
-
-After the first successful integration, commit `sp-vise/` and run Vise in CI:
-
-```sh
-vise check --ci   # read-only; active contract + every recorded engagement
-```
-
-Use `--all-engagements` when you want the same combined re-verdict outside CI. It is not an additional command that CI needs to run after `--ci`.
-
-When adopting Vise on an existing codebase, use `vise baseline` to snapshot pre-existing rule findings, then `vise check --new-only` to gate only on findings introduced since. The requested outcome's completeness is never baselined — a baselined repo can't go green without the feature actually being built.
+It verifies the active contract *and* re-verdicts every previously finished feature, failing the build unless all governed work still holds. Baseline behavior for pre-existing codebases and per-feature re-verification are covered in the [reference](/ai-mcp/vise/cli-reference).
 
 ## Related
 
-    Install Vise and run your first integration.
-    The commands behind each step of the loop.
+    Install Vise and ask for your first feature.
+    The commands for verifying recorded evidence and gating releases.
     Build realtime SDK features with the correct lifecycle.
     User login, session renewal, and regional configuration.
 
@@ -70176,7 +70127,7 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 
 ## Skill or MCP?
 
-The [skill](/ai-mcp/vise/overview#install-the-ai-skill) and the MCP server are complementary:
+The [skill](/ai-mcp/vise/overview#get-started) and the MCP server are complementary:
 
 - The **skill** teaches the agent *when* to inspect, plan, fetch docs, validate, and attest.
 - The **MCP server** exposes the *tools* the agent calls to do it.
@@ -70192,13 +70143,13 @@ For MCP-capable hosts, install the skill **and** register the MCP server. On hos
 
 ---
 
-### [CLI reference](https://learn.social.plus/ai-mcp/vise/cli-reference)
+### [Command reference](https://learn.social.plus/ai-mcp/vise/cli-reference)
 
-> The Vise commands you'll run most often, grouped by task.
+> For reviewers and CI — the commands behind the skill, and the ones you run to verify recorded evidence.
 
-This page covers the commands most integrations use. For the complete list and every flag, run `vise --help` or `vise <command> --help`. Each command has an [MCP tool equivalent](/ai-mcp/vise/mcp-server#what-it-exposes) in snake_case.
+Day to day, you don't need this page: your agent runs these commands through the [skill](/ai-mcp/vise/overview#get-started). It exists for the moments a human drives Vise directly — reviewing recorded evidence, gating a release in CI, or peeking under the hood. For the complete list and every flag, run `vise --help` or `vise <command> --help`. Each command has an [MCP tool equivalent](/ai-mcp/vise/mcp-server#what-it-exposes) in snake_case.
 
-  Most commands take a project path (default: the current directory) and write their state under `sp-vise/`. Commands that change generated code are run by your AI agent through the [skill](/ai-mcp/vise/overview#install-the-ai-skill); the commands below are the ones you or your reviewer run directly.
+  Most commands take a project path (default: the current directory) and read or write state under `sp-vise/`. The ones reviewers reach for most: `vise status`, `vise check --ci`, and `vise explain`.
 
 ## Explore and plan
 
@@ -70231,7 +70182,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
-See [Reading a check result](/ai-mcp/vise/how-it-works#reading-a-check-result) for what each state means.
+See [What your agent will report](/ai-mcp/vise/how-it-works#what-your-agent-will-report) for what each state means.
 
 ## Evidence
 

--- a/llms.txt
+++ b/llms.txt
@@ -429,14 +429,14 @@
 ## AI / MCP
 
 - [AI / MCP](https://learn.social.plus/ai-mcp/overview): Connect AI coding tools to the social.plus documentation MCP server.
-- [Vise](https://learn.social.plus/ai-mcp/vise/overview): Use the local Vise CLI to guide and validate AI-assisted social.plus SDK integrations.
-- [Evaluate Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate): Inspect a real app and review a grounded Vise plan before using production credentials or changing code.
-- [Custom SDK UI path](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui): Use Vise to govern a differentiated social.plus experience built directly on the SDK.
-- [UIKit quick-launch path](https://learn.social.plus/ai-mcp/vise/uikit-quickstart): Use Vise to choose and govern a prebuilt social.plus UIKit integration without drifting into unnecessary custom SDK UI.
-- [Brownfield and day-2 path](https://learn.social.plus/ai-mcp/vise/brownfield-day2): Add another social.plus feature while keeping existing integrations and earlier Vise engagements reviewable.
-- [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works): The governed loop, what Vise checks, and how to read a compliance result.
+- [Vise](https://learn.social.plus/ai-mcp/vise/overview): Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work.
+- [Try Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate): Add the skill to your agent and watch it plan a real integration — no credentials, no code changes.
+- [Custom SDK UI](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui): Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app.
+- [UIKit quick launch](https://learn.social.plus/ai-mcp/vise/uikit-quickstart): Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
+- [Adding to an existing app](https://learn.social.plus/ai-mcp/vise/brownfield-day2): Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it.
+- [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works): The loop the skill drives your agent through, what gets checked, and what 'done' means.
 - [Run Vise as an MCP server](https://learn.social.plus/ai-mcp/vise/mcp-server): Expose Vise's local tools to Claude Code, Cursor, Codex, and VS Code over MCP.
-- [CLI reference](https://learn.social.plus/ai-mcp/vise/cli-reference): The Vise commands you'll run most often, grouped by task.
+- [Command reference](https://learn.social.plus/ai-mcp/vise/cli-reference): For reviewers and CI — the commands behind the skill, and the ones you run to verify recorded evidence.
 - [Claude](https://learn.social.plus/ai-mcp/claude-desktop): Connect social.plus to Claude — both claude.ai web and the Claude Desktop app.
 - [VS Code](https://learn.social.plus/ai-mcp/vscode): Connect social.plus to GitHub Copilot in VS Code via the MCP server.
 - [Cursor](https://learn.social.plus/ai-mcp/cursor): Connect social.plus to Cursor's built-in MCP client.


### PR DESCRIPTION
## Why

The Vise docs taught the CLI, not the product. Across the eight pages a reader encountered ~30 distinct `vise` commands, and five of the eight pages instructed the **human** to hand-type commands that, in the real flow, the agent runs for them through the skill. The actual user contract is two commands — `npm install -g @amityco/social-plus-vise` and `vise install-skill --target <host>` — followed by a plain-language ask to your agent.

## What changed

- **overview** — leads with the outcome, then a 3-step get-started (install → add skill → ask) with example prompts as the primary artifact, and a "what happens next" section that sets expectations in user terms (the agent asks you product questions; Vise checks the code; done means verified). The MCP comparison and preview/privacy callouts kept, moved below the fold. Internal command names removed from the quickstart.
- **evaluate** — the 15-minute trial no longer hand-types `doctor`/`inspect`/`plan`; it installs the skill and asks the agent for a plan-only run, then reviews what comes back.
- **sdk-custom-ui / uikit-quickstart / brownfield-day2** — rewritten as prompt-first guides: what to ask, what the agent will ask you, what "done" looks like. Raw command sequences and internal intake keys (e.g. `--answer solution_path=uikit`) removed.
- **how-it-works** — same trust story; loop labels in plain language; the results table reframed as "what your agent will report"; attestation/runtime-proof/sync kept as concepts without command syntax.
- **cli-reference** — retitled **Command reference**, explicitly framed for reviewers and CI.
- **ai-mcp overview** — Vise card and closing paragraph reworded skill-first.
- Stale `#install-the-ai-skill` / `#reading-a-check-result` anchors retargeted.

User-facing pages now carry at most one command each (`install-skill` on evaluate; `vise check --ci` as the CI gate on brownfield/how-it-works — the one command that is legitimately human-run).

## Verification

- `.docs-ops/ci/check-mdx.py` — 9 files checked, 0 problems
- No dangling anchors (`grep` for the renamed heading slugs is clean)
- All page URLs unchanged — no redirects or docs.json changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)