### PR TITLE
docs(vise): sync customer operations assurance

### DIFF
--- a/ai-mcp/vise/brownfield-day2.mdx
+++ b/ai-mcp/vise/brownfield-day2.mdx
@@ -5,6 +5,10 @@ description: "Add a feature, diagnose a problem, or upgrade the SDK without losi
 
 Use this path when the app already has social.plus. Start with the outcome or symptom; your agent chooses the Vise workflow.
 
+<Info>
+  Ask the agent to start with `vise status . --format human`. It reads the current lifecycle state without running project sensors or changing files, then routes unchanged work, a Day-2 change, or a release handoff to the smallest next action.
+</Info>
+
 <Tabs>
   <Tab title="Add or change a feature">
     Ask for the new behavior and name what must keep working:
@@ -49,6 +53,8 @@ If the integration predates Vise, pre-existing findings can be recorded as a bas
 
 If earlier features were built with Vise, they stay recorded and re-verifiable. Ask the agent to report earlier-feature drift separately from the current work.
 
+If a support incident or dogfood miss reveals a reusable blind spot, a reviewed `incident-protection` learning record can bind a sanitized finding fixture, clean control, and exact verification evidence. It stays local, never uploads customer source, and does not edit rules or change readiness automatically.
+
 ## What "done" looks like
 
 The handoff should state:
@@ -61,6 +67,9 @@ The handoff should state:
 
 <Accordion title="Under the hood: commands used by the agent" icon="terminal">
   ```sh
+  # Route the current lifecycle job without changing the project
+  vise status . --format human
+
   # Assess a planned change
   vise impact . --format human
 
@@ -72,6 +81,10 @@ The handoff should state:
 
   # Protect current and previously completed features in CI
   vise check . --ci
+
+  # Preview a reviewed incident-to-protection record without writing
+  vise learning record . --kind incident-protection \
+    --evidence <repo-relative-input.json> --no-write
   ```
 
   See the [command reference](/ai-mcp/vise/cli-reference) for baseline, evidence, and per-feature options.

--- a/ai-mcp/vise/ci-verification.mdx
+++ b/ai-mcp/vise/ci-verification.mdx
@@ -11,7 +11,8 @@ The gate checks more than the feature currently being edited:
 
 - the active integration still matches its recorded scope
 - deterministic SDK and platform requirements still pass
-- required evidence and project sensors are present and current
+- required evidence and project sensors are present and current, including any retained runtime receipt
+- accepted organization policy remains current, authentic, and inside its lifecycle and trust boundaries
 - every previously completed Vise feature still holds against the current code
 
 This matters when a later change passes for one surface but quietly breaks an earlier feed, comments, community, or chat experience.
@@ -26,14 +27,28 @@ vise check . --ci
 
 Keep the command read-only in CI. Changes to contracts, attestations, baselines, runtime waivers, or policy selections should be deliberate reviewable changes made before the pipeline runs.
 
+For a more diagnostic pipeline, verify retained runtime evidence or the repository policy source in separate read-only steps before the composed gate:
+
+```sh
+vise smoke verify . \
+  --evidence sp-vise/evidence/runtime-smoke/<surface>.json
+vise policy status . --ci
+vise check . --ci
+```
+
 ## Read the outcome
 
 - **Green:** the active work and all recorded completed features still hold.
 - **Active failure:** the current integration, required evidence, or project validation needs attention.
 - **Earlier-feature drift:** the active work passes, but a previously completed surface no longer does.
 - **Release review required:** when Passport comparison is enabled, the compliance checks pass but a person still needs to review the candidate's release evidence.
+- **Policy review required or blocked:** the accepted policy source changed or crossed a lifecycle, signing-key, or rotation boundary; Vise returns the exact owner instead of accepting a successor automatically.
 
 Link the CI output to the changed application code and committed `sp-vise/` evidence so reviewers can reproduce the result locally.
+
+<Info>
+  MCP `check_compliance` returns the same compliance result and exit code with an additive `customerOperations` summary for build, Day-2, and release routing. The summary does not run sensors, write files, or turn advisory findings into a gate.
+</Info>
 
 <Accordion title="Advanced: compare an approved and candidate release" icon="terminal">
   Teams using Integration Passports can add the same release comparison used during human review:

--- a/ai-mcp/vise/cli-reference.mdx
+++ b/ai-mcp/vise/cli-reference.mdx
@@ -31,9 +31,12 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 
 | Command | Purpose |
 | --- | --- |
+| `vise status [path]` | Read-only lifecycle front door for build, Day-2 change, and release review. Keeps compliance, runtime, SDK, policy, advisory, Passport, and human-approval claims separate; reports owners and the smallest next actions without running sensors, writing files, or changing the compliance exit code |
 | `vise impact [path] [--symptom "..."]` | Read-only Day-2 planner. Compare the project with recorded intent, lifecycle state, SDK declarations, policy, and evidence; classify evidence as preserved, stale, missing, or unknown; and return the smallest safe recovery sequence. A symptom can authorize a bounded repair when recorded cross-surface intent and current source confirm the gap |
-| `vise sdk-release [path]` | Explain whether detected SDK declarations and supported lockfile resolutions match Vise's exact extraction-grounded snapshots. It does not fetch registries, edit dependencies, or infer semantic compatibility from semver |
+| `vise sdk-release [path]` | Explain whether detected SDK declarations and supported lockfile resolutions match Vise's exact extraction-grounded snapshots, reviewed knowledge, and five-platform fact-depth contract. `meets-target`, `target-gap`, `regressed`, and `unknown` stay explicit; it does not fetch registries, edit dependencies, or infer semantic compatibility from semver |
 | `vise sdk-release --from-surface-dir <before> --to-surface-dir <after>` | Diff two SDK surface snapshots for symbol, model-field, capability, and affected-rule changes |
+| `vise policy status [path] [--source <manifest>] [--ci]` | Read-only organization-policy source, lifecycle, trust-key rotation/revocation, deterministic update impact, and exact owner routing. CI exits `0`, `12`, or `13` for `ready`, `review-required`, or `blocked` |
+| `vise policy accept [path] --source <manifest> --recorded-by <identity> --reason "..."` | CLI-only explicit write: pin the exact reviewed source and Policy Pack digests and write an audit receipt. It never rewrites policy inputs, manages keys, or asserts release approval |
 | `vise passport [path] [--write]` | Compose sanitized accepted intent, lifecycle, SDK assurance, evidence hashes, runtime state, residual risk, and replay commands into digest-bound claims. Read-only unless `--write` is explicit |
 | `vise passport verify [path] [--passport <path>]` | Recompute Passport claims and local evidence states without rerunning or repairing the project |
 | `vise passport compare [path] --from <before> --to <after>` | Compare two valid Passports and compose a Governed Release Review result: `ready`, `review-required`, or `blocked` |
@@ -54,7 +57,6 @@ See [Review and release an integration](/ai-mcp/vise/release-assurance) for the 
 | `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
 | `vise check [path] --all-engagements` | The normal check plus re-verification of every recorded engagement; exit `11` means your current work is green but a previously finished surface drifted |
 | `vise validate [path]` | Run the deterministic validators only (no attestation comparison) |
-| `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
 See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each state means.
@@ -67,7 +69,8 @@ See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each s
 | `vise attest [path] --rule <id> --signer host-agent --confidence high --evidence-file evidence.json --rationale "..."` | Record that a rule is satisfied through architecture the check can't see |
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke declare [path] --surface <id> [--route <route>] [--target-type <type>]` | Declare the exact runtime collection surface and, when applicable, its route and SDK target |
-| `vise smoke [path] --log <file> [--surface <id> ...]` | Assess normalized runtime markers and write independent per-surface receipts. Marker surface, route, and target must match the declaration; repeat `--surface` to assess selected surfaces |
+| `vise smoke [path] --log <file> [--surface <id> ...] [--receipt-context <json>]` | Assess normalized runtime markers and write independent per-surface receipts. Marker surface, route, and target must match the declaration; strict receipt context additionally binds source, build, runner, artifacts, and prior Passport lineage |
+| `vise smoke verify [path] --evidence <scoped-runtime-smoke.json>` | Read-only receipt verification without relaunching the app; distinguishes `absent`, `stale`, `tampered`, `failed`, and `passed` |
 | `vise smoke waive [path] --reason "..." --mode declined\|deviceless` | Record an auditable runtime-proof waiver |
 
 ## Engagement history
@@ -106,6 +109,7 @@ See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each s
 | `vise experience sensors [path]` | Write the advisory experience sensor framework |
 | `vise experience-report [path]` | Write a dimensioned advisory experience review |
 | `vise learning record [path]` | Record a local-only learning event or reviewed aggregate Outcome Evidence |
+| `vise learning record [path] --kind incident-protection --evidence <input.json> [--no-write]` | Preview or record a reviewed, sanitized incident bound to distinct finding/clean fixtures and exact evidence. It never executes replay, uploads source, edits protection, or changes readiness |
 | `vise learning show [path]` | Read the local learning summary and non-causal advisory deltas |
 
 These commands do not upload customer data, assign a calibrated score, change recommendations automatically, or affect `vise check` exit codes.

--- a/ai-mcp/vise/evaluate.mdx
+++ b/ai-mcp/vise/evaluate.mdx
@@ -16,20 +16,75 @@ Use a clean branch or disposable copy of a real app. This walkthrough stops afte
     vise install-skill --target claude  # or: cursor . / vscode . / copilot . / codex
     ```
   </Step>
-  <Step title="Ask for a plan only">
-    Open the app in your agent and ask:
+  <Step title="Choose an evaluation input">
+    Pick the example closest to your situation. The outputs below show the expected shape; the details should come from your app.
 
-    ```text
-    Using Vise, plan how you'd add a social feed to this app with social.plus.
-    Don't change code yet. Show me the plan and the decisions you need from me.
-    ```
+    <Tabs>
+      <Tab title="Add a first feed">
+        **Input**
+
+        ```text
+        Using Vise, plan how you'd add a social feed to this app with social.plus.
+        Don't change code yet. Show me the plan and the decisions you need from me.
+        ```
+
+        **Representative output**
+
+        ```text
+        App detected: the concrete web or mobile app and its platform
+        Recommended path: UIKit or custom SDK UI, with a reason
+        Open decisions: region, target screen, feed source, feature scope
+        Relevant docs: cited social.plus setup and feed guidance
+        Files changed: none
+        ```
+      </Tab>
+      <Tab title="Add comments">
+        **Input**
+
+        ```text
+        We already use social.plus for a feed. Using Vise, plan how to add
+        comments to the existing post detail experience. Preserve the feed,
+        and don't change code yet.
+        ```
+
+        **Representative output**
+
+        ```text
+        Existing surface: feed and post detail flow
+        Change impact: comments belong to the selected post
+        Preserve: current feed behavior and earlier evidence
+        Open decisions: replies, reactions, moderation, target route
+        Files changed: none
+        ```
+      </Tab>
+      <Tab title="Investigate a missing feed">
+        **Input**
+
+        ```text
+        Using Vise, investigate why the feed is missing from the selected
+        Community detail page. Show me the intended journey, likely gap, and
+        smallest safe repair plan. Don't change code yet.
+        ```
+
+        **Representative output**
+
+        ```text
+        Intended journey: selected community -> detail page -> community feed
+        Current evidence: route, target source, and relevant implementation
+        Likely gap: implementation mismatch or stale/missing runtime proof
+        Next step: bounded repair and the checks that must be refreshed
+        Files changed: none
+        ```
+      </Tab>
+    </Tabs>
   </Step>
   <Step title="Review the response">
-    Look for three things:
+    Look for four things:
 
     - the correct app and platform were identified
     - the plan cites real social.plus capabilities and documentation
     - region, target screen, data source, and other product choices appear as questions rather than guesses
+    - the response confirms that no files were changed
   </Step>
   <Step title="Stop before implementation">
     For this evaluation, the plan and decision list are the deliverable. Do not answer the questions until you want the agent to begin implementation.

--- a/ai-mcp/vise/how-it-works.mdx
+++ b/ai-mcp/vise/how-it-works.mdx
@@ -18,6 +18,8 @@ flowchart LR
   F --> G[Human review]
 ```
 
+On resumed work, `vise status` reads the current evidence first and routes the agent to the relevant build, Day-2, or release-review step. It does not run project sensors or change the existing compliance result.
+
 1. **Inspect and plan.** The agent identifies the app surface, reads social.plus documentation and SDK facts, and asks instead of guessing.
 2. **Confirm decisions.** Vise records the feature, placement, data target, selected capabilities, and definition of done.
 3. **Implement and check.** The agent validates real SDK usage, platform lifecycle, and feature completeness while it works.
@@ -48,6 +50,15 @@ The contract, check results, attestations, and runtime receipts live in `sp-vise
 Evidence can prove an automatic check passed, explain architecture a static rule cannot follow, or show that a specific surface mounted and loaded data at its recorded route and target.
 
 It does not replace product QA, security review, or human release approval. User-visible work still needs a real launch or an honest recorded waiver.
+
+| Claim | What Vise can establish | What remains separate |
+| --- | --- | --- |
+| Compliance | Recorded scope, deterministic SDK/platform checks, and earlier-feature drift | Product and security judgment |
+| Project sensors | The detected build, lint, typecheck, test, or SDK-smoke command result | Tests that were unavailable or not selected |
+| Runtime receipt | Retained source, build, runner, route, target, artifact, and Passport lineage still match | Visual quality and unobserved SDK semantics |
+| SDK assurance | Exact extracted symbols, models, capability anchors, provenance, freshness, and fact-depth state | Compatibility beyond the reviewed evidence |
+| Organization policy | Accepted source, lifecycle, trust-key state, update impact, and responsible owner | Policy acceptance and release approval |
+| Passport and advisory review | Digest-bound handoff claims and disclosed movement | The human decision to ship |
 
 ## Related
 

--- a/ai-mcp/vise/mcp-server.mdx
+++ b/ai-mcp/vise/mcp-server.mdx
@@ -3,7 +3,7 @@ title: "Run Vise as an MCP server"
 description: "Expose Vise's local tools to Claude Code, Cursor, Codex, and VS Code over MCP."
 ---
 
-Vise ships an MCP adapter, so any MCP-capable host can call Vise's tools — inspect, plan, assess Day-2 impact, check SDK release boundaries, compose Passports, validate, run sensors, and look up docs — directly during the coding loop. Start it with:
+Vise ships an MCP adapter, so any MCP-capable host can call Vise's tools — inspect, plan, assess Day-2 impact, check SDK and organization-policy boundaries, verify runtime receipts, compose Passports, validate, run sensors, and look up docs — directly during the coding loop. Start it with:
 
 ```sh
 vise mcp
@@ -95,7 +95,9 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 | `analyze_sdk_release` | `vise sdk-release` | Explain exact-snapshot SDK assurance or diff two extracted SDK surface snapshots |
 | `plan_integration` | `vise plan` | Grounded plan with docs citations and intake |
 | `init_compliance` | `vise init` | Write the `sp-vise/` contract |
-| `check_compliance` | `vise check` | Validate the code against the contract |
+| `check_compliance` | `vise check` + lifecycle summary | Validate the code against the contract and add the same `customerOperations` build, Day-2, and release routing returned by CLI `vise status` |
+| `assess_policy_operations` | `vise policy status` | Read the repository policy source, lifecycle and trust state, deterministic update impact, and exact owner routing |
+| `verify_runtime_receipt` | `vise smoke verify` | Verify retained source/build/runner/surface/artifact/Passport bindings without relaunching the app |
 | `generate_integration_passport` | `vise passport` | Compose a digest-bound, sanitized integration handoff; read-only unless writing is explicit |
 | `verify_integration_passport` | `vise passport verify` | Recompute Passport claims and local evidence hashes without repairing the project |
 | `compare_integration_passports` | `vise passport compare` | Compare handoffs and compose the Governed Release Review decision |
@@ -107,7 +109,9 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 | `attest_rule` / `explain_rule` | `vise attest` / `vise explain` | Record evidence and read rule guidance |
 | `record_learning` / `show_learning` | `vise learning record` / `vise learning show` | Record and read local-only, advisory learning and Outcome Evidence |
 
-Signing trust envelopes and installing Managed Placements are intentionally CLI-only. An MCP host can verify an envelope, but Vise does not expose private-key signing through MCP.
+`check_compliance` keeps its established compliance fields and exit code; `customerOperations` is additive and read-only. It does not run sensors, write files, gate on advisory findings, or infer human approval.
+
+Signing trust envelopes, accepting an organization policy source, and installing Managed Placements are intentionally CLI-only. An MCP host can verify an envelope or assess policy, but Vise does not expose private-key signing or controlled policy acceptance through MCP.
 
 ## Skill or MCP?
 

--- a/ai-mcp/vise/overview.mdx
+++ b/ai-mcp/vise/overview.mdx
@@ -8,6 +8,8 @@ Vise helps AI coding agents integrate social.plus without guessing SDK APIs or s
 
 After setup, you talk to your agent—not to Vise.
 
+When you return to an existing project, `vise status . --format human` is the read-only front door. It routes the agent to one of three jobs—finish the build, assess a Day-2 change, or prepare release review—while keeping compliance, runtime proof, SDK assurance, organization policy, advisory review, Passport verification, and human approval as separate claims.
+
 ## Get started
 
 <Info>
@@ -44,7 +46,7 @@ After setup, you talk to your agent—not to Vise.
 
 1. **A grounded plan.** The agent uses real social.plus documentation and SDK facts.
 2. **Implementation with checks.** Vise checks SDK usage, lifecycle behavior, feature completeness, and the project's own validation commands.
-3. **An honest handoff.** The result says what passed, what still needs a decision, and whether the intended surface worked at runtime.
+3. **An honest handoff.** The result says what passed, what still needs a decision, whether the intended surface worked at runtime, and who owns the smallest next action.
 
 The contract and evidence live in `sp-vise/` so reviewers and CI can reproduce the result after the conversation ends. See [How Vise works](/ai-mcp/vise/how-it-works) for the complete loop and result states.
 

--- a/ai-mcp/vise/release-assurance.mdx
+++ b/ai-mcp/vise/release-assurance.mdx
@@ -5,6 +5,12 @@ description: "Review what changed, what proves it, and which decisions remain hu
 
 A green Vise result is ready for human review; it is not a release approval.
 
+Start with the lifecycle summary so the reviewer sees the smallest missing action without collapsing independent claims:
+
+```sh
+vise status . --format human
+```
+
 ## Ask for a release handoff
 
 ```text
@@ -18,11 +24,13 @@ If your team has an approved Vise handoff, provide it so the candidate can be co
 ## What the reviewer should receive
 
 1. **What changed?** The accepted feature scope, placement, target, source, and dependency changes.
-2. **What proves it?** Automatic checks, project sensors, attestations, and runtime evidence—or clearly disclosed waivers.
-3. **What moved?** SDK assurance, policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
+2. **What proves it?** Automatic checks, project sensors, attestations, and a source/build/route/target-bound runtime receipt—or clearly disclosed waivers.
+3. **What moved?** SDK knowledge and fact depth, organization policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
 4. **What remains human?** Product QA, security review, risk acceptance, and release approval.
 
 An optional **Integration Passport** packages the candidate's intent and evidence into verifiable claims so another reviewer can detect changed or stale material.
+
+A verified runtime receipt proves that its retained evidence still matches the recorded build and surface; it does not prove visual quality, every SDK behavior, or release approval. Organization Policy Operations likewise identifies accepted, changed, expired, superseded, or revoked policy and routes the exact owner without accepting an update automatically.
 
 ## Read the decision
 
@@ -38,7 +46,10 @@ Vise never records or impersonates human approval.
   Policy Packs can declare approved SDK ranges and required evidence. Trust envelopes can authenticate a reviewed Passport or Policy Pack across teams or CI systems. A valid signature proves provenance, not integration correctness.
 
   ```sh
+  vise policy status . --ci --format human
   vise sdk-release . --format human
+  vise smoke verify . \
+    --evidence sp-vise/evidence/runtime-smoke/<surface>.json
   vise passport . --write
   vise passport verify . --format human
   vise passport compare . \
@@ -46,6 +57,8 @@ Vise never records or impersonates human approval.
     --to <candidate-passport.json> \
     --format human
   ```
+
+  Policy status exits `0` for `ready`, `12` for `review-required`, and `13` for `blocked`. Accepting a reviewed repository policy source is a separate CLI-only write with `vise policy accept`; its receipt proves the recording action, not release approval.
 
   See the [command reference](/ai-mcp/vise/cli-reference) for policy, trust, and CI options.
 </Accordion>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69676,6 +69676,8 @@ Vise helps AI coding agents integrate social.plus without guessing SDK APIs or s
 
 After setup, you talk to your agent—not to Vise.
 
+When you return to an existing project, `vise status . --format human` is the read-only front door. It routes the agent to one of three jobs—finish the build, assess a Day-2 change, or prepare release review—while keeping compliance, runtime proof, SDK assurance, organization policy, advisory review, Passport verification, and human approval as separate claims.
+
 ## Get started
 
   Vise requires Node.js 20 or newer.
@@ -69702,7 +69704,7 @@ Add a social feed to this app using social.plus.
 
 1. **A grounded plan.** The agent uses real social.plus documentation and SDK facts.
 2. **Implementation with checks.** Vise checks SDK usage, lifecycle behavior, feature completeness, and the project's own validation commands.
-3. **An honest handoff.** The result says what passed, what still needs a decision, and whether the intended surface worked at runtime.
+3. **An honest handoff.** The result says what passed, what still needs a decision, whether the intended surface worked at runtime, and who owns the smallest next action.
 
 The contract and evidence live in `sp-vise/` so reviewers and CI can reproduce the result after the conversation ends. See [How Vise works](/ai-mcp/vise/how-it-works) for the complete loop and result states.
 
@@ -69733,17 +69735,64 @@ Use a clean branch or disposable copy of a real app. This walkthrough stops afte
 npm install -g @amityco/social-plus-vise
 vise install-skill --target claude  # or: cursor . / vscode . / copilot . / codex
 ```
-    Open the app in your agent and ask:
+    Pick the example closest to your situation. The outputs below show the expected shape; the details should come from your app.
+
+        **Input**
 
 ```text
 Using Vise, plan how you'd add a social feed to this app with social.plus.
 Don't change code yet. Show me the plan and the decisions you need from me.
 ```
-    Look for three things:
+
+        **Representative output**
+
+```text
+App detected: the concrete web or mobile app and its platform
+Recommended path: UIKit or custom SDK UI, with a reason
+Open decisions: region, target screen, feed source, feature scope
+Relevant docs: cited social.plus setup and feed guidance
+Files changed: none
+```
+        **Input**
+
+```text
+We already use social.plus for a feed. Using Vise, plan how to add
+comments to the existing post detail experience. Preserve the feed,
+and don't change code yet.
+```
+
+        **Representative output**
+
+```text
+Existing surface: feed and post detail flow
+Change impact: comments belong to the selected post
+Preserve: current feed behavior and earlier evidence
+Open decisions: replies, reactions, moderation, target route
+Files changed: none
+```
+        **Input**
+
+```text
+Using Vise, investigate why the feed is missing from the selected
+Community detail page. Show me the intended journey, likely gap, and
+smallest safe repair plan. Don't change code yet.
+```
+
+        **Representative output**
+
+```text
+Intended journey: selected community -> detail page -> community feed
+Current evidence: route, target source, and relevant implementation
+Likely gap: implementation mismatch or stale/missing runtime proof
+Next step: bounded repair and the checks that must be refreshed
+Files changed: none
+```
+    Look for four things:
 
     - the correct app and platform were identified
     - the plan cites real social.plus capabilities and documentation
     - region, target screen, data source, and other product choices appear as questions rather than guesses
+    - the response confirms that no files were changed
     For this evaluation, the plan and decision list are the deliverable. Do not answer the questions until you want the agent to begin implementation.
 
 This exercise shows that Vise works with your agent and codebase. It does not prove that an integration has been built, passes project checks, or works with your credentials and tenant data.
@@ -69887,6 +69936,8 @@ Then run the app and look at it. Passing checks prove the code is right; only a 
 
 Use this path when the app already has social.plus. Start with the outcome or symptom; your agent chooses the Vise workflow.
 
+  Ask the agent to start with `vise status . --format human`. It reads the current lifecycle state without running project sensors or changing files, then routes unchanged work, a Day-2 change, or a release handoff to the smallest next action.
+
     Ask for the new behavior and name what must keep working:
 
 ```text
@@ -69923,6 +69974,8 @@ If the integration predates Vise, pre-existing findings can be recorded as a bas
 
 If earlier features were built with Vise, they stay recorded and re-verifiable. Ask the agent to report earlier-feature drift separately from the current work.
 
+If a support incident or dogfood miss reveals a reusable blind spot, a reviewed `incident-protection` learning record can bind a sanitized finding fixture, clean control, and exact verification evidence. It stays local, never uploads customer source, and does not edit rules or change readiness automatically.
+
 ## What "done" looks like
 
 The handoff should state:
@@ -69934,6 +69987,9 @@ The handoff should state:
 - which advisory findings or product decisions remain open
 
 ```sh
+# Route the current lifecycle job without changing the project
+vise status . --format human
+
 # Assess a planned change
 vise impact . --format human
 
@@ -69945,6 +70001,10 @@ vise sdk-release . --format human
 
 # Protect current and previously completed features in CI
 vise check . --ci
+
+# Preview a reviewed incident-to-protection record without writing
+vise learning record . --kind incident-protection \
+  --evidence <repo-relative-input.json> --no-write
 ```
 
   See the [command reference](/ai-mcp/vise/cli-reference) for baseline, evidence, and per-feature options.
@@ -69968,7 +70028,8 @@ The gate checks more than the feature currently being edited:
 
 - the active integration still matches its recorded scope
 - deterministic SDK and platform requirements still pass
-- required evidence and project sensors are present and current
+- required evidence and project sensors are present and current, including any retained runtime receipt
+- accepted organization policy remains current, authentic, and inside its lifecycle and trust boundaries
 - every previously completed Vise feature still holds against the current code
 
 This matters when a later change passes for one surface but quietly breaks an earlier feed, comments, community, or chat experience.
@@ -69983,14 +70044,26 @@ vise check . --ci
 
 Keep the command read-only in CI. Changes to contracts, attestations, baselines, runtime waivers, or policy selections should be deliberate reviewable changes made before the pipeline runs.
 
+For a more diagnostic pipeline, verify retained runtime evidence or the repository policy source in separate read-only steps before the composed gate:
+
+```sh
+vise smoke verify . \
+  --evidence sp-vise/evidence/runtime-smoke/<surface>.json
+vise policy status . --ci
+vise check . --ci
+```
+
 ## Read the outcome
 
 - **Green:** the active work and all recorded completed features still hold.
 - **Active failure:** the current integration, required evidence, or project validation needs attention.
 - **Earlier-feature drift:** the active work passes, but a previously completed surface no longer does.
 - **Release review required:** when Passport comparison is enabled, the compliance checks pass but a person still needs to review the candidate's release evidence.
+- **Policy review required or blocked:** the accepted policy source changed or crossed a lifecycle, signing-key, or rotation boundary; Vise returns the exact owner instead of accepting a successor automatically.
 
 Link the CI output to the changed application code and committed `sp-vise/` evidence so reviewers can reproduce the result locally.
+
+  MCP `check_compliance` returns the same compliance result and exit code with an additive `customerOperations` summary for build, Day-2, and release routing. The summary does not run sensors, write files, or turn advisory findings into a gate.
 
   Teams using Integration Passports can add the same release comparison used during human review:
 
@@ -70015,6 +70088,12 @@ vise check . --ci \
 
 A green Vise result is ready for human review; it is not a release approval.
 
+Start with the lifecycle summary so the reviewer sees the smallest missing action without collapsing independent claims:
+
+```sh
+vise status . --format human
+```
+
 ## Ask for a release handoff
 
 ```text
@@ -70028,11 +70107,13 @@ If your team has an approved Vise handoff, provide it so the candidate can be co
 ## What the reviewer should receive
 
 1. **What changed?** The accepted feature scope, placement, target, source, and dependency changes.
-2. **What proves it?** Automatic checks, project sensors, attestations, and runtime evidence—or clearly disclosed waivers.
-3. **What moved?** SDK assurance, policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
+2. **What proves it?** Automatic checks, project sensors, attestations, and a source/build/route/target-bound runtime receipt—or clearly disclosed waivers.
+3. **What moved?** SDK knowledge and fact depth, organization policy, evidence freshness, residual risk, or previously completed behavior that differs from the accepted candidate.
 4. **What remains human?** Product QA, security review, risk acceptance, and release approval.
 
 An optional **Integration Passport** packages the candidate's intent and evidence into verifiable claims so another reviewer can detect changed or stale material.
+
+A verified runtime receipt proves that its retained evidence still matches the recorded build and surface; it does not prove visual quality, every SDK behavior, or release approval. Organization Policy Operations likewise identifies accepted, changed, expired, superseded, or revoked policy and routes the exact owner without accepting an update automatically.
 
 ## Read the decision
 
@@ -70047,7 +70128,10 @@ Vise never records or impersonates human approval.
   Policy Packs can declare approved SDK ranges and required evidence. Trust envelopes can authenticate a reviewed Passport or Policy Pack across teams or CI systems. A valid signature proves provenance, not integration correctness.
 
 ```sh
+vise policy status . --ci --format human
 vise sdk-release . --format human
+vise smoke verify . \
+  --evidence sp-vise/evidence/runtime-smoke/<surface>.json
 vise passport . --write
 vise passport verify . --format human
 vise passport compare . \
@@ -70055,6 +70139,8 @@ vise passport compare . \
   --to <candidate-passport.json> \
   --format human
 ```
+
+  Policy status exits `0` for `ready`, `12` for `review-required`, and `13` for `blocked`. Accepting a reviewed repository policy source is a separate CLI-only write with `vise policy accept`; its receipt proves the recording action, not release approval.
 
   See the [command reference](/ai-mcp/vise/cli-reference) for policy, trust, and CI options.
 
@@ -70085,6 +70171,8 @@ flowchart LR
   E --> F[Record evidence]
   F --> G[Human review]
 ```
+
+On resumed work, `vise status` reads the current evidence first and routes the agent to the relevant build, Day-2, or release-review step. It does not run project sensors or change the existing compliance result.
 
 1. **Inspect and plan.** The agent identifies the app surface, reads social.plus documentation and SDK facts, and asks instead of guessing.
 2. **Confirm decisions.** Vise records the feature, placement, data target, selected capabilities, and definition of done.
@@ -70117,6 +70205,15 @@ Evidence can prove an automatic check passed, explain architecture a static rule
 
 It does not replace product QA, security review, or human release approval. User-visible work still needs a real launch or an honest recorded waiver.
 
+| Claim | What Vise can establish | What remains separate |
+| --- | --- | --- |
+| Compliance | Recorded scope, deterministic SDK/platform checks, and earlier-feature drift | Product and security judgment |
+| Project sensors | The detected build, lint, typecheck, test, or SDK-smoke command result | Tests that were unavailable or not selected |
+| Runtime receipt | Retained source, build, runner, route, target, artifact, and Passport lineage still match | Visual quality and unobserved SDK semantics |
+| SDK assurance | Exact extracted symbols, models, capability anchors, provenance, freshness, and fact-depth state | Compatibility beyond the reviewed evidence |
+| Organization policy | Accepted source, lifecycle, trust-key state, update impact, and responsible owner | Policy acceptance and release approval |
+| Passport and advisory review | Digest-bound handoff claims and disclosed movement | The human decision to ship |
+
 ## Related
 
     Add, diagnose, or upgrade without losing earlier evidence.
@@ -70130,7 +70227,7 @@ It does not replace product QA, security review, or human release approval. User
 
 > Expose Vise's local tools to Claude Code, Cursor, Codex, and VS Code over MCP.
 
-Vise ships an MCP adapter, so any MCP-capable host can call Vise's tools — inspect, plan, assess Day-2 impact, check SDK release boundaries, compose Passports, validate, run sensors, and look up docs — directly during the coding loop. Start it with:
+Vise ships an MCP adapter, so any MCP-capable host can call Vise's tools — inspect, plan, assess Day-2 impact, check SDK and organization-policy boundaries, verify runtime receipts, compose Passports, validate, run sensors, and look up docs — directly during the coding loop. Start it with:
 
 ```sh
 vise mcp
@@ -70210,7 +70307,9 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 | `analyze_sdk_release` | `vise sdk-release` | Explain exact-snapshot SDK assurance or diff two extracted SDK surface snapshots |
 | `plan_integration` | `vise plan` | Grounded plan with docs citations and intake |
 | `init_compliance` | `vise init` | Write the `sp-vise/` contract |
-| `check_compliance` | `vise check` | Validate the code against the contract |
+| `check_compliance` | `vise check` + lifecycle summary | Validate the code against the contract and add the same `customerOperations` build, Day-2, and release routing returned by CLI `vise status` |
+| `assess_policy_operations` | `vise policy status` | Read the repository policy source, lifecycle and trust state, deterministic update impact, and exact owner routing |
+| `verify_runtime_receipt` | `vise smoke verify` | Verify retained source/build/runner/surface/artifact/Passport bindings without relaunching the app |
 | `generate_integration_passport` | `vise passport` | Compose a digest-bound, sanitized integration handoff; read-only unless writing is explicit |
 | `verify_integration_passport` | `vise passport verify` | Recompute Passport claims and local evidence hashes without repairing the project |
 | `compare_integration_passports` | `vise passport compare` | Compare handoffs and compose the Governed Release Review decision |
@@ -70222,7 +70321,9 @@ The Vise MCP tools mirror the [CLI commands](/ai-mcp/vise/cli-reference), named 
 | `attest_rule` / `explain_rule` | `vise attest` / `vise explain` | Record evidence and read rule guidance |
 | `record_learning` / `show_learning` | `vise learning record` / `vise learning show` | Record and read local-only, advisory learning and Outcome Evidence |
 
-Signing trust envelopes and installing Managed Placements are intentionally CLI-only. An MCP host can verify an envelope, but Vise does not expose private-key signing through MCP.
+`check_compliance` keeps its established compliance fields and exit code; `customerOperations` is additive and read-only. It does not run sensors, write files, gate on advisory findings, or infer human approval.
+
+Signing trust envelopes, accepting an organization policy source, and installing Managed Placements are intentionally CLI-only. An MCP host can verify an envelope or assess policy, but Vise does not expose private-key signing or controlled policy acceptance through MCP.
 
 ## Skill or MCP?
 
@@ -70272,9 +70373,12 @@ For broad requests that span several surfaces (feed + chat + profile), Vise sequ
 
 | Command | Purpose |
 | --- | --- |
+| `vise status [path]` | Read-only lifecycle front door for build, Day-2 change, and release review. Keeps compliance, runtime, SDK, policy, advisory, Passport, and human-approval claims separate; reports owners and the smallest next actions without running sensors, writing files, or changing the compliance exit code |
 | `vise impact [path] [--symptom "..."]` | Read-only Day-2 planner. Compare the project with recorded intent, lifecycle state, SDK declarations, policy, and evidence; classify evidence as preserved, stale, missing, or unknown; and return the smallest safe recovery sequence. A symptom can authorize a bounded repair when recorded cross-surface intent and current source confirm the gap |
-| `vise sdk-release [path]` | Explain whether detected SDK declarations and supported lockfile resolutions match Vise's exact extraction-grounded snapshots. It does not fetch registries, edit dependencies, or infer semantic compatibility from semver |
+| `vise sdk-release [path]` | Explain whether detected SDK declarations and supported lockfile resolutions match Vise's exact extraction-grounded snapshots, reviewed knowledge, and five-platform fact-depth contract. `meets-target`, `target-gap`, `regressed`, and `unknown` stay explicit; it does not fetch registries, edit dependencies, or infer semantic compatibility from semver |
 | `vise sdk-release --from-surface-dir <before> --to-surface-dir <after>` | Diff two SDK surface snapshots for symbol, model-field, capability, and affected-rule changes |
+| `vise policy status [path] [--source <manifest>] [--ci]` | Read-only organization-policy source, lifecycle, trust-key rotation/revocation, deterministic update impact, and exact owner routing. CI exits `0`, `12`, or `13` for `ready`, `review-required`, or `blocked` |
+| `vise policy accept [path] --source <manifest> --recorded-by <identity> --reason "..."` | CLI-only explicit write: pin the exact reviewed source and Policy Pack digests and write an audit receipt. It never rewrites policy inputs, manages keys, or asserts release approval |
 | `vise passport [path] [--write]` | Compose sanitized accepted intent, lifecycle, SDK assurance, evidence hashes, runtime state, residual risk, and replay commands into digest-bound claims. Read-only unless `--write` is explicit |
 | `vise passport verify [path] [--passport <path>]` | Recompute Passport claims and local evidence states without rerunning or repairing the project |
 | `vise passport compare [path] --from <before> --to <after>` | Compare two valid Passports and compose a Governed Release Review result: `ready`, `review-required`, or `blocked` |
@@ -70295,7 +70399,6 @@ See [Review and release an integration](/ai-mcp/vise/release-assurance) for the 
 | `vise check [path] --engagement <outcome>` | Re-verify one previously completed engagement against the current rules and code (exit `11` on drift, `0` when it still holds) |
 | `vise check [path] --all-engagements` | The normal check plus re-verification of every recorded engagement; exit `11` means your current work is green but a previously finished surface drifted |
 | `vise validate [path]` | Run the deterministic validators only (no attestation comparison) |
-| `vise status [path]` | Summarize the current compliance state, including `previousEngagements` — the last recorded state of surfaces built in earlier engagements |
 | `vise explain <ruleId>` | Print a rule's rationale, evidence requirements, and remediation |
 
 See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each state means.
@@ -70308,7 +70411,8 @@ See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each s
 | `vise attest [path] --rule <id> --signer host-agent --confidence high --evidence-file evidence.json --rationale "..."` | Record that a rule is satisfied through architecture the check can't see |
 | `vise sync [path]` | Persist deterministic-pass evidence after a green check |
 | `vise smoke declare [path] --surface <id> [--route <route>] [--target-type <type>]` | Declare the exact runtime collection surface and, when applicable, its route and SDK target |
-| `vise smoke [path] --log <file> [--surface <id> ...]` | Assess normalized runtime markers and write independent per-surface receipts. Marker surface, route, and target must match the declaration; repeat `--surface` to assess selected surfaces |
+| `vise smoke [path] --log <file> [--surface <id> ...] [--receipt-context <json>]` | Assess normalized runtime markers and write independent per-surface receipts. Marker surface, route, and target must match the declaration; strict receipt context additionally binds source, build, runner, artifacts, and prior Passport lineage |
+| `vise smoke verify [path] --evidence <scoped-runtime-smoke.json>` | Read-only receipt verification without relaunching the app; distinguishes `absent`, `stale`, `tampered`, `failed`, and `passed` |
 | `vise smoke waive [path] --reason "..." --mode declined\|deviceless` | Record an auditable runtime-proof waiver |
 
 ## Engagement history
@@ -70347,6 +70451,7 @@ See [Read the result](/ai-mcp/vise/how-it-works#read-the-result) for what each s
 | `vise experience sensors [path]` | Write the advisory experience sensor framework |
 | `vise experience-report [path]` | Write a dimensioned advisory experience review |
 | `vise learning record [path]` | Record a local-only learning event or reviewed aggregate Outcome Evidence |
+| `vise learning record [path] --kind incident-protection --evidence <input.json> [--no-write]` | Preview or record a reviewed, sanitized incident bound to distinct finding/clean fixtures and exact evidence. It never executes replay, uploads source, edits protection, or changes readiness |
 | `vise learning show [path]` | Read the local learning summary and non-causal advisory deltas |
 
 These commands do not upload customer data, assign a calibrated score, change recommendations automatically, or affect `vise check` exit codes.


### PR DESCRIPTION
## Summary
- document `vise status` as the read-only build, Day-2, and release-review front door
- add organization policy operations, runtime receipt verification, SDK fact-depth, and incident-protection boundaries to existing task-first pages
- document MCP `customerOperations`, `assess_policy_operations`, and `verify_runtime_receipt` behavior
- include the pending compact evaluation input/output examples
- regenerate `llms-full.txt`; no navigation or llms config changes were needed

## Validation
- `python3 -m json.tool docs.json`
- `python3 tools/check_internal_links.py` (320 files, 1914 links)
- `python3 .docs-ops/ci/check-mdx.py` (329 files)
- `(cd llmstxt && go test ./...)`
- `(cd llmstxt && go run ./cmd/main.go)`
- `git diff --check`