### PR TITLE
docs(vise): simplify use-case guidance

### DIFF
--- a/ai-mcp/vise/brownfield-day2.mdx
+++ b/ai-mcp/vise/brownfield-day2.mdx
@@ -1,81 +1,89 @@
 ---
-title: "Adding to an existing app"
-description: "Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it."
+title: "Maintain an existing integration"
+description: "Add a feature, diagnose a problem, or upgrade the SDK without losing confidence in the social.plus experiences that already work."
 ---
 
-The second feature gets the same guardrails as the first. Just ask:
+Use this path when the app already has social.plus. Start with the outcome or symptom; your agent chooses the Vise workflow.
 
-```text
-We already use social.plus for the feed — add comments to it.
-```
+<Tabs>
+  <Tab title="Add or change a feature">
+    Ask for the new behavior and name what must keep working:
 
-Vise handles both histories your app might have.
+    ```text
+    We already use social.plus for the feed. Using Vise, add comments to the
+    existing post detail screen. Preserve the current feed behavior and show
+    me the impact and product questions before changing code.
+    ```
 
-## Start with a read-only impact assessment
+    Expect a short assessment of the existing surface, the new scope, affected files and evidence, and any product decisions still missing.
+  </Tab>
+  <Tab title="Fix a problem">
+    Describe what the user sees, where it happens, and what should happen instead:
 
-Before the agent edits an existing integration, it runs:
+    ```text
+    Using Vise, diagnose why the feed is missing from the selected Community
+    detail page. Show me the likely gap and the smallest safe repair before
+    changing code.
+    ```
 
-```sh
-vise impact . --format human
-```
+    The agent should compare the intended route and data target with the current source and evidence, then separate the repair from the checks that need to be refreshed.
+  </Tab>
+  <Tab title="Upgrade the SDK">
+    Ask for the version and feature impact before changing dependencies:
 
-The Day-2 Change Planner compares the current project with the recorded contract, dependency snapshot, engagement history, design contract, attestations, and runtime evidence. It classifies evidence as preserved, stale, missing, or unknown, then returns the smallest safe sequence of existing commands. It does not edit code or sidecars, switch engagements, accept policy changes, run sensors, or record attestations.
+    ```text
+    Using Vise, assess the social.plus SDK upgrade in this app. Explain the
+    current and target version boundary, affected features, and validation
+    plan before changing dependencies or source code.
+    ```
 
-If the change starts with a reported product symptom, include it:
+    Vise checks the declaration and supported lockfile resolution. It reports the assurance boundary honestly rather than treating a version range as proof of compatibility.
+  </Tab>
+</Tabs>
 
-```sh
-vise impact . \
-  --symptom "Feed is missing from the selected Community detail page" \
-  --format human
-```
+## Protect what already works
 
-For a recorded cross-surface journey, Vise can correlate that symptom with the signed placement and target relationship and the current source. It distinguishes an implementation gap from code that has been repaired but still needs fresh static and runtime proof.
+Before editing, the agent should identify the existing feature, route, data target, and evidence that could be affected.
 
-## The existing integration was built by hand
+If the integration predates Vise, pre-existing findings can be recorded as a baseline so the new change is judged on its own work. The baseline never excuses the requested outcome or anything the change introduces.
 
-If your app adopted social.plus before Vise, the codebase may carry findings Vise would flag today. The agent snapshots those as a **baseline** before writing any code, so your new feature is judged on its own merits — not blocked by legacy code you didn't touch.
+If earlier features were built with Vise, they stay recorded and re-verifiable. Ask the agent to report earlier-feature drift separately from the current work.
 
-Two guarantees keep the baseline honest:
+## What "done" looks like
 
-- It excludes only pre-existing findings. Anything the new work introduces still gates.
-- The feature you asked for is never baselined — the app can't pass without the feature actually being built, complete with its agreed scope.
+The handoff should state:
 
-## Earlier features were built with Vise
+- what behavior and scope changed
+- whether every earlier completed feature still holds
+- which project build, lint, typecheck, test, and SDK smoke checks ran
+- whether changed user-visible surfaces have fresh runtime proof or an explicit waiver
+- which advisory findings or product decisions remain open
 
-Finished features stay recorded, visible, and re-verifiable. When the agent starts a new feature, the previous one's final state is preserved and the switch is disclosed — and replacing a feature that already passed requires an explicit confirmation from you, so nothing green is silently overwritten.
+<Accordion title="Under the hood: commands used by the agent" icon="terminal">
+  ```sh
+  # Assess a planned change
+  vise impact . --format human
 
-At any point you can ask:
+  # Attach a reported symptom
+  vise impact . --symptom "Feed is missing from Community detail" --format human
 
-```text
-Check whether the features we built earlier with Vise still hold.
-```
+  # Inspect the installed SDK boundary
+  vise sdk-release . --format human
 
-If a later change broke a previously finished surface, you'll be told exactly which one drifted — even while the current work passes.
+  # Protect current and previously completed features in CI
+  vise check . --ci
+  ```
 
-When the dependency declaration or lockfile changed, `vise sdk-release . --format human` separately explains whether the installed SDK still matches an exact extraction-grounded snapshot. It reports the assurance boundary without changing the dependency or treating semver as proof of compatibility.
+  See the [command reference](/ai-mcp/vise/cli-reference) for baseline, evidence, and per-feature options.
+</Accordion>
 
-## Keep everything verified in CI
-
-One read-only command in your pipeline holds the current work *and* every previously finished feature green:
-
-```sh
-vise check --ci
-```
-
-It fails with a distinct exit code when a finished feature drifts, even if the active work passes. See the [reference](/ai-mcp/vise/cli-reference) for baseline and re-verification details.
-
-## When you review the handoff
-
-- Was a baseline used, and when was it recorded?
-- Do earlier features still hold, or did the agent disclose drift?
-- Is there route- and target-matched runtime proof for each changed surface — or an explicit, recorded waiver?
-- Are remaining advisory findings and open non-blocking decisions listed?
+## Related
 
 <CardGroup cols={2}>
-  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-    Contracts, evidence, and what your agent's reports mean.
+  <Card title="Keep integrations verified in CI" icon="code-branch" href="/ai-mcp/vise/ci-verification">
+    Protect current and earlier social.plus features after the handoff.
   </Card>
   <Card title="Review and release" icon="clipboard-check" href="/ai-mcp/vise/release-assurance">
-    Compare verifiable handoffs without confusing readiness with approval.
+    Turn the completed change into a reviewable release candidate.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/choose-integration-path.mdx
+++ b/ai-mcp/vise/choose-integration-path.mdx
@@ -1,0 +1,53 @@
+---
+title: "Choose how to build your social experience"
+description: "Decide whether to launch with a prebuilt UIKit surface or build a differentiated experience directly on the social.plus SDK."
+---
+
+Before your agent writes code, choose how much of the experience your app needs to own. Vise can inspect your project and recommend a path, but you make the final product decision.
+
+## Ask your agent for a recommendation
+
+```text
+Using Vise, inspect this app and recommend whether this feature should use
+social.plus UIKit or a custom UI built on the SDK. Explain the tradeoffs for
+our existing design system and target screen. Don't change code yet.
+```
+
+## Compare the two paths
+
+| Consideration | UIKit | Custom SDK UI |
+| --- | --- | --- |
+| Best fit | A standard feed, chat, community, or story experience | A differentiated layout, workflow, or interaction model |
+| Fastest route | Yes — start from prebuilt social.plus screens | No — your app owns the presentation and behavior |
+| Design control | Theme and customize within UIKit's supported levels | Full control through your app's components and design system |
+| SDK responsibility | Mostly configuration and app-owned integration boundaries | Your app owns SDK queries, lifecycle, state, and UI behavior |
+| Ongoing maintenance | Follow UIKit releases and supported extension points | Maintain the complete app-owned implementation |
+
+Choose **UIKit** when the desired experience is close to a standard social surface and speed matters most. Choose a **custom SDK UI** when the interaction itself differentiates your product or must fit an established app-specific workflow.
+
+<Info>
+  A mixed approach is possible, but it should be an explicit architecture decision. Do not start with UIKit and quietly replace standard behavior with raw SDK calls during implementation.
+</Info>
+
+## Decisions to make before implementation
+
+Whichever path you choose, expect your agent to confirm:
+
+- the feature and capabilities that are in scope
+- the screen or route where it belongs
+- the social.plus region and identity source
+- where the feed, community, channel, or other target comes from
+- the design constraints and runtime environment the finished work must satisfy
+
+Once those decisions are clear, ask the agent to record the agreed outcome and begin implementation.
+
+## Continue with your chosen path
+
+<CardGroup cols={2}>
+  <Card title="Launch a standard social experience" icon="window" href="/ai-mcp/vise/uikit-quickstart">
+    Use a prebuilt UIKit surface with the lightest customization that fits.
+  </Card>
+  <Card title="Build a custom social experience" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
+    Build a differentiated, app-owned experience directly on the SDK.
+  </Card>
+</CardGroup>

--- a/ai-mcp/vise/ci-verification.mdx
+++ b/ai-mcp/vise/ci-verification.mdx
@@ -1,0 +1,59 @@
+---
+title: "Keep integrations verified in CI"
+description: "Make the same Vise contract and evidence that guided implementation protect current and previously completed social.plus features in CI."
+---
+
+After the first integration is green, keep it verifiable after the coding-agent conversation ends. Commit the `sp-vise/` folder with the application, then run Vise as a read-only CI gate.
+
+## What the CI gate protects
+
+The gate checks more than the feature currently being edited:
+
+- the active integration still matches its recorded scope
+- deterministic SDK and platform requirements still pass
+- required evidence and project sensors are present and current
+- every previously completed Vise feature still holds against the current code
+
+This matters when a later change passes for one surface but quietly breaks an earlier feed, comments, community, or chat experience.
+
+## Add the gate
+
+Install the same Vise version your team uses for local work, then run:
+
+```sh
+vise check . --ci
+```
+
+Keep the command read-only in CI. Changes to contracts, attestations, baselines, runtime waivers, or policy selections should be deliberate reviewable changes made before the pipeline runs.
+
+## Read the outcome
+
+- **Green:** the active work and all recorded completed features still hold.
+- **Active failure:** the current integration, required evidence, or project validation needs attention.
+- **Earlier-feature drift:** the active work passes, but a previously completed surface no longer does.
+- **Release review required:** when Passport comparison is enabled, the compliance checks pass but a person still needs to review the candidate's release evidence.
+
+Link the CI output to the changed application code and committed `sp-vise/` evidence so reviewers can reproduce the result locally.
+
+<Accordion title="Advanced: compare an approved and candidate release" icon="terminal">
+  Teams using Integration Passports can add the same release comparison used during human review:
+
+  ```sh
+  vise check . --ci \
+    --from-passport <approved-passport.json> \
+    --to-passport <candidate-passport.json>
+  ```
+
+  A `ready` result supports human release review; it does not record approval. See the [command reference](/ai-mcp/vise/cli-reference) for exact exit codes and trust-policy options.
+</Accordion>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    Understand result states and which ones need human input.
+  </Card>
+  <Card title="Review and release" icon="clipboard-check" href="/ai-mcp/vise/release-assurance">
+    Review the candidate evidence without confusing readiness with approval.
+  </Card>
+</CardGroup>

--- a/ai-mcp/vise/cli-reference.mdx
+++ b/ai-mcp/vise/cli-reference.mdx
@@ -40,7 +40,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | `vise trust sign [path] ...` | CLI-only explicit write: wrap a reviewed Passport or Policy Pack in an Ed25519 envelope using an external private key that Vise does not retain |
 | `vise trust verify [path] --envelope <path> --trust-policy <path>` | Authenticate envelope integrity, issuer/key authorization, artifact type, audience, and validity. Signature validity does not replace Passport or Policy Pack semantic validation |
 
-See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance) for the recommended handoff flow.
+See [Review and release an integration](/ai-mcp/vise/release-assurance) for the recommended handoff flow.
 
 ## Validate and verify
 
@@ -57,7 +57,7 @@ See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance) for
 | `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
-See [What your agent will report](/ai-mcp/vise/how-it-works#what-your-agent-will-report) for what each state means.
+See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each state means.
 
 ## Evidence
 

--- a/ai-mcp/vise/evaluate.mdx
+++ b/ai-mcp/vise/evaluate.mdx
@@ -1,73 +1,53 @@
 ---
 title: "Try Vise in 15 minutes"
-description: "Add the skill to your agent and watch it plan a real integration — no credentials, no code changes."
+description: "Let your agent plan a real social.plus integration without credentials or code changes."
 ---
 
-This walkthrough shows what working with Vise feels like before you commit to anything. You'll ask your agent to *plan* an integration and stop there — so you can judge the workflow without production credentials or source changes.
+Use a clean branch or disposable copy of a real app. This walkthrough stops after planning so you can evaluate the workflow safely.
 
 <Info>
-  Vise requires Node.js 20 or newer. It runs locally and does not upload your source code, file contents, or search queries. Your AI coding tool follows its own data policy.
+  Vise requires Node.js 20 or newer. It runs locally; your coding agent follows its own data policy.
 </Info>
 
-## Run the evaluation
-
-Use a clean branch or a disposable copy of a real app repository — a real codebase shows you far more than an empty scaffold.
-
 <Steps>
-  <Step title="Install Vise and add the skill">
+  <Step title="Install Vise and its skill">
     ```sh
     npm install -g @amityco/social-plus-vise
-    vise install-skill --target claude     # or: cursor . / vscode . / copilot . / codex
+    vise install-skill --target claude  # or: cursor . / vscode . / copilot . / codex
     ```
   </Step>
-  <Step title="Ask your agent for a plan — and only a plan">
+  <Step title="Ask for a plan only">
     Open the app in your agent and ask:
 
     ```text
     Using Vise, plan how you'd add a social feed to this app with social.plus.
-    Don't change any code yet — show me the plan and the questions
-    you'd need me to answer first.
+    Don't change code yet. Show me the plan and the decisions you need from me.
     ```
   </Step>
-  <Step title="Review what comes back">
-    A good result has three parts:
+  <Step title="Review the response">
+    Look for three things:
 
-    - **Your app, recognized.** The agent identifies the platform and, in a monorepo, which app the feature would land in.
-    - **A grounded route.** The plan cites real social.plus documentation and SDK capabilities — not remembered or invented APIs.
-    - **Questions instead of guesses.** Decisions the agent should never make alone — region, target screen, where the feed's data comes from — arrive as explicit questions for you.
+    - the correct app and platform were identified
+    - the plan cites real social.plus capabilities and documentation
+    - region, target screen, data source, and other product choices appear as questions rather than guesses
   </Step>
-  <Step title="Stop here (for now)">
-    Don't answer the questions yet — answering them is what moves the agent into implementation. For the evaluation, the deliverable is the plan and the decision list, and you've seen the most important behavior already: the agent asked rather than guessed.
+  <Step title="Stop before implementation">
+    For this evaluation, the plan and decision list are the deliverable. Do not answer the questions until you want the agent to begin implementation.
   </Step>
 </Steps>
 
-Curious what happened under the hood? The agent ran a couple of Vise commands on your behalf — you can see them in its transcript, and they're documented in the [reference](/ai-mcp/vise/cli-reference). You never need to run them yourself.
+This exercise shows that Vise works with your agent and codebase. It does not prove that an integration has been built, passes project checks, or works with your credentials and tenant data.
 
-## What this shows
-
-- Vise works in your environment, with your agent.
-- It reads your actual codebase, not a template.
-- Plans are grounded in social.plus documentation.
-- Product decisions are surfaced to you instead of silently invented.
-
-## What this doesn't show
-
-- An implemented, validated integration — nothing was built yet.
-- That the feature works with your tenant data and credentials.
-- Runtime behavior on a device or in a browser.
-
-To see those, take the next step: answer the agent's questions and let it implement. Vise then checks the work until it's verifiably done.
-
-## Choose your integration path
+## Continue
 
 <CardGroup cols={3}>
-  <Card title="Custom SDK UI" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
-    A differentiated, app-owned experience built directly on the social.plus SDK.
+  <Card title="Choose how to build" icon="route" href="/ai-mcp/vise/choose-integration-path">
+    Compare UIKit with a custom SDK experience.
   </Card>
-  <Card title="UIKit quick launch" icon="window" href="/ai-mcp/vise/uikit-quickstart">
-    Prebuilt social.plus UIKit surfaces with the lightest customization that fits.
+  <Card title="Maintain an existing integration" icon="screwdriver-wrench" href="/ai-mcp/vise/brownfield-day2">
+    Add, diagnose, or upgrade an existing social.plus app.
   </Card>
-  <Card title="Adding to an existing app" icon="rotate" href="/ai-mcp/vise/brownfield-day2">
-    Add a feature to an app that already uses social.plus.
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    Understand the full implementation and validation loop.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/how-it-works.mdx
+++ b/ai-mcp/vise/how-it-works.mdx
@@ -1,115 +1,67 @@
 ---
 title: "How Vise works"
-description: "The loop the skill drives your agent through, what gets checked, and what 'done' means."
+description: "How a feature request becomes a grounded plan, checked code, reviewable evidence, and a clear next action."
 ---
 
-Vise turns your feature request into a grounded plan, records what "done" means for it, and keeps checking the generated code until the integration is finished — where finished means verified, explained with evidence, intentionally scoped out, or explicitly waiting on your decision. Never just "the agent stopped."
+Vise gives an AI coding agent a repeatable social.plus integration loop. You describe the outcome, answer the product decisions only your team can make, and review the result.
 
-## The loop your agent follows
-
-The [skill](/ai-mcp/vise/overview#get-started) drives your agent through the same loop on every integration:
+## From request to evidence
 
 ```mermaid
 flowchart LR
-  A[understand your app] --> B[plan from the docs]
-  B --> C[record the contract]
-  C --> D[implement]
-  D --> E[check]
-  E -->|not done| D
-  E -->|passes| F[run your project's checks]
-  F --> G[done: evidence recorded]
+  A[Ask for an outcome] --> B[Inspect and plan]
+  B --> C[Confirm decisions]
+  C --> D[Implement and check]
+  D -->|Needs work| D
+  D --> E[Run project checks]
+  E --> F[Record evidence]
+  F --> G[Human review]
 ```
 
-- **Understand your app** — detect the platform, the app surfaces in a monorepo, design signals, and which of your project's own checks are available. In a very large repository, the agent confirms which concrete app it's working in before continuing.
-- **Plan from the docs** — produce a plan with social.plus docs citations, plus the questions the agent must ask you rather than guess. A multi-surface journey also records how its surfaces relate — for example, that a community-detail feed reads and writes the selected community, or that comments belong to the selected post.
-- **Record the contract** — once you've answered, the expectations for this feature, its placement, and its target are written down (see below).
-- **Implement** — the agent edits your app, held to real SDK APIs.
-- **Check** — the code is validated against the recorded contract; the agent iterates until it passes.
-- **Run your project's checks** — your repository's own build, lint, typecheck, and SDK smoke checks.
+1. **Inspect and plan.** The agent identifies the app surface, reads social.plus documentation and SDK facts, and asks instead of guessing.
+2. **Confirm decisions.** Vise records the feature, placement, data target, selected capabilities, and definition of done.
+3. **Implement and check.** The agent validates real SDK usage, platform lifecycle, and feature completeness while it works.
+4. **Run project checks.** The app's build, lint, typecheck, tests, and SDK smoke checks run when available.
+5. **Record evidence.** The result explains what passed, what still needs work, and whether the intended surface worked at runtime.
 
-## What Vise checks
+## Read the result
 
-Vise focuses on the mistakes that pass a demo and break in production:
+Ask your agent to separate the outcome into what passed, what it will fix, and what needs your decision.
 
-- **SDK grounding** — the agent is held to real, source-anchored SDK facts (actual types and field names), so it won't invent a symbol the SDK doesn't expose.
-- **Platform correctness** — 400+ platform-specific checks: SDK setup and region, session renewal and login lifecycle, secret handling and committed environment files, Live Object and Live Collection usage, and feed, comment, chat, notification, community, follow, story, and moderation patterns.
-- **Feature completeness** — the whole outcome, including pagination, empty and error states, and the optional capabilities you asked for — not just the happy path.
-- **Design and experience** — generated UI reviewed against your design system. This layer is **advisory**; brand fit still needs human judgment.
-- **Project sensors** — your repository's own build, lint, typecheck, and SDK import smoke checks.
+| Result | What happens next |
+| --- | --- |
+| `green` | Review the feature through your normal product process |
+| `deterministic-failures` or `completeness-gap` | The agent fixes the code or finishes the agreed scope |
+| `selected-capability-failures` | Finish the selected capability or explicitly remove it from scope |
+| `blocked` | Answer the named product or project question |
+| `needs-attestation` | Review evidence for correct architecture the automatic check cannot see |
+| `contract-drift` | Confirm the changed intent or restore the implementation |
+| `runtime-proof-waived` | Accept the explicit waiver or request a real launch |
+| `engagement-drift` | Reopen the earlier feature or explicitly accept the change |
 
-Deterministic SDK correctness and explicit completeness decisions are the checks that block. Design and experience guidance stays advisory.
+`no-platform` means Vise did not find a supported app surface. Confirm that the agent is working in the correct package before concluding that there is nothing to validate.
 
-## The `sp-vise/` folder
+## What the evidence means
 
-The recorded contract, its check results, and all supporting evidence live in a small `sp-vise/` folder in your repo. Commit it with your app: it's what lets a reviewer see *why* the integration is trustworthy — and what lets CI keep verifying the work after the chat transcript is long gone.
+The contract, check results, attestations, and runtime receipts live in `sp-vise/`. Commit that folder with the application so review and CI do not depend on an agent transcript.
 
-## What your agent will report
+Evidence can prove an automatic check passed, explain architecture a static rule cannot follow, or show that a specific surface mounted and loaded data at its recorded route and target.
 
-Every check ends in one of these states. Your agent will name them when it reports back, so here's what each one means for you:
-
-| State | Meaning | What you do |
-| --- | --- | --- |
-| `green` | Every applicable check passes | Accept the integration |
-| `needs-attestation` | A rule is satisfied through architecture the automatic check can't see | Let the agent record evidence and a rationale, then review it |
-| `deterministic-failures` | A rule failed in the code | Nothing — the agent fixes and re-checks |
-| `completeness-gap` | The feature you asked for isn't fully built yet | Nothing — the agent keeps going, or asks you to drop scope explicitly |
-| `selected-capability-failures` | An optional capability you chose isn't satisfied | Decide: finish it, or intentionally drop it |
-| `blocked` | A decision only your team can make is missing | Answer the question |
-| `contract-drift` | The code no longer matches what was recorded | Decide with the agent: re-plan, or restore the code |
-| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept the recorded waiver, or ask for a real run |
-| `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Current work is fine, but a previously finished feature no longer holds | Re-open the drifted feature or accept the documented change |
-
-## Evidence instead of "trust me"
-
-Three kinds of proof accumulate in `sp-vise/` as the agent works:
-
-- **Attestations.** Some correct code passes through indirection a static check can't follow — a helper module, a wrapper, a pattern unique to your codebase. Instead of failing silently or passing blindly, the agent records *why* the rule is satisfied, with evidence and a rationale you can audit.
-- **Runtime proof.** For user-visible surfaces, Vise assesses normalized launch markers into independent per-surface receipts — did the intended screen mount, authenticate, and load data at the declared route and target? A comments run cannot overwrite valid community-feed proof, and changed placement cannot inherit an older receipt. When no device or emulator is available, an explicit waiver is recorded instead of a silent pass.
-- **Deterministic passes.** After a green check, the passing evidence itself is persisted, so review doesn't depend on re-running anything.
-
-Reviewers can inspect all of it with a few read-only commands — see the [reference](/ai-mcp/vise/cli-reference).
-
-## Adding features later
-
-The second feature is governed as carefully as the first, whether the existing integration was built by hand or through Vise — and earlier finished features stay recorded and re-verifiable. See [Adding to an existing app](/ai-mcp/vise/brownfield-day2).
-
-## Vise in CI
-
-After the first successful integration, commit `sp-vise/` and add one read-only command to your pipeline:
-
-```sh
-vise check --ci
-```
-
-It verifies the active contract *and* re-verdicts every previously finished feature, failing the build unless all governed work still holds. Baseline behavior for pre-existing codebases and per-feature re-verification are covered in the [reference](/ai-mcp/vise/cli-reference).
-
-For a release candidate, CI can also compare an approved Integration Passport with the candidate:
-
-```sh
-vise check . --ci \
-  --from-passport <approved-passport.json> \
-  --to-passport <candidate-passport.json>
-```
-
-This adds the same Governed Release Review returned by `vise passport compare`. A `ready` result means the automated evidence supports human review; it never means Vise approved the release. Otherwise-green compliance exits `12` when the release review is `review-required` or `blocked`. See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance).
+It does not replace product QA, security review, or human release approval. User-visible work still needs a real launch or an honest recorded waiver.
 
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="Vise overview" icon="shield-check" href="/ai-mcp/vise/overview">
-    Install Vise and ask for your first feature.
+  <Card title="Maintain an existing integration" icon="screwdriver-wrench" href="/ai-mcp/vise/brownfield-day2">
+    Add, diagnose, or upgrade without losing earlier evidence.
   </Card>
-  <Card title="For reviewers and CI" icon="terminal" href="/ai-mcp/vise/cli-reference">
-    The commands for verifying recorded evidence and gating releases.
+  <Card title="Keep integrations verified in CI" icon="code-branch" href="/ai-mcp/vise/ci-verification">
+    Carry the same contract and evidence into the pipeline.
   </Card>
-  <Card title="Review and release" icon="clipboard-check" href="/ai-mcp/vise/release-assurance">
-    SDK assurance, Integration Passports, and governed release review.
+  <Card title="Command reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
+    Look up the full command surface when operating Vise directly.
   </Card>
-  <Card title="Live Objects and Collections" icon="radio" href="/social-plus-sdk/core-concepts/realtime-communication/live-objects-collections/overview">
-    Build realtime SDK features with the correct lifecycle.
-  </Card>
-  <Card title="Authentication" icon="key" href="/social-plus-sdk/getting-started/authentication">
-    User login, session renewal, and regional configuration.
+  <Card title="Run Vise as an MCP server" icon="plug" href="/ai-mcp/vise/mcp-server">
+    Expose Vise's local tools to an MCP-capable coding host.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/overview.mdx
+++ b/ai-mcp/vise/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Vise"
-description: "Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work."
+description: "Give your AI coding agent a grounded, verifiable workflow for building social.plus features."
 tag: "Preview"
 ---
 
-Vise makes AI coding agents good at integrating social.plus. Install it, add its skill to the agent you already use, then ask for the feature you want — a social feed, chat, communities, stories. Your agent writes the code; Vise keeps it grounded in the real SDK, asks you the decisions only you can make, and keeps checking until the feature is genuinely done.
+Vise helps AI coding agents integrate social.plus without guessing SDK APIs or stopping at code that merely looks finished. You ask for a feed, chat, communities, stories, or another product outcome; the agent plans, implements, checks, and explains the work.
 
-You interact with Vise twice: once to install it, once to add the skill. After that, you talk to your agent — not to Vise.
+After setup, you talk to your agent—not to Vise.
 
 ## Get started
 
@@ -20,7 +20,7 @@ You interact with Vise twice: once to install it, once to add the skill. After t
     npm install -g @amityco/social-plus-vise
     ```
   </Step>
-  <Step title="Add the skill to your AI coding agent">
+  <Step title="Add the skill to your coding agent">
     ```sh
     vise install-skill --target claude     # Claude Code
     vise install-skill --target cursor .   # Cursor
@@ -29,78 +29,52 @@ You interact with Vise twice: once to install it, once to add the skill. After t
     vise install-skill --target codex      # OpenAI Codex
     ```
 
-    Using a different agent? `vise print-skill` prints the skill so you can paste it anywhere.
+    For another agent, use `vise print-skill` and paste the result into its instructions.
   </Step>
-  <Step title="Ask for a feature">
-    Open your app in your agent and ask in plain language:
-
+  <Step title="Ask for an outcome">
     ```text
     Add a social feed to this app using social.plus.
     ```
 
-    ```text
-    Add chat between users in this app with social.plus.
-    ```
-
-    ```text
-    We already use social.plus for the feed — add comments to it.
-    ```
+    Your agent inspects the app and asks for decisions such as region, target screen, identity source, and feature scope before editing.
   </Step>
 </Steps>
 
-That's the whole setup. The skill teaches your agent when to inspect your project, ground its plan in the real social.plus SDK, and validate its own work — you watch that happen; you don't run it.
+## What to expect
 
-## What happens next
+1. **A grounded plan.** The agent uses real social.plus documentation and SDK facts.
+2. **Implementation with checks.** Vise checks SDK usage, lifecycle behavior, feature completeness, and the project's own validation commands.
+3. **An honest handoff.** The result says what passed, what still needs a decision, and whether the intended surface worked at runtime.
 
-Once you ask for a feature, expect three things:
-
-1. **Your agent asks you a few product questions.** Things only you can decide — which region your app runs in, which screen the feature lives on, where a community ID comes from. Vise stops the agent from inventing these answers.
-2. **Your agent writes the code, and Vise checks it.** Not just "does it compile" — that the code uses APIs the SDK actually exposes, follows the platform's session and realtime-data lifecycle, and covers the whole feature: pagination, loading, empty, and error states, not just the happy path.
-3. **"Done" means verified, not "the agent stopped talking."** The work ends in one of a few honest states: every check passes, a check is satisfied in a way that's explained with recorded evidence, something was intentionally scoped out, or the agent is blocked waiting on a decision from you. The evidence lives in your repo (an `sp-vise/` folder), so a reviewer can see *why* the integration is trustworthy — not just that a chat transcript ended.
-
-## What Vise checks
-
-- **Real SDK usage** — the agent is held to source-anchored SDK facts (actual types and field names), so it can't invent an API that doesn't exist.
-- **Platform correctness** — 400+ checks for the mistakes that pass a demo and break in production: setup and region, session renewal, secret handling, realtime data lifecycle, and feature-specific patterns across feeds, chat, comments, communities, notifications, and more.
-- **Feature completeness** — the outcome you asked for, in full, including the optional capabilities you chose.
-- **Your project's own checks** — your repository's build, lint, typecheck, and test commands run as part of the loop.
-- **Design fit** — generated UI is reviewed against your design system. This part is advisory; brand judgment stays human.
+The contract and evidence live in `sp-vise/` so reviewers and CI can reproduce the result after the conversation ends. See [How Vise works](/ai-mcp/vise/how-it-works) for the complete loop and result states.
 
 <Warning>
-  **Preview release.** Vise is usable for guided social.plus integrations today, but details may still change as it hardens through more real projects. Treat it as strong guardrails for AI-assisted work — not a substitute for code review, product QA, or trying the feature on a real device.
+  **Preview release.** Vise provides strong guardrails for AI-assisted integration, but it does not replace code review, product QA, security review, or a real launch on your tenant data.
 </Warning>
 
 <Info>
-  Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
+  Vise runs locally and does not upload your source code, file contents, or search queries. The hosted [docs MCP server](/ai-mcp/overview) is different: it helps assistants search the documentation, while Vise guides and validates work inside your project.
 </Info>
 
-## Vise and the docs MCP server
-
-Both connect AI tools to social.plus, and they work well together.
-
-| Tool | What it does | Runs where |
-| --- | --- | --- |
-| [Docs MCP server](/ai-mcp/overview) | Lets an assistant search and read social.plus documentation | Hosted at `https://learn.social.plus/mcp` |
-| Vise | Guides and validates an agent that is **editing your app** | Locally, in your project |
-
-Vise can also expose its tools [over MCP](/ai-mcp/vise/mcp-server) if your agent host prefers MCP tools to a skill.
-
-## Next steps
+## Choose your next step
 
 <CardGroup cols={2}>
   <Card title="Try Vise in 15 minutes" icon="stopwatch" href="/ai-mcp/vise/evaluate">
-    Watch your agent plan a real integration — no credentials, no code changes.
+    Review a grounded plan without changing code or using credentials.
   </Card>
-  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-    What the skill drives, what gets checked, and what "done" means.
+  <Card title="Choose how to build" icon="route" href="/ai-mcp/vise/choose-integration-path">
+    Compare a prebuilt UIKit surface with a custom SDK experience.
+  </Card>
+  <Card title="Maintain an existing integration" icon="screwdriver-wrench" href="/ai-mcp/vise/brownfield-day2">
+    Add a feature, diagnose a problem, or upgrade the SDK safely.
+  </Card>
+  <Card title="Keep it verified in CI" icon="code-branch" href="/ai-mcp/vise/ci-verification">
+    Protect current and previously completed social.plus features.
   </Card>
   <Card title="Review and release" icon="clipboard-check" href="/ai-mcp/vise/release-assurance">
-    SDK assurance, verifiable Passports, policy, trust, and release review.
+    Prepare a verifiable handoff without confusing readiness with approval.
   </Card>
-  <Card title="Run Vise as an MCP server" icon="plug" href="/ai-mcp/vise/mcp-server">
-    Optional: expose Vise's tools to MCP-capable hosts.
-  </Card>
-  <Card title="For reviewers and CI" icon="terminal" href="/ai-mcp/vise/cli-reference">
-    The commands for reviewing recorded evidence and gating releases.
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    Understand the loop, evidence, and result states.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/release-assurance.mdx
+++ b/ai-mcp/vise/release-assurance.mdx
@@ -1,97 +1,64 @@
 ---
-title: "Reviewing and releasing an integration"
-description: "Turn Vise's recorded contract and evidence into a verifiable release handoff without confusing automated readiness with human approval."
+title: "Review and release an integration"
+description: "Review what changed, what proves it, and which decisions remain human before release."
 ---
 
-A green integration is ready to be reviewed, but a release decision also needs to answer what changed, whether the SDK boundary is understood, and whether the evidence still belongs to the candidate being shipped. Vise keeps those questions reproducible with SDK Release Intelligence, Integration Passports, and Governed Release Review.
+A green Vise result is ready for human review; it is not a release approval.
 
-<Info>
-  These commands are read-only unless you explicitly add `--write` or use `vise trust sign`. Vise can say that automated evidence is ready for review; it never records or impersonates human release approval.
-</Info>
+## Ask for a release handoff
 
-## The release-review flow
+```text
+Using Vise, prepare this social.plus change for release review. Summarize
+what changed, the SDK boundary, evidence, regressions or waivers, and the
+decisions a person still needs to make. Do not claim human approval.
+```
 
-<Steps>
-  <Step title="Check the SDK boundary">
-    Run:
+If your team has an approved Vise handoff, provide it so the candidate can be compared with that known point.
 
-    ```sh
-    vise sdk-release . --format human
-    ```
+## What the reviewer should receive
 
-    Vise compares the detected dependency declaration and supported lockfile resolution with the exact SDK snapshots it has verified. It reports whether the project is exact-snapshot verified, range-only, older, newer, or unversioned. It does not fetch a registry, edit dependencies, or infer semantic compatibility from semver alone.
-  </Step>
-  <Step title="Generate and verify a candidate Passport">
-    Run:
+1. **What changed?** The accepted feature scope, placement, target, source, and dependency changes.
+2. **What proves it?** Automatic checks, project sensors, attestations, and runtime evidence—or clearly disclosed waivers.
+3. **What moved?** SDK assurance, policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
+4. **What remains human?** Product QA, security review, risk acceptance, and release approval.
 
-    ```sh
-    vise passport . --write
-    vise passport verify . --format human
-    ```
+An optional **Integration Passport** packages the candidate's intent and evidence into verifiable claims so another reviewer can detect changed or stale material.
 
-    An Integration Passport binds the accepted intent, lifecycle state, SDK assurance, evidence hashes, runtime proof or waiver, residual risks, and replay commands into digest-bound claims. Verification recomputes those claims and local evidence states; it does not rerun or repair the project.
-  </Step>
-  <Step title="Compare the approved and candidate handoffs">
-    Run:
-
-    ```sh
-    vise passport compare . \
-      --from <approved-passport.json> \
-      --to <candidate-passport.json> \
-      --format human
-    ```
-
-    The comparison discloses regressions and reviewable lifecycle movement, then composes a Governed Release Review decision.
-  </Step>
-  <Step title="Apply the same review in CI">
-    Run:
-
-    ```sh
-    vise check . --ci \
-      --from-passport <approved-passport.json> \
-      --to-passport <candidate-passport.json>
-    ```
-
-    Existing compliance failures keep their normal exit codes. If compliance is otherwise green but release evidence is `review-required` or `blocked`, the command exits `12`.
-  </Step>
-</Steps>
-
-## Reading the release decision
+## Read the decision
 
 | Decision | Meaning | Human action |
 | --- | --- | --- |
-| `ready` | Automated evidence supports release review and no blocking regression was found | Complete your normal product, security, and release approval |
-| `review-required` | Evidence is internally valid, but lifecycle, SDK, policy, or provenance movement needs a person to review it | Review the disclosed changes and owners before approving |
-| `blocked` | A required claim, evidence class, policy requirement, or trusted provenance condition is not satisfied | Resolve the named blockers and regenerate the candidate Passport |
+| `ready` | No blocking automated regression was found | Complete normal product, security, and release review |
+| `review-required` | Valid evidence contains SDK, policy, lifecycle, or provenance movement | Review the disclosed changes and owners |
+| `blocked` | Required evidence, policy, or trusted provenance is missing | Resolve the named blocker and prepare a new candidate |
 
-`ready` never means “approved.” The release review records `humanApprovalAsserted: false` in every state.
+Vise never records or impersonates human approval.
 
-## Organization policy and trusted handoffs
+<Accordion title="Advanced release controls and commands" icon="terminal">
+  Policy Packs can declare approved SDK ranges and required evidence. Trust envelopes can authenticate a reviewed Passport or Policy Pack across teams or CI systems. A valid signature proves provenance, not integration correctness.
 
-An optional **Policy Pack** lets your organization declare approved SDK ranges, required evidence classes and capabilities, runtime-waiver constraints, release severities, and responsible owners. It is accepted only through an explicit `vise init --policy-pack <path>`; later Day-2, SDK-release, and Passport operations reuse and re-check that recorded selection.
+  ```sh
+  vise sdk-release . --format human
+  vise passport . --write
+  vise passport verify . --format human
+  vise passport compare . \
+    --from <approved-passport.json> \
+    --to <candidate-passport.json> \
+    --format human
+  ```
 
-For handoffs that cross repositories, teams, or CI systems, a **Portable Trust Envelope** can authenticate a reviewed Passport or Policy Pack. Signing is an explicit CLI-only operation using a caller-supplied Ed25519 private key that Vise does not retain. Verification checks the envelope against a local trust policy:
+  See the [command reference](/ai-mcp/vise/cli-reference) for policy, trust, and CI options.
+</Accordion>
 
-```sh
-vise trust verify . \
-  --envelope <artifact.envelope.json> \
-  --trust-policy <trust-policy.json>
-```
+Keep the candidate Passport and comparison when used, the committed `sp-vise/` evidence, CI output, applicable policy files, and the approval recorded by your own release process.
 
-A valid signature proves authorized provenance, not that the enclosed integration is correct. Passport and Policy Pack validation still applies.
-
-## What to keep with the release
-
-- the candidate Integration Passport and its comparison result
-- the exact Policy Pack and trust policy used, when applicable
-- the `sp-vise/` contract, engagement history, and evidence referenced by the Passport
-- the CI output and the human approval recorded by your own release process
+## Related
 
 <CardGroup cols={2}>
-  <Card title="Adding to an existing app" icon="arrows-rotate" href="/ai-mcp/vise/brownfield-day2">
-    Assess changes and preserve earlier social.plus features.
+  <Card title="Keep integrations verified in CI" icon="code-branch" href="/ai-mcp/vise/ci-verification">
+    Reproduce the checks in the release pipeline.
   </Card>
-  <Card title="Command reference" icon="terminal" href="/ai-mcp/vise/cli-reference">
-    See the complete reviewer and CI command surface.
+  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
+    Understand result states and their human-review boundary.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/sdk-custom-ui.mdx
+++ b/ai-mcp/vise/sdk-custom-ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Custom SDK UI"
+title: "Build a custom social experience"
 description: "Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app."
 ---
 
@@ -40,10 +40,10 @@ Then run the app and look at it. Passing checks prove the code is right; only a 
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-    The loop your agent follows and what its reports mean.
+  <Card title="Choose an integration path" icon="route" href="/ai-mcp/vise/choose-integration-path">
+    Compare custom SDK ownership with a prebuilt UIKit surface.
   </Card>
-  <Card title="UIKit quick launch" icon="window" href="/ai-mcp/vise/uikit-quickstart">
+  <Card title="Launch a standard social experience" icon="window" href="/ai-mcp/vise/uikit-quickstart">
     Prefer a prebuilt surface? Launch with UIKit instead.
   </Card>
 </CardGroup>

--- a/ai-mcp/vise/uikit-quickstart.mdx
+++ b/ai-mcp/vise/uikit-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "UIKit quick launch"
+title: "Launch a standard social experience"
 description: "Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits."
 ---
 
@@ -30,10 +30,10 @@ Vise validates everything your app owns — SDK setup and region, authentication
 ## Related
 
 <CardGroup cols={2}>
-  <Card title="How Vise works" icon="gears" href="/ai-mcp/vise/how-it-works">
-    The loop your agent follows and what its reports mean.
+  <Card title="Choose an integration path" icon="route" href="/ai-mcp/vise/choose-integration-path">
+    Compare UIKit with a custom SDK experience.
   </Card>
-  <Card title="Custom SDK UI" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
+  <Card title="Build a custom social experience" icon="code" href="/ai-mcp/vise/sdk-custom-ui">
     Need a differentiated experience? Build directly on the SDK.
   </Card>
 </CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -856,14 +856,41 @@
             "group": "Vise",
             "pages": [
               "ai-mcp/vise/overview",
-              "ai-mcp/vise/evaluate",
-              "ai-mcp/vise/sdk-custom-ui",
-              "ai-mcp/vise/uikit-quickstart",
-              "ai-mcp/vise/brownfield-day2",
-              "ai-mcp/vise/release-assurance",
-              "ai-mcp/vise/how-it-works",
-              "ai-mcp/vise/mcp-server",
-              "ai-mcp/vise/cli-reference"
+              {
+                "group": "Start",
+                "pages": [
+                  "ai-mcp/vise/evaluate",
+                  "ai-mcp/vise/choose-integration-path"
+                ]
+              },
+              {
+                "group": "Build",
+                "pages": [
+                  "ai-mcp/vise/uikit-quickstart",
+                  "ai-mcp/vise/sdk-custom-ui"
+                ]
+              },
+              {
+                "group": "Maintain",
+                "pages": [
+                  "ai-mcp/vise/brownfield-day2"
+                ]
+              },
+              {
+                "group": "Review and ship",
+                "pages": [
+                  "ai-mcp/vise/ci-verification",
+                  "ai-mcp/vise/release-assurance"
+                ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "ai-mcp/vise/how-it-works",
+                  "ai-mcp/vise/mcp-server",
+                  "ai-mcp/vise/cli-reference"
+                ]
+              }
             ]
           }
         ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69670,11 +69670,11 @@ When an agent is **editing your app**, use [Vise](/ai-mcp/vise/overview): instal
 
 ### [Vise](https://learn.social.plus/ai-mcp/vise/overview)
 
-> Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work.
+> Give your AI coding agent a grounded, verifiable workflow for building social.plus features.
 
-Vise makes AI coding agents good at integrating social.plus. Install it, add its skill to the agent you already use, then ask for the feature you want — a social feed, chat, communities, stories. Your agent writes the code; Vise keeps it grounded in the real SDK, asks you the decisions only you can make, and keeps checking until the feature is genuinely done.
+Vise helps AI coding agents integrate social.plus without guessing SDK APIs or stopping at code that merely looks finished. You ask for a feed, chat, communities, stories, or another product outcome; the agent plans, implements, checks, and explains the work.
 
-You interact with Vise twice: once to install it, once to add the skill. After that, you talk to your agent — not to Vise.
+After setup, you talk to your agent—not to Vise.
 
 ## Get started
 
@@ -69691,120 +69691,154 @@ vise install-skill --target copilot .  # GitHub Copilot
 vise install-skill --target codex      # OpenAI Codex
 ```
 
-    Using a different agent? `vise print-skill` prints the skill so you can paste it anywhere.
-    Open your app in your agent and ask in plain language:
-
+    For another agent, use `vise print-skill` and paste the result into its instructions.
 ```text
 Add a social feed to this app using social.plus.
 ```
 
-```text
-Add chat between users in this app with social.plus.
-```
+    Your agent inspects the app and asks for decisions such as region, target screen, identity source, and feature scope before editing.
 
-```text
-We already use social.plus for the feed — add comments to it.
-```
+## What to expect
 
-That's the whole setup. The skill teaches your agent when to inspect your project, ground its plan in the real social.plus SDK, and validate its own work — you watch that happen; you don't run it.
+1. **A grounded plan.** The agent uses real social.plus documentation and SDK facts.
+2. **Implementation with checks.** Vise checks SDK usage, lifecycle behavior, feature completeness, and the project's own validation commands.
+3. **An honest handoff.** The result says what passed, what still needs a decision, and whether the intended surface worked at runtime.
 
-## What happens next
+The contract and evidence live in `sp-vise/` so reviewers and CI can reproduce the result after the conversation ends. See [How Vise works](/ai-mcp/vise/how-it-works) for the complete loop and result states.
 
-Once you ask for a feature, expect three things:
+  **Preview release.** Vise provides strong guardrails for AI-assisted integration, but it does not replace code review, product QA, security review, or a real launch on your tenant data.
 
-1. **Your agent asks you a few product questions.** Things only you can decide — which region your app runs in, which screen the feature lives on, where a community ID comes from. Vise stops the agent from inventing these answers.
-2. **Your agent writes the code, and Vise checks it.** Not just "does it compile" — that the code uses APIs the SDK actually exposes, follows the platform's session and realtime-data lifecycle, and covers the whole feature: pagination, loading, empty, and error states, not just the happy path.
-3. **"Done" means verified, not "the agent stopped talking."** The work ends in one of a few honest states: every check passes, a check is satisfied in a way that's explained with recorded evidence, something was intentionally scoped out, or the agent is blocked waiting on a decision from you. The evidence lives in your repo (an `sp-vise/` folder), so a reviewer can see *why* the integration is trustworthy — not just that a chat transcript ended.
+  Vise runs locally and does not upload your source code, file contents, or search queries. The hosted [docs MCP server](/ai-mcp/overview) is different: it helps assistants search the documentation, while Vise guides and validates work inside your project.
 
-## What Vise checks
+## Choose your next step
 
-- **Real SDK usage** — the agent is held to source-anchored SDK facts (actual types and field names), so it can't invent an API that doesn't exist.
-- **Platform correctness** — 400+ checks for the mistakes that pass a demo and break in production: setup and region, session renewal, secret handling, realtime data lifecycle, and feature-specific patterns across feeds, chat, comments, communities, notifications, and more.
-- **Feature completeness** — the outcome you asked for, in full, including the optional capabilities you chose.
-- **Your project's own checks** — your repository's build, lint, typecheck, and test commands run as part of the loop.
-- **Design fit** — generated UI is reviewed against your design system. This part is advisory; brand judgment stays human.
-
-  **Preview release.** Vise is usable for guided social.plus integrations today, but details may still change as it hardens through more real projects. Treat it as strong guardrails for AI-assisted work — not a substitute for code review, product QA, or trying the feature on a real device.
-
-  Vise runs on your machine. It fetches public social.plus documentation and SDK version information, but it does not upload your source code, file contents, or search queries.
-
-## Vise and the docs MCP server
-
-Both connect AI tools to social.plus, and they work well together.
-
-| Tool | What it does | Runs where |
-| --- | --- | --- |
-| [Docs MCP server](/ai-mcp/overview) | Lets an assistant search and read social.plus documentation | Hosted at `https://learn.social.plus/mcp` |
-| Vise | Guides and validates an agent that is **editing your app** | Locally, in your project |
-
-Vise can also expose its tools [over MCP](/ai-mcp/vise/mcp-server) if your agent host prefers MCP tools to a skill.
-
-## Next steps
-
-    Watch your agent plan a real integration — no credentials, no code changes.
-    What the skill drives, what gets checked, and what "done" means.
-    SDK assurance, verifiable Passports, policy, trust, and release review.
-    Optional: expose Vise's tools to MCP-capable hosts.
-    The commands for reviewing recorded evidence and gating releases.
+    Review a grounded plan without changing code or using credentials.
+    Compare a prebuilt UIKit surface with a custom SDK experience.
+    Add a feature, diagnose a problem, or upgrade the SDK safely.
+    Protect current and previously completed social.plus features.
+    Prepare a verifiable handoff without confusing readiness with approval.
+    Understand the loop, evidence, and result states.
 
 ---
 
 ### [Try Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate)
 
-> Add the skill to your agent and watch it plan a real integration — no credentials, no code changes.
+> Let your agent plan a real social.plus integration without credentials or code changes.
 
-This walkthrough shows what working with Vise feels like before you commit to anything. You'll ask your agent to *plan* an integration and stop there — so you can judge the workflow without production credentials or source changes.
+Use a clean branch or disposable copy of a real app. This walkthrough stops after planning so you can evaluate the workflow safely.
 
-  Vise requires Node.js 20 or newer. It runs locally and does not upload your source code, file contents, or search queries. Your AI coding tool follows its own data policy.
-
-## Run the evaluation
-
-Use a clean branch or a disposable copy of a real app repository — a real codebase shows you far more than an empty scaffold.
+  Vise requires Node.js 20 or newer. It runs locally; your coding agent follows its own data policy.
 
 ```sh
 npm install -g @amityco/social-plus-vise
-vise install-skill --target claude     # or: cursor . / vscode . / copilot . / codex
+vise install-skill --target claude  # or: cursor . / vscode . / copilot . / codex
 ```
     Open the app in your agent and ask:
 
 ```text
 Using Vise, plan how you'd add a social feed to this app with social.plus.
-Don't change any code yet — show me the plan and the questions
-you'd need me to answer first.
+Don't change code yet. Show me the plan and the decisions you need from me.
 ```
-    A good result has three parts:
+    Look for three things:
 
-    - **Your app, recognized.** The agent identifies the platform and, in a monorepo, which app the feature would land in.
-    - **A grounded route.** The plan cites real social.plus documentation and SDK capabilities — not remembered or invented APIs.
-    - **Questions instead of guesses.** Decisions the agent should never make alone — region, target screen, where the feed's data comes from — arrive as explicit questions for you.
-    Don't answer the questions yet — answering them is what moves the agent into implementation. For the evaluation, the deliverable is the plan and the decision list, and you've seen the most important behavior already: the agent asked rather than guessed.
+    - the correct app and platform were identified
+    - the plan cites real social.plus capabilities and documentation
+    - region, target screen, data source, and other product choices appear as questions rather than guesses
+    For this evaluation, the plan and decision list are the deliverable. Do not answer the questions until you want the agent to begin implementation.
 
-Curious what happened under the hood? The agent ran a couple of Vise commands on your behalf — you can see them in its transcript, and they're documented in the [reference](/ai-mcp/vise/cli-reference). You never need to run them yourself.
+This exercise shows that Vise works with your agent and codebase. It does not prove that an integration has been built, passes project checks, or works with your credentials and tenant data.
 
-## What this shows
+## Continue
 
-- Vise works in your environment, with your agent.
-- It reads your actual codebase, not a template.
-- Plans are grounded in social.plus documentation.
-- Product decisions are surfaced to you instead of silently invented.
-
-## What this doesn't show
-
-- An implemented, validated integration — nothing was built yet.
-- That the feature works with your tenant data and credentials.
-- Runtime behavior on a device or in a browser.
-
-To see those, take the next step: answer the agent's questions and let it implement. Vise then checks the work until it's verifiably done.
-
-## Choose your integration path
-
-    A differentiated, app-owned experience built directly on the social.plus SDK.
-    Prebuilt social.plus UIKit surfaces with the lightest customization that fits.
-    Add a feature to an app that already uses social.plus.
+    Compare UIKit with a custom SDK experience.
+    Add, diagnose, or upgrade an existing social.plus app.
+    Understand the full implementation and validation loop.
 
 ---
 
-### [Custom SDK UI](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui)
+### [Choose how to build your social experience](https://learn.social.plus/ai-mcp/vise/choose-integration-path)
+
+> Decide whether to launch with a prebuilt UIKit surface or build a differentiated experience directly on the social.plus SDK.
+
+Before your agent writes code, choose how much of the experience your app needs to own. Vise can inspect your project and recommend a path, but you make the final product decision.
+
+## Ask your agent for a recommendation
+
+```text
+Using Vise, inspect this app and recommend whether this feature should use
+social.plus UIKit or a custom UI built on the SDK. Explain the tradeoffs for
+our existing design system and target screen. Don't change code yet.
+```
+
+## Compare the two paths
+
+| Consideration | UIKit | Custom SDK UI |
+| --- | --- | --- |
+| Best fit | A standard feed, chat, community, or story experience | A differentiated layout, workflow, or interaction model |
+| Fastest route | Yes — start from prebuilt social.plus screens | No — your app owns the presentation and behavior |
+| Design control | Theme and customize within UIKit's supported levels | Full control through your app's components and design system |
+| SDK responsibility | Mostly configuration and app-owned integration boundaries | Your app owns SDK queries, lifecycle, state, and UI behavior |
+| Ongoing maintenance | Follow UIKit releases and supported extension points | Maintain the complete app-owned implementation |
+
+Choose **UIKit** when the desired experience is close to a standard social surface and speed matters most. Choose a **custom SDK UI** when the interaction itself differentiates your product or must fit an established app-specific workflow.
+
+  A mixed approach is possible, but it should be an explicit architecture decision. Do not start with UIKit and quietly replace standard behavior with raw SDK calls during implementation.
+
+## Decisions to make before implementation
+
+Whichever path you choose, expect your agent to confirm:
+
+- the feature and capabilities that are in scope
+- the screen or route where it belongs
+- the social.plus region and identity source
+- where the feed, community, channel, or other target comes from
+- the design constraints and runtime environment the finished work must satisfy
+
+Once those decisions are clear, ask the agent to record the agreed outcome and begin implementation.
+
+## Continue with your chosen path
+
+    Use a prebuilt UIKit surface with the lightest customization that fits.
+    Build a differentiated, app-owned experience directly on the SDK.
+
+---
+
+### [Launch a standard social experience](https://learn.social.plus/ai-mcp/vise/uikit-quickstart)
+
+> Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
+
+Choose this path when you want a standard social surface live quickly — a community feed, chat, stories — using social.plus UIKit's prebuilt screens, themed to your brand.
+
+## What to ask
+
+```text
+Use social.plus UIKit to launch a standard community feed in this app.
+Recommend the lowest customization level that fits our design system,
+and don't hand-roll standard surfaces from SDK primitives.
+```
+
+## What your agent will ask you
+
+The usual product questions — platform, screen or route, region, identity — plus one that's specific to UIKit:
+
+- **How much to customize.** The agent recommends the lightest level that fits your design system: theming and dynamic UI, component styling, localization, behavior overrides, or fork-and-extend as a last resort. You confirm the choice; it's recorded with the rest of the plan.
+
+## Staying on the UIKit path
+
+The skill keeps the agent honest about the boundary. Once UIKit is the chosen route, UIKit's installation, provider, behavior, and customization guidance is the implementation source — the agent shouldn't quietly rebuild a standard feed from raw SDK calls. Mixing in direct SDK code is reserved for behavior that's genuinely differentiated for your app.
+
+## What "done" looks like
+
+Vise validates everything your app owns — SDK setup and region, authentication, configuration, and your project's own build, lint, and test checks. What it can't see inside prebuilt UIKit internals it won't claim to have verified. A themed UIKit screen still deserves product QA and a real launch before you ship it.
+
+## Related
+
+    Compare UIKit with a custom SDK experience.
+    Need a differentiated experience? Build directly on the SDK.
+
+---
+
+### [Build a custom social experience](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui)
 
 > Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app.
 
@@ -69842,306 +69876,253 @@ Then run the app and look at it. Passing checks prove the code is right; only a 
 
 ## Related
 
-    The loop your agent follows and what its reports mean.
+    Compare custom SDK ownership with a prebuilt UIKit surface.
     Prefer a prebuilt surface? Launch with UIKit instead.
 
 ---
 
-### [UIKit quick launch](https://learn.social.plus/ai-mcp/vise/uikit-quickstart)
+### [Maintain an existing integration](https://learn.social.plus/ai-mcp/vise/brownfield-day2)
 
-> Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
+> Add a feature, diagnose a problem, or upgrade the SDK without losing confidence in the social.plus experiences that already work.
 
-Choose this path when you want a standard social surface live quickly — a community feed, chat, stories — using social.plus UIKit's prebuilt screens, themed to your brand.
+Use this path when the app already has social.plus. Start with the outcome or symptom; your agent chooses the Vise workflow.
 
-## What to ask
+    Ask for the new behavior and name what must keep working:
 
 ```text
-Use social.plus UIKit to launch a standard community feed in this app.
-Recommend the lowest customization level that fits our design system,
-and don't hand-roll standard surfaces from SDK primitives.
+We already use social.plus for the feed. Using Vise, add comments to the
+existing post detail screen. Preserve the current feed behavior and show
+me the impact and product questions before changing code.
 ```
 
-## What your agent will ask you
+    Expect a short assessment of the existing surface, the new scope, affected files and evidence, and any product decisions still missing.
+    Describe what the user sees, where it happens, and what should happen instead:
 
-The usual product questions — platform, screen or route, region, identity — plus one that's specific to UIKit:
+```text
+Using Vise, diagnose why the feed is missing from the selected Community
+detail page. Show me the likely gap and the smallest safe repair before
+changing code.
+```
 
-- **How much to customize.** The agent recommends the lightest level that fits your design system: theming and dynamic UI, component styling, localization, behavior overrides, or fork-and-extend as a last resort. You confirm the choice; it's recorded with the rest of the plan.
+    The agent should compare the intended route and data target with the current source and evidence, then separate the repair from the checks that need to be refreshed.
+    Ask for the version and feature impact before changing dependencies:
 
-## Staying on the UIKit path
+```text
+Using Vise, assess the social.plus SDK upgrade in this app. Explain the
+current and target version boundary, affected features, and validation
+plan before changing dependencies or source code.
+```
 
-The skill keeps the agent honest about the boundary. Once UIKit is the chosen route, UIKit's installation, provider, behavior, and customization guidance is the implementation source — the agent shouldn't quietly rebuild a standard feed from raw SDK calls. Mixing in direct SDK code is reserved for behavior that's genuinely differentiated for your app.
+    Vise checks the declaration and supported lockfile resolution. It reports the assurance boundary honestly rather than treating a version range as proof of compatibility.
+
+## Protect what already works
+
+Before editing, the agent should identify the existing feature, route, data target, and evidence that could be affected.
+
+If the integration predates Vise, pre-existing findings can be recorded as a baseline so the new change is judged on its own work. The baseline never excuses the requested outcome or anything the change introduces.
+
+If earlier features were built with Vise, they stay recorded and re-verifiable. Ask the agent to report earlier-feature drift separately from the current work.
 
 ## What "done" looks like
 
-Vise validates everything your app owns — SDK setup and region, authentication, configuration, and your project's own build, lint, and test checks. What it can't see inside prebuilt UIKit internals it won't claim to have verified. A themed UIKit screen still deserves product QA and a real launch before you ship it.
+The handoff should state:
+
+- what behavior and scope changed
+- whether every earlier completed feature still holds
+- which project build, lint, typecheck, test, and SDK smoke checks ran
+- whether changed user-visible surfaces have fresh runtime proof or an explicit waiver
+- which advisory findings or product decisions remain open
+
+```sh
+# Assess a planned change
+vise impact . --format human
+
+# Attach a reported symptom
+vise impact . --symptom "Feed is missing from Community detail" --format human
+
+# Inspect the installed SDK boundary
+vise sdk-release . --format human
+
+# Protect current and previously completed features in CI
+vise check . --ci
+```
+
+  See the [command reference](/ai-mcp/vise/cli-reference) for baseline, evidence, and per-feature options.
 
 ## Related
 
-    The loop your agent follows and what its reports mean.
-    Need a differentiated experience? Build directly on the SDK.
+    Protect current and earlier social.plus features after the handoff.
+    Turn the completed change into a reviewable release candidate.
 
 ---
 
-### [Adding to an existing app](https://learn.social.plus/ai-mcp/vise/brownfield-day2)
+### [Keep integrations verified in CI](https://learn.social.plus/ai-mcp/vise/ci-verification)
 
-> Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it.
+> Make the same Vise contract and evidence that guided implementation protect current and previously completed social.plus features in CI.
 
-The second feature gets the same guardrails as the first. Just ask:
+After the first integration is green, keep it verifiable after the coding-agent conversation ends. Commit the `sp-vise/` folder with the application, then run Vise as a read-only CI gate.
 
-```text
-We already use social.plus for the feed — add comments to it.
-```
+## What the CI gate protects
 
-Vise handles both histories your app might have.
+The gate checks more than the feature currently being edited:
 
-## Start with a read-only impact assessment
+- the active integration still matches its recorded scope
+- deterministic SDK and platform requirements still pass
+- required evidence and project sensors are present and current
+- every previously completed Vise feature still holds against the current code
 
-Before the agent edits an existing integration, it runs:
+This matters when a later change passes for one surface but quietly breaks an earlier feed, comments, community, or chat experience.
 
-```sh
-vise impact . --format human
-```
+## Add the gate
 
-The Day-2 Change Planner compares the current project with the recorded contract, dependency snapshot, engagement history, design contract, attestations, and runtime evidence. It classifies evidence as preserved, stale, missing, or unknown, then returns the smallest safe sequence of existing commands. It does not edit code or sidecars, switch engagements, accept policy changes, run sensors, or record attestations.
-
-If the change starts with a reported product symptom, include it:
+Install the same Vise version your team uses for local work, then run:
 
 ```sh
-vise impact . \
-  --symptom "Feed is missing from the selected Community detail page" \
-  --format human
+vise check . --ci
 ```
 
-For a recorded cross-surface journey, Vise can correlate that symptom with the signed placement and target relationship and the current source. It distinguishes an implementation gap from code that has been repaired but still needs fresh static and runtime proof.
+Keep the command read-only in CI. Changes to contracts, attestations, baselines, runtime waivers, or policy selections should be deliberate reviewable changes made before the pipeline runs.
 
-## The existing integration was built by hand
+## Read the outcome
 
-If your app adopted social.plus before Vise, the codebase may carry findings Vise would flag today. The agent snapshots those as a **baseline** before writing any code, so your new feature is judged on its own merits — not blocked by legacy code you didn't touch.
+- **Green:** the active work and all recorded completed features still hold.
+- **Active failure:** the current integration, required evidence, or project validation needs attention.
+- **Earlier-feature drift:** the active work passes, but a previously completed surface no longer does.
+- **Release review required:** when Passport comparison is enabled, the compliance checks pass but a person still needs to review the candidate's release evidence.
 
-Two guarantees keep the baseline honest:
+Link the CI output to the changed application code and committed `sp-vise/` evidence so reviewers can reproduce the result locally.
 
-- It excludes only pre-existing findings. Anything the new work introduces still gates.
-- The feature you asked for is never baselined — the app can't pass without the feature actually being built, complete with its agreed scope.
-
-## Earlier features were built with Vise
-
-Finished features stay recorded, visible, and re-verifiable. When the agent starts a new feature, the previous one's final state is preserved and the switch is disclosed — and replacing a feature that already passed requires an explicit confirmation from you, so nothing green is silently overwritten.
-
-At any point you can ask:
-
-```text
-Check whether the features we built earlier with Vise still hold.
-```
-
-If a later change broke a previously finished surface, you'll be told exactly which one drifted — even while the current work passes.
-
-When the dependency declaration or lockfile changed, `vise sdk-release . --format human` separately explains whether the installed SDK still matches an exact extraction-grounded snapshot. It reports the assurance boundary without changing the dependency or treating semver as proof of compatibility.
-
-## Keep everything verified in CI
-
-One read-only command in your pipeline holds the current work *and* every previously finished feature green:
+  Teams using Integration Passports can add the same release comparison used during human review:
 
 ```sh
-vise check --ci
+vise check . --ci \
+  --from-passport <approved-passport.json> \
+  --to-passport <candidate-passport.json>
 ```
 
-It fails with a distinct exit code when a finished feature drifts, even if the active work passes. See the [reference](/ai-mcp/vise/cli-reference) for baseline and re-verification details.
+  A `ready` result supports human release review; it does not record approval. See the [command reference](/ai-mcp/vise/cli-reference) for exact exit codes and trust-policy options.
 
-## When you review the handoff
+## Related
 
-- Was a baseline used, and when was it recorded?
-- Do earlier features still hold, or did the agent disclose drift?
-- Is there route- and target-matched runtime proof for each changed surface — or an explicit, recorded waiver?
-- Are remaining advisory findings and open non-blocking decisions listed?
-
-    Contracts, evidence, and what your agent's reports mean.
-    Compare verifiable handoffs without confusing readiness with approval.
+    Understand result states and which ones need human input.
+    Review the candidate evidence without confusing readiness with approval.
 
 ---
 
-### [Reviewing and releasing an integration](https://learn.social.plus/ai-mcp/vise/release-assurance)
+### [Review and release an integration](https://learn.social.plus/ai-mcp/vise/release-assurance)
 
-> Turn Vise's recorded contract and evidence into a verifiable release handoff without confusing automated readiness with human approval.
+> Review what changed, what proves it, and which decisions remain human before release.
 
-A green integration is ready to be reviewed, but a release decision also needs to answer what changed, whether the SDK boundary is understood, and whether the evidence still belongs to the candidate being shipped. Vise keeps those questions reproducible with SDK Release Intelligence, Integration Passports, and Governed Release Review.
+A green Vise result is ready for human review; it is not a release approval.
 
-  These commands are read-only unless you explicitly add `--write` or use `vise trust sign`. Vise can say that automated evidence is ready for review; it never records or impersonates human release approval.
+## Ask for a release handoff
 
-## The release-review flow
+```text
+Using Vise, prepare this social.plus change for release review. Summarize
+what changed, the SDK boundary, evidence, regressions or waivers, and the
+decisions a person still needs to make. Do not claim human approval.
+```
 
-    Run:
+If your team has an approved Vise handoff, provide it so the candidate can be compared with that known point.
+
+## What the reviewer should receive
+
+1. **What changed?** The accepted feature scope, placement, target, source, and dependency changes.
+2. **What proves it?** Automatic checks, project sensors, attestations, and runtime evidence—or clearly disclosed waivers.
+3. **What moved?** SDK assurance, policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
+4. **What remains human?** Product QA, security review, risk acceptance, and release approval.
+
+An optional **Integration Passport** packages the candidate's intent and evidence into verifiable claims so another reviewer can detect changed or stale material.
+
+## Read the decision
+
+| Decision | Meaning | Human action |
+| --- | --- | --- |
+| `ready` | No blocking automated regression was found | Complete normal product, security, and release review |
+| `review-required` | Valid evidence contains SDK, policy, lifecycle, or provenance movement | Review the disclosed changes and owners |
+| `blocked` | Required evidence, policy, or trusted provenance is missing | Resolve the named blocker and prepare a new candidate |
+
+Vise never records or impersonates human approval.
+
+  Policy Packs can declare approved SDK ranges and required evidence. Trust envelopes can authenticate a reviewed Passport or Policy Pack across teams or CI systems. A valid signature proves provenance, not integration correctness.
 
 ```sh
 vise sdk-release . --format human
-```
-
-    Vise compares the detected dependency declaration and supported lockfile resolution with the exact SDK snapshots it has verified. It reports whether the project is exact-snapshot verified, range-only, older, newer, or unversioned. It does not fetch a registry, edit dependencies, or infer semantic compatibility from semver alone.
-    Run:
-
-```sh
 vise passport . --write
 vise passport verify . --format human
-```
-
-    An Integration Passport binds the accepted intent, lifecycle state, SDK assurance, evidence hashes, runtime proof or waiver, residual risks, and replay commands into digest-bound claims. Verification recomputes those claims and local evidence states; it does not rerun or repair the project.
-    Run:
-
-```sh
 vise passport compare . \
   --from <approved-passport.json> \
   --to <candidate-passport.json> \
   --format human
 ```
 
-    The comparison discloses regressions and reviewable lifecycle movement, then composes a Governed Release Review decision.
-    Run:
+  See the [command reference](/ai-mcp/vise/cli-reference) for policy, trust, and CI options.
 
-```sh
-vise check . --ci \
-  --from-passport <approved-passport.json> \
-  --to-passport <candidate-passport.json>
-```
+Keep the candidate Passport and comparison when used, the committed `sp-vise/` evidence, CI output, applicable policy files, and the approval recorded by your own release process.
 
-    Existing compliance failures keep their normal exit codes. If compliance is otherwise green but release evidence is `review-required` or `blocked`, the command exits `12`.
+## Related
 
-## Reading the release decision
-
-| Decision | Meaning | Human action |
-| --- | --- | --- |
-| `ready` | Automated evidence supports release review and no blocking regression was found | Complete your normal product, security, and release approval |
-| `review-required` | Evidence is internally valid, but lifecycle, SDK, policy, or provenance movement needs a person to review it | Review the disclosed changes and owners before approving |
-| `blocked` | A required claim, evidence class, policy requirement, or trusted provenance condition is not satisfied | Resolve the named blockers and regenerate the candidate Passport |
-
-`ready` never means “approved.” The release review records `humanApprovalAsserted: false` in every state.
-
-## Organization policy and trusted handoffs
-
-An optional **Policy Pack** lets your organization declare approved SDK ranges, required evidence classes and capabilities, runtime-waiver constraints, release severities, and responsible owners. It is accepted only through an explicit `vise init --policy-pack <path>`; later Day-2, SDK-release, and Passport operations reuse and re-check that recorded selection.
-
-For handoffs that cross repositories, teams, or CI systems, a **Portable Trust Envelope** can authenticate a reviewed Passport or Policy Pack. Signing is an explicit CLI-only operation using a caller-supplied Ed25519 private key that Vise does not retain. Verification checks the envelope against a local trust policy:
-
-```sh
-vise trust verify . \
-  --envelope <artifact.envelope.json> \
-  --trust-policy <trust-policy.json>
-```
-
-A valid signature proves authorized provenance, not that the enclosed integration is correct. Passport and Policy Pack validation still applies.
-
-## What to keep with the release
-
-- the candidate Integration Passport and its comparison result
-- the exact Policy Pack and trust policy used, when applicable
-- the `sp-vise/` contract, engagement history, and evidence referenced by the Passport
-- the CI output and the human approval recorded by your own release process
-
-    Assess changes and preserve earlier social.plus features.
-    See the complete reviewer and CI command surface.
+    Reproduce the checks in the release pipeline.
+    Understand result states and their human-review boundary.
 
 ---
 
 ### [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works)
 
-> The loop the skill drives your agent through, what gets checked, and what 'done' means.
+> How a feature request becomes a grounded plan, checked code, reviewable evidence, and a clear next action.
 
-Vise turns your feature request into a grounded plan, records what "done" means for it, and keeps checking the generated code until the integration is finished — where finished means verified, explained with evidence, intentionally scoped out, or explicitly waiting on your decision. Never just "the agent stopped."
+Vise gives an AI coding agent a repeatable social.plus integration loop. You describe the outcome, answer the product decisions only your team can make, and review the result.
 
-## The loop your agent follows
-
-The [skill](/ai-mcp/vise/overview#get-started) drives your agent through the same loop on every integration:
+## From request to evidence
 
 ```mermaid
 flowchart LR
-  A[understand your app] --> B[plan from the docs]
-  B --> C[record the contract]
-  C --> D[implement]
-  D --> E[check]
-  E -->|not done| D
-  E -->|passes| F[run your project's checks]
-  F --> G[done: evidence recorded]
+  A[Ask for an outcome] --> B[Inspect and plan]
+  B --> C[Confirm decisions]
+  C --> D[Implement and check]
+  D -->|Needs work| D
+  D --> E[Run project checks]
+  E --> F[Record evidence]
+  F --> G[Human review]
 ```
 
-- **Understand your app** — detect the platform, the app surfaces in a monorepo, design signals, and which of your project's own checks are available. In a very large repository, the agent confirms which concrete app it's working in before continuing.
-- **Plan from the docs** — produce a plan with social.plus docs citations, plus the questions the agent must ask you rather than guess. A multi-surface journey also records how its surfaces relate — for example, that a community-detail feed reads and writes the selected community, or that comments belong to the selected post.
-- **Record the contract** — once you've answered, the expectations for this feature, its placement, and its target are written down (see below).
-- **Implement** — the agent edits your app, held to real SDK APIs.
-- **Check** — the code is validated against the recorded contract; the agent iterates until it passes.
-- **Run your project's checks** — your repository's own build, lint, typecheck, and SDK smoke checks.
+1. **Inspect and plan.** The agent identifies the app surface, reads social.plus documentation and SDK facts, and asks instead of guessing.
+2. **Confirm decisions.** Vise records the feature, placement, data target, selected capabilities, and definition of done.
+3. **Implement and check.** The agent validates real SDK usage, platform lifecycle, and feature completeness while it works.
+4. **Run project checks.** The app's build, lint, typecheck, tests, and SDK smoke checks run when available.
+5. **Record evidence.** The result explains what passed, what still needs work, and whether the intended surface worked at runtime.
 
-## What Vise checks
+## Read the result
 
-Vise focuses on the mistakes that pass a demo and break in production:
+Ask your agent to separate the outcome into what passed, what it will fix, and what needs your decision.
 
-- **SDK grounding** — the agent is held to real, source-anchored SDK facts (actual types and field names), so it won't invent a symbol the SDK doesn't expose.
-- **Platform correctness** — 400+ platform-specific checks: SDK setup and region, session renewal and login lifecycle, secret handling and committed environment files, Live Object and Live Collection usage, and feed, comment, chat, notification, community, follow, story, and moderation patterns.
-- **Feature completeness** — the whole outcome, including pagination, empty and error states, and the optional capabilities you asked for — not just the happy path.
-- **Design and experience** — generated UI reviewed against your design system. This layer is **advisory**; brand fit still needs human judgment.
-- **Project sensors** — your repository's own build, lint, typecheck, and SDK import smoke checks.
+| Result | What happens next |
+| --- | --- |
+| `green` | Review the feature through your normal product process |
+| `deterministic-failures` or `completeness-gap` | The agent fixes the code or finishes the agreed scope |
+| `selected-capability-failures` | Finish the selected capability or explicitly remove it from scope |
+| `blocked` | Answer the named product or project question |
+| `needs-attestation` | Review evidence for correct architecture the automatic check cannot see |
+| `contract-drift` | Confirm the changed intent or restore the implementation |
+| `runtime-proof-waived` | Accept the explicit waiver or request a real launch |
+| `engagement-drift` | Reopen the earlier feature or explicitly accept the change |
 
-Deterministic SDK correctness and explicit completeness decisions are the checks that block. Design and experience guidance stays advisory.
+`no-platform` means Vise did not find a supported app surface. Confirm that the agent is working in the correct package before concluding that there is nothing to validate.
 
-## The `sp-vise/` folder
+## What the evidence means
 
-The recorded contract, its check results, and all supporting evidence live in a small `sp-vise/` folder in your repo. Commit it with your app: it's what lets a reviewer see *why* the integration is trustworthy — and what lets CI keep verifying the work after the chat transcript is long gone.
+The contract, check results, attestations, and runtime receipts live in `sp-vise/`. Commit that folder with the application so review and CI do not depend on an agent transcript.
 
-## What your agent will report
+Evidence can prove an automatic check passed, explain architecture a static rule cannot follow, or show that a specific surface mounted and loaded data at its recorded route and target.
 
-Every check ends in one of these states. Your agent will name them when it reports back, so here's what each one means for you:
-
-| State | Meaning | What you do |
-| --- | --- | --- |
-| `green` | Every applicable check passes | Accept the integration |
-| `needs-attestation` | A rule is satisfied through architecture the automatic check can't see | Let the agent record evidence and a rationale, then review it |
-| `deterministic-failures` | A rule failed in the code | Nothing — the agent fixes and re-checks |
-| `completeness-gap` | The feature you asked for isn't fully built yet | Nothing — the agent keeps going, or asks you to drop scope explicitly |
-| `selected-capability-failures` | An optional capability you chose isn't satisfied | Decide: finish it, or intentionally drop it |
-| `blocked` | A decision only your team can make is missing | Answer the question |
-| `contract-drift` | The code no longer matches what was recorded | Decide with the agent: re-plan, or restore the code |
-| `runtime-proof-waived` | On-device runtime proof was honestly waived | Accept the recorded waiver, or ask for a real run |
-| `no-platform` | No supported platform was detected | Nothing to validate here |
-| `engagement-drift` | Current work is fine, but a previously finished feature no longer holds | Re-open the drifted feature or accept the documented change |
-
-## Evidence instead of "trust me"
-
-Three kinds of proof accumulate in `sp-vise/` as the agent works:
-
-- **Attestations.** Some correct code passes through indirection a static check can't follow — a helper module, a wrapper, a pattern unique to your codebase. Instead of failing silently or passing blindly, the agent records *why* the rule is satisfied, with evidence and a rationale you can audit.
-- **Runtime proof.** For user-visible surfaces, Vise assesses normalized launch markers into independent per-surface receipts — did the intended screen mount, authenticate, and load data at the declared route and target? A comments run cannot overwrite valid community-feed proof, and changed placement cannot inherit an older receipt. When no device or emulator is available, an explicit waiver is recorded instead of a silent pass.
-- **Deterministic passes.** After a green check, the passing evidence itself is persisted, so review doesn't depend on re-running anything.
-
-Reviewers can inspect all of it with a few read-only commands — see the [reference](/ai-mcp/vise/cli-reference).
-
-## Adding features later
-
-The second feature is governed as carefully as the first, whether the existing integration was built by hand or through Vise — and earlier finished features stay recorded and re-verifiable. See [Adding to an existing app](/ai-mcp/vise/brownfield-day2).
-
-## Vise in CI
-
-After the first successful integration, commit `sp-vise/` and add one read-only command to your pipeline:
-
-```sh
-vise check --ci
-```
-
-It verifies the active contract *and* re-verdicts every previously finished feature, failing the build unless all governed work still holds. Baseline behavior for pre-existing codebases and per-feature re-verification are covered in the [reference](/ai-mcp/vise/cli-reference).
-
-For a release candidate, CI can also compare an approved Integration Passport with the candidate:
-
-```sh
-vise check . --ci \
-  --from-passport <approved-passport.json> \
-  --to-passport <candidate-passport.json>
-```
-
-This adds the same Governed Release Review returned by `vise passport compare`. A `ready` result means the automated evidence supports human review; it never means Vise approved the release. Otherwise-green compliance exits `12` when the release review is `review-required` or `blocked`. See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance).
+It does not replace product QA, security review, or human release approval. User-visible work still needs a real launch or an honest recorded waiver.
 
 ## Related
 
-    Install Vise and ask for your first feature.
-    The commands for verifying recorded evidence and gating releases.
-    SDK assurance, Integration Passports, and governed release review.
-    Build realtime SDK features with the correct lifecycle.
-    User login, session renewal, and regional configuration.
+    Add, diagnose, or upgrade without losing earlier evidence.
+    Carry the same contract and evidence into the pipeline.
+    Look up the full command surface when operating Vise directly.
+    Expose Vise's local tools to an MCP-capable coding host.
 
 ---
 
@@ -70300,7 +70281,7 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 | `vise trust sign [path] ...` | CLI-only explicit write: wrap a reviewed Passport or Policy Pack in an Ed25519 envelope using an external private key that Vise does not retain |
 | `vise trust verify [path] --envelope <path> --trust-policy <path>` | Authenticate envelope integrity, issuer/key authorization, artifact type, audience, and validity. Signature validity does not replace Passport or Policy Pack semantic validation |
 
-See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance) for the recommended handoff flow.
+See [Review and release an integration](/ai-mcp/vise/release-assurance) for the recommended handoff flow.
 
 ## Validate and verify
 
@@ -70317,7 +70298,7 @@ See [Reviewing and releasing an integration](/ai-mcp/vise/release-assurance) for
 | `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
-See [What your agent will report](/ai-mcp/vise/how-it-works#what-your-agent-will-report) for what each state means.
+See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each state means.
 
 ## Evidence
 

--- a/llms.txt
+++ b/llms.txt
@@ -429,13 +429,15 @@
 ## AI / MCP
 
 - [AI / MCP](https://learn.social.plus/ai-mcp/overview): Connect AI coding tools to the social.plus documentation MCP server.
-- [Vise](https://learn.social.plus/ai-mcp/vise/overview): Install Vise, add its skill to your AI coding agent, and get social.plus integrations that actually work.
-- [Try Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate): Add the skill to your agent and watch it plan a real integration — no credentials, no code changes.
-- [Custom SDK UI](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui): Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app.
-- [UIKit quick launch](https://learn.social.plus/ai-mcp/vise/uikit-quickstart): Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
-- [Adding to an existing app](https://learn.social.plus/ai-mcp/vise/brownfield-day2): Ask your agent for the next social.plus feature — whether the app adopted social.plus before Vise or built earlier features with it.
-- [Reviewing and releasing an integration](https://learn.social.plus/ai-mcp/vise/release-assurance): Turn Vise's recorded contract and evidence into a verifiable release handoff without confusing automated readiness with human approval.
-- [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works): The loop the skill drives your agent through, what gets checked, and what 'done' means.
+- [Vise](https://learn.social.plus/ai-mcp/vise/overview): Give your AI coding agent a grounded, verifiable workflow for building social.plus features.
+- [Try Vise in 15 minutes](https://learn.social.plus/ai-mcp/vise/evaluate): Let your agent plan a real social.plus integration without credentials or code changes.
+- [Choose how to build your social experience](https://learn.social.plus/ai-mcp/vise/choose-integration-path): Decide whether to launch with a prebuilt UIKit surface or build a differentiated experience directly on the social.plus SDK.
+- [Launch a standard social experience](https://learn.social.plus/ai-mcp/vise/uikit-quickstart): Ask your agent to launch a prebuilt social.plus UIKit surface with the lightest customization that fits.
+- [Build a custom social experience](https://learn.social.plus/ai-mcp/vise/sdk-custom-ui): Ask your agent for a differentiated social.plus experience built directly on the SDK and owned by your app.
+- [Maintain an existing integration](https://learn.social.plus/ai-mcp/vise/brownfield-day2): Add a feature, diagnose a problem, or upgrade the SDK without losing confidence in the social.plus experiences that already work.
+- [Keep integrations verified in CI](https://learn.social.plus/ai-mcp/vise/ci-verification): Make the same Vise contract and evidence that guided implementation protect current and previously completed social.plus features in CI.
+- [Review and release an integration](https://learn.social.plus/ai-mcp/vise/release-assurance): Review what changed, what proves it, and which decisions remain human before release.
+- [How Vise works](https://learn.social.plus/ai-mcp/vise/how-it-works): How a feature request becomes a grounded plan, checked code, reviewable evidence, and a clear next action.
 - [Run Vise as an MCP server](https://learn.social.plus/ai-mcp/vise/mcp-server): Expose Vise's local tools to Claude Code, Cursor, Codex, and VS Code over MCP.
 - [Command reference](https://learn.social.plus/ai-mcp/vise/cli-reference): For reviewers and CI — the commands behind the skill, and the ones you run to verify recorded evidence.
 - [Claude](https://learn.social.plus/ai-mcp/claude-desktop): Connect social.plus to Claude — both claude.ai web and the Claude Desktop app.

--- a/llmstxt/llms-config.yml
+++ b/llmstxt/llms-config.yml
@@ -478,11 +478,23 @@ sections:
     pages:
       - path: ai-mcp/overview.mdx
       - path: ai-mcp/vise/overview.mdx
+
+      # Start
       - path: ai-mcp/vise/evaluate.mdx
-      - path: ai-mcp/vise/sdk-custom-ui.mdx
+      - path: ai-mcp/vise/choose-integration-path.mdx
+
+      # Build
       - path: ai-mcp/vise/uikit-quickstart.mdx
+      - path: ai-mcp/vise/sdk-custom-ui.mdx
+
+      # Maintain
       - path: ai-mcp/vise/brownfield-day2.mdx
+
+      # Review and ship
+      - path: ai-mcp/vise/ci-verification.mdx
       - path: ai-mcp/vise/release-assurance.mdx
+
+      # Reference
       - path: ai-mcp/vise/how-it-works.mdx
       - path: ai-mcp/vise/mcp-server.mdx
       - path: ai-mcp/vise/cli-reference.mdx


### PR DESCRIPTION
## Summary
- reorganize Vise docs around Start, Build, Maintain, Review and ship, and Reference
- consolidate overlapping maintenance and result guidance to reduce repetition
- add focused path-selection and CI pages while keeping CLI detail in Reference
- regenerate llms.txt and llms-full.txt

## Validation
- python3 -m json.tool docs.json
- python3 tools/check_internal_links.py
- python3 .docs-ops/ci/check-mdx.py
- cd llmstxt && go test ./...
- deterministic llms regeneration
- git diff --check

The Vise section is reduced from the expanded 14-page, ~8,630-word draft to 11 pages and ~6,150 words.