### PR TITLE
feat: correct claims that no longer match the chat v4 UIKit

### DIFF
--- a/uikit/components/chat.mdx
+++ b/uikit/components/chat.mdx
@@ -16,7 +16,7 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
     **Complete Messaging Foundation**
     - One-on-one and group conversations
     - Real-time message delivery and sync
-    - Rich media support (images, videos, files)
+    - Rich media support (images and videos)
     - Message editing, deletion, and reactions
   </Card>
   <Card title="Live Stream Integration" icon="tobroadcast">
@@ -55,8 +55,8 @@ social.plus Chat UIKit provides a complete suite of messaging components designe
     Complete messaging interface for one-on-one and basic group conversations.
 
     **Key Features:**
-    - Real-time messaging with text, media, and file support
-    - Message reactions, threading, and rich content
+    - Real-time messaging with text and media support
+    - Message reactions, replies, and rich content
     - Message editing, deletion, and interaction controls
     - Network awareness and offline handling
 

--- a/uikit/components/chat/conversation-chat.mdx
+++ b/uikit/components/chat/conversation-chat.mdx
@@ -4,7 +4,7 @@ description: "Complete messaging interface for one-on-one and group conversation
 ---
 
 <Info>
-**Key Benefit**: Seamlessly integrate complete chat functionality into your application with pre-built components that handle messaging, media sharing, reactions, and threading out of the box.
+**Key Benefit**: Seamlessly integrate complete chat functionality into your application with pre-built components that handle messaging, media sharing, reactions, and replies out of the box.
 </Info>
 
 ## Feature Overview
@@ -15,14 +15,14 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
   <Card title="Core Messaging" icon="comments">
     **Complete Chat Experience**
     - Send and receive text messages
-    - Rich media support (images, videos, etc.)
+    - Rich media support (images and videos)
     - Message editing and deletion
     - Real-time message delivery
   </Card>
   <Card title="Interactive Features" icon="heart">
     **Enhanced Engagement**
     - Message reactions with emojis
-    - Message threading and replies
+    - Message replies and quoted context
     - User action controls
     - Conversation management
   </Card>
@@ -106,7 +106,7 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
 
     ### Message Bubble Rendering
 
-    The AmityMessageBubbleView renders individual chat messages as bubbles in the conversation view.
+    The AmityMessageBubble renders individual chat messages as bubbles in the conversation view.
 
     ### Features
 
@@ -134,7 +134,7 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
     <CodeGroup>
     ```dart Flutter - Message Bubble
     Widget messageBubbleView(AmityMessage message) {
-      return MessageBubbleView(
+      return AmityMessageBubble(
         message: message,
       );
     }
@@ -362,7 +362,7 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
   <Accordion title="Component Integration" icon="puzzle-piece">
     **Integrating chat components into your app**
     
-    The UIKit components are designed to work seamlessly together. Use AmityChatPage as your main interface, and leverage individual components like MessageBubbleView and MessageComposer when you need granular control over specific parts of the chat experience.
+    The UIKit components are designed to work seamlessly together. Use AmityChatPage as your main interface, and leverage individual components like AmityMessageBubble and MessageComposer when you need granular control over specific parts of the chat experience.
   </Accordion>
 
   <Accordion title="UI Customization Strategy" icon="palette">
@@ -418,5 +418,5 @@ This UIKit is designed to seamlessly integrate messaging functionalities into yo
 </CardGroup>
 
 <Tip>
-**Implementation Strategy**: Start with the AmityChatPage component for a complete chat experience, then customize individual components like MessageBubbleView and MessageComposer as needed for your specific use case.
+**Implementation Strategy**: Start with the AmityChatPage component for a complete chat experience, then customize individual components like AmityMessageBubble and MessageComposer as needed for your specific use case.
 </Tip>

--- a/uikit/components/chat/group-chat.mdx
+++ b/uikit/components/chat/group-chat.mdx
@@ -31,8 +31,8 @@ The Group Chat UIKit is designed to provide a complete solution for multi-user c
 <CardGroup cols={2}>
   <Card title="Rich Messaging" icon="comments">
     **Interactive Communication**
-    - Text, images, videos, and files
-    - Message reactions and threading
+    - Text, images, and videos
+    - Message reactions and replies
     - Edit and delete capabilities
     - Real-time message delivery
   </Card>
@@ -72,7 +72,7 @@ The Group Chat UIKit is designed to provide a complete solution for multi-user c
     | Feature                | Description                                    |
     | ---------------------- | ---------------------------------------------- |
     | Real-time Display      | Live message updates and conversation flow     |
-    | Message Composition    | Text, images, videos, and file attachments    |
+    | Message Composition    | Text, images, and videos                       |
     | Message Actions        | Reply, edit, delete, and reaction capabilities |
     | Member Interaction     | User profiles and member-specific actions     |
     | Link Preview           | Automatic rich preview for shared URLs        |
@@ -370,7 +370,7 @@ The Group Chat UIKit is designed to provide a complete solution for multi-user c
 
     ### Message Bubble Rendering
 
-    The AmityMessageBubbleView renders individual chat messages as bubbles in the conversation view.
+    The AmityMessageBubble renders individual chat messages as bubbles in the conversation view.
 
     ### Features
 
@@ -398,7 +398,7 @@ The Group Chat UIKit is designed to provide a complete solution for multi-user c
     <CodeGroup>
     ```dart Flutter - Message Bubble
     Widget messageBubbleView(AmityMessage message) {
-      return MessageBubbleView(
+      return AmityMessageBubble(
         message: message,
       );
     }

--- a/uikit/components/chat/overview.mdx
+++ b/uikit/components/chat/overview.mdx
@@ -32,7 +32,6 @@ social.plus UIKit provides a comprehensive set of chat components for building m
   <Accordion title="Rich Media Support">
     - Text messages with formatting
     - Image and video sharing
-    - File attachments
   </Accordion>
   
   <Accordion title="Advanced Features">
@@ -66,10 +65,8 @@ All chat components are available across platforms with platform-specific optimi
   </Card>
   <Card title="Web & Cross-Platform" icon="globe">
     **React Web & React Native**
-    - Progressive Web App support
+    - Embeds as React components via `AmityUiKitProvider`
     - Responsive design for all screen sizes
-    - WebRTC integration for voice/video
-    - Service worker for offline support
   </Card>
 </CardGroup>
 
@@ -96,26 +93,22 @@ All chat components are available across platforms with platform-specific optimi
 
 <CodeGroup>
 ```swift iOS
-import AmityUIKit
+import AmityUIKit4
 
-// Initialize chat view controller
-let chatVC = AmityChatViewController()
-chatVC.channelId = "your_channel_id"
+// AmityChatPage is a SwiftUI view. Wrap it to present it from a UIKit stack.
+let chatPage = AmityChatPage(channelId: "your_channel_id")
+let hostingController = AmitySwiftUIHostingController(rootView: chatPage)
 
-// Present chat interface
-navigationController?.pushViewController(chatVC, animated: true)
+navigationController?.pushViewController(hostingController, animated: true)
 ```
 
 ```kotlin Android
-import com.amity.socialcloud.uikit.chat.AmityChatFragment
+import com.amity.socialcloud.uikit.chat.compose.conversation.AmityChatPageActivity
 
-// Create chat fragment
-val chatFragment = AmityChatFragment.newInstance("your_channel_id")
-
-// Add to container
-supportFragmentManager.beginTransaction()
-    .replace(R.id.container, chatFragment)
-    .commit()
+// The chat page is an Activity. Launch it with its Intent factory.
+startActivity(
+    AmityChatPageActivity.newIntent(context, channelId = "your_channel_id")
+)
 ```
 
 ```tsx React
@@ -310,7 +303,7 @@ For live streaming or event chat:
 For customer service integration:
 
 1. **Conversation Chat** - Agent-customer messaging
-2. **File sharing** - Document and image support
+2. **Media sharing** - Image and video support
 3. **Admin features** - Supervisor tools and analytics
 
 ## Next Steps

--- a/uikit/components/chat/search-chat.mdx
+++ b/uikit/components/chat/search-chat.mdx
@@ -16,7 +16,7 @@ The Chat Search UIKit provides comprehensive search functionality that enables u
     **Find Conversations Fast**
     - Search by channel name and participants
     - Real-time result updates
-    - Filter by channel type
+    - Covers both conversation and community channels
     - Archive status visibility
   </Card>
   <Card title="Message Search Mode" icon="magnifying-glass">


### PR DESCRIPTION
File attachments: removed. The v4 composer offers Camera and Media only on every platform — Android PickVisualMedia.ImageAndVideo, Web accept="video/*,image/*", Flutter pickImageAndVideo, iOS's document picker has no call site. File messages remain a real SDK capability, so the SDK pages are untouched.

Component names that resolve to nothing: AmityMessageBubbleView does not exist (Flutter's MessageBubbleView is deprecated in favour of AmityMessageBubble, which is also Android's name); "threading" is quote-reply; search has no channel-type filter.

Never-shipped capabilities: Progressive Web App, WebRTC voice/video and service workers have no implementation in any repo. Replaced with the one verifiable claim, AmityUiKitProvider.

v3 remnants: the iOS and Android quick-starts referenced AmityChatViewController and AmityChatFragment, which exist in no version including the legacy modules. Rewritten against AmityChatPage via AmitySwiftUIHostingController, and AmityChatPageActivity.newIntent.